### PR TITLE
Fixed "object reference not set to an instance..." bug when using multiple results files with Scenario Outlines.

### DIFF
--- a/src/Pickles/Pickles/ConfigurationReporter.cs
+++ b/src/Pickles/Pickles/ConfigurationReporter.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
 
 namespace PicklesDoc.Pickles
 {
@@ -18,8 +22,15 @@ namespace PicklesDoc.Pickles
             if (configuration.HasTestResults)
             {
                 writeToLog(string.Format("Test Result Format        : {0}", configuration.TestResultsFormat));
-                writeToLog(string.Format("Test Result File          : {0}", configuration.TestResultsFile.FullName));
+                writeToLog(string.Format("Test Result File(s)       : {0}", GetTestResultFileNames(configuration.TestResultsFiles)));
             }
         }
+
+        private static string GetTestResultFileNames(IEnumerable<FileInfoBase> testResultsFiles)
+        {
+            var fileNames = testResultsFiles.Select(x => x.FullName).ToArray();
+            return string.Join(";", fileNames);
+        }
+
     }
 }


### PR DESCRIPTION
Fixes "object reference not set to an instance.." exception when running Pickles against multiple NUnit results files that have tests for Scenario Outlines.

Suitable unit test to follow.
