### PR TITLE
Features don't render correctly when there are less than 4 spaces 

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/Markdown.Converter.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/Markdown.Converter.js
@@ -974,7 +974,7 @@ else
             // attacklab: sentinel workarounds for lack of \A and \Z, safari\khtml bug
             text += "~0";
 
-            text = text.replace(/(?:\n\n|^)((?:(?:[ ]{4}|\t).*\n+)+)(\n*[ ]{0,3}[^ \t\n]|(?=~0))/g,
+            text = text.replace(/(?:\n\n|^)((?:(?:[ ]{0}|\t).*\n+)+)(\n*[ ]{0,3}[^ \t\n]|(?=~0))/g,
                 function (wholeMatch, m1, m2) {
                     var codeblock = m1;
                     var nextChar = m2;


### PR DESCRIPTION
When a feature does not have 4 spaces at the start of a line, it does
not render correctly with the code tags.
