### PR TITLE
Adding background to features in word

### DIFF
--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordBackgroundFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordBackgroundFormatter.cs
@@ -1,0 +1,61 @@
+﻿
+using System.Collections.Generic;
+using DocumentFormat.OpenXml.Wordprocessing;
+using PicklesDoc.Pickles.Extensions;
+using PicklesDoc.Pickles.Parser;
+using PicklesDoc.Pickles.TestFrameworks;
+using Table = DocumentFormat.OpenXml.Wordprocessing.Table;
+using TableRow = DocumentFormat.OpenXml.Wordprocessing.TableRow;
+
+namespace PicklesDoc.Pickles.DocumentationBuilders.Word
+{
+	public class WordBackgroundFormatter
+	{
+
+		public void Format(Body body, Scenario background)
+		{
+			var headerParagraph = new Paragraph(new ParagraphProperties(new ParagraphStyleId { Val = "Heading2" }));
+			headerParagraph.Append(new Run(new RunProperties(new Bold()), new Text(background.Name)));
+
+			var table = new Table();
+			table.Append(GenerateTableProperties());
+			var row = new TableRow();
+			var cell = new TableCell();
+			cell.Append(headerParagraph);
+
+			foreach (var step in background.Steps)
+			{
+				cell.Append(WordStepFormatter.GenerateStepParagraph(step));
+			}
+
+			cell.Append(CreateEmptyLine());
+			row.Append(cell);
+			table.Append(row);
+
+			body.Append(table);
+		}
+
+		private static TableProperties GenerateTableProperties()
+		{
+			var tableProperties1 = new TableProperties();
+			var tableStyle1 = new TableStyle { Val = "TableGrid" };
+			var tableWidth1 = new TableWidth { Width = "4900", Type = TableWidthUnitValues.Pct };
+			var tableLook1 = new TableLook { Val = "04A0" };
+			var tableJustification = new TableJustification { Val = TableRowAlignmentValues.Center };
+
+			tableProperties1.Append(tableStyle1);
+			tableProperties1.Append(tableWidth1);
+			tableProperties1.Append(tableLook1);
+			tableProperties1.Append(tableJustification);
+			return tableProperties1;
+		}
+
+		private static Paragraph CreateEmptyLine()
+		{
+			// Is there a better way to do this?
+			var emptyLine = new Paragraph(new ParagraphProperties(new ParagraphStyleId { Val = "Normal" }));
+			emptyLine.Append(new Run(new Text("")));
+			return emptyLine;
+		}
+	}
+}

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordFeatureFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordFeatureFormatter.cs
@@ -35,11 +35,13 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
         private readonly WordScenarioOutlineFormatter wordScenarioOutlineFormatter;
         private readonly WordStyleApplicator wordStyleApplicator;
         private readonly WordDescriptionFormatter wordDescriptionFormatter;
+        private readonly WordBackgroundFormatter wordBackgroundFormatter;
 
         public WordFeatureFormatter(WordScenarioFormatter wordScenarioFormatter,
                                     WordScenarioOutlineFormatter wordScenarioOutlineFormatter,
                                     WordStyleApplicator wordStyleApplicator, 
                                     WordDescriptionFormatter wordDescriptionFormatter,
+                                    WordBackgroundFormatter wordBackgroundFormatter,
                                     Configuration configuration,
                                     ITestResults nunitResults)
         {
@@ -47,6 +49,7 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
             this.wordScenarioOutlineFormatter = wordScenarioOutlineFormatter;
             this.wordStyleApplicator = wordStyleApplicator;
             this.wordDescriptionFormatter = wordDescriptionFormatter;
+            this.wordBackgroundFormatter = wordBackgroundFormatter;
             this.configuration = configuration;
             this.nunitResults = nunitResults;
         }
@@ -72,6 +75,7 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
 
             body.GenerateParagraph(feature.Name, "Heading1");
             this.wordDescriptionFormatter.Format(body, feature.Description);
+            this.wordBackgroundFormatter.Format(body, feature.Background);
 
             foreach (IFeatureElement featureElement in feature.FeatureElements)
             {

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordStepFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordStepFormatter.cs
@@ -37,17 +37,12 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
 
         public void Format(Body body, Step step)
         {
-            // HACK - We need to generate a custom paragraph here because 2 Run objects are needed to allow for the bolded keyword
-            var paragraph = new Paragraph(new ParagraphProperties(new ParagraphStyleId {Val = "Normal"}));
-            paragraph.Append(new Run(new RunProperties(new Bold()), new Text(step.NativeKeyword)));
-            var nameText = new Text {Space = SpaceProcessingModeValues.Preserve};
-            nameText.Text = " " + step.Name;
-            paragraph.Append(new Run(nameText));
+            var paragraph = GenerateStepParagraph(step);
             body.Append(paragraph);
 
             if (!string.IsNullOrEmpty(step.DocStringArgument))
             {
-                string[] lines = step.DocStringArgument.Split(new[] {Environment.NewLine},
+                string[] lines = step.DocStringArgument.Split(new[] { Environment.NewLine },
                                                               StringSplitOptions.RemoveEmptyEntries);
                 foreach (string line in lines)
                 {
@@ -59,6 +54,17 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
             {
                 this.wordTableFormatter.Format(body, step.TableArgument);
             }
+        }
+
+        public static Paragraph GenerateStepParagraph(Step step)
+        {
+            // HACK - We need to generate a custom paragraph here because 2 Run objects are needed to allow for the bolded keyword
+            var paragraph = new Paragraph(new ParagraphProperties(new ParagraphStyleId { Val = "Normal" }));
+            paragraph.Append(new Run(new RunProperties(new Bold()), new Text(step.NativeKeyword)));
+            var nameText = new Text { Space = SpaceProcessingModeValues.Preserve };
+            nameText.Text = " " + step.Name;
+            paragraph.Append(new Run(nameText));
+            return paragraph;
         }
     }
 }

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -238,6 +238,7 @@
     <Compile Include="DocumentationBuilders\Word\TableOfContentsAdder\PtOpenXmlUtil.cs" />
     <Compile Include="DocumentationBuilders\Word\TableOfContentsAdder\PtUtil.cs" />
     <Compile Include="DocumentationBuilders\Word\TableOfContentsAdder\TocAdder.cs" />
+    <Compile Include="DocumentationBuilders\Word\WordBackgroundFormatter.cs" />
     <Compile Include="DocumentationBuilders\Word\WordDescriptionFormatter.cs" />
     <Compile Include="DocumentationBuilders\Word\WordDocumentationBuilder.cs" />
     <Compile Include="DocumentationBuilders\Word\WordFeatureFormatter.cs" />


### PR DESCRIPTION
This is a naive attempt at modifying the word generator to include backgrounds. I'm not sure it's the best, so you may want to adjust styling and such - sorry if it's not that elegant, I had never generated word documents from c#.

Here is the result (in libreoffice, you may want to try it in word... I'll give it a try in word tomorrow)

![2013-08-08_23-24_628x274](https://f.cloud.github.com/assets/541961/936202/1a2df354-00a4-11e3-8c74-cd61ddb31aa1.png)
