### PR TITLE
Fixed Background description

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/Index.html
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/Index.html
@@ -112,7 +112,7 @@
                     <div class="row-fluid" data-bind="if: Background.Steps">
                         <div class="scenario">
                             <h4>Background:</h4>
-                            <div class="description" data-bind="html: renderMarkdownBlock(Description)"></div>
+                            <div class="description" data-bind="html: renderMarkdownBlock(Background.Description)"></div>
                             <ul data-bind="template: { name: 'steps-template', foreach: Background.Steps }"></ul>
                         </div>
                     </div>


### PR DESCRIPTION
The Background's description was being rendered from "Description", which was using the Feature's description. This has been changed to Background.Description and now correctly renders the background's description.
