### PR TITLE
DITA Correction of the generated path to features files

### DIFF
--- a/src/Pickles/Pickles/DocumentationBuilders/DITA/DitaFeatureFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/DITA/DitaFeatureFormatter.cs
@@ -91,7 +91,8 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.DITA
                 new FileInfo(Path.Combine(this.configuration.OutputFolder.FullName, featureNode.RelativePathFromRoot)).
                     Directory.FullName.ToLowerInvariant();
             if (!Directory.Exists(relativePath)) Directory.CreateDirectory(relativePath);
-            string filename = Path.Combine(relativePath, feature.Name.ToDitaName() + ".dita");
+            Uri relativeFilePath = ditaMapPathGenerator.GeneratePathToFeature(featureNode);
+            string filename = Path.Combine(relativePath, Path.GetFileName(relativeFilePath.ToString()));
             var document =
                 new XDocument(new XDocumentType("topic", "-//OASIS//DTD DITA Topic//EN", "topic.dtd", string.Empty),
                               topic);


### PR DESCRIPTION
In the DITA generator, the path generated in the DITAMAP file did not match the filename of the corresponding DITA file on disk, it used the feature name instead of the filename.

This was causing error when trying to process the dita file.
