### PR TITLE
Big tables are hidden of display

### DIFF
--- a/src/Pickles/Pickles/Resources/structure.css
+++ b/src/Pickles/Pickles/Resources/structure.css
@@ -165,7 +165,7 @@ div.description ul {
  * Feature - formatting tables (example or step tables)
  *************************************************************************/
 
-#feature .table_container { margin: 8px 0px 8px 0px; }
+#feature .table_container { margin: 8px 0px 8px 0px; overflow:auto; }
 
 #feature table {
     border-collapse: collapse;


### PR DESCRIPTION
Adding #feature .table_container { margin: 8px 0px 8px 0px; overflow:auto; },
so tables with lots of columns can be displayed
