### PR TITLE
Handle cucumber feature with no scenarios

### DIFF
--- a/src/Pickles/Pickles/TestFrameworks/CucumberJsonResults.cs
+++ b/src/Pickles/Pickles/TestFrameworks/CucumberJsonResults.cs
@@ -84,7 +84,7 @@ namespace PicklesDoc.Pickles.TestFrameworks
 
         private TestResult GetResultFromFeature(CucumberObjects.Feature cucumberFeature)
         {
-            if (cucumberFeature == null) return TestResult.Inconclusive;
+            if (cucumberFeature == null || cucumberFeature.elements == null) return TestResult.Inconclusive;
 
             bool wasSuccessful = cucumberFeature.elements.All(CheckScenarioStatus);
 


### PR DESCRIPTION
- Was getting an ArgumentNullException if the feature didn't have any
  scenarios.
