### PR TITLE
Added .nuspec for Pickles.CommandLine. Resolves #40

### DIFF
--- a/NuGetPackAll.cmd
+++ b/NuGetPackAll.cmd
@@ -2,3 +2,5 @@ pushd src\Pickles\Pickles.PowerShell && ..\.nuget\nuget.exe pack Pickles.nuspec 
 popd
 pushd src\Pickles\Pickles.MSBuild && ..\.nuget\nuget.exe pack Pickles.MSBuild.nuspec -Version %1
 popd
+pushd src\Pickles\Pickles.CommandLine && ..\.nuget\nuget.exe pack Pickles.CommandLine.nuspec -Version %1
+popd

--- a/src/Pickles/Pickles.CommandLine/Pickles.CommandLine.nuspec
+++ b/src/Pickles/Pickles.CommandLine/Pickles.CommandLine.nuspec
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
+  <metadata>
+    <id>Pickles.CommandLine</id>
+    <version>$version$</version>
+    <title>Pickles - Gherkin Documentation Generator</title>
+    <authors>Marcus Hammarberg</authors>
+    <owners>Jeffrey Cameron</owners>
+    <projectUrl>https://github.com/picklesdoc/pickles</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Pickles is an open source living documentation generator that works on feature files written in the Gherkin language, popularized in tools like Cucumber and SpecFlow. Pickles can be incorporated into your build process to produce living documenation in a format that is more accessible to your clients. Gherkin language files are written in plain text and stored in your source folder. This can make them inaccessible to clients who may not know how to work with source control or who are not interested in seeing all of the source code, just the features.</description>
+    <summary>A documentation generator for features written in the Gherkin language</summary>
+    <copyright>Copyright © Jeffrey Cameron 2010-2011</copyright>
+  </metadata>
+  <files>
+    <file src="bin\Release\*.dll" target="tools" />
+    <file src="bin\Release\*.exe" target="tools" />
+    <file src="bin\Release\*.exe.config" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
Here's a .nuspec file for a Pickles.CommandLine package. 

I think this is a better solution than to ship the Pickles.exe in all the other packages. 
