### PR TITLE
Fixed issue where multiple results files for a single feature causes exceptions when processing scenario outline examples.

### DIFF
--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -203,6 +203,7 @@
     <Compile Include="DirectoryCrawlers\ImageFileDetectorTests.cs" />
     <Compile Include="DirectoryCrawlers\RelevantFileDetectorTests.cs" />
     <Compile Include="WhenParsingMultipleMsTestTestResultsFiles.cs" />
+    <Compile Include="WhenParsingMultipleNUnitResultsFilesForASingleFeature.cs" />
     <Compile Include="WhenParsingMultipleTestResultsTests.cs" />
     <Compile Include="WhenParsingSpecRunTestResultsFile.cs" />
     <Compile Include="DirectoryCrawlers\FolderDirectoryTreeNodeTests.cs" />
@@ -278,6 +279,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="results-example-nunit - Run 1.xml" />
+    <EmbeddedResource Include="results-example-nunit - Run 2.xml" />
     <EmbeddedResource Include="results-example-specrun.html" />
     <None Include="DocumentationBuilders\HTML\FormattingAFeature.feature">
       <Generator>SpecFlowSingleFileGenerator</Generator>

--- a/src/Pickles/Pickles.Test/WhenParsingMultipleNUnitResultsFilesForASingleFeature.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingMultipleNUnitResultsFilesForASingleFeature.cs
@@ -1,0 +1,72 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="WhenParsingMultipleNUnitResultsFiles.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using NUnit.Framework;
+using PicklesDoc.Pickles.ObjectModel;
+using PicklesDoc.Pickles.TestFrameworks;
+using Should;
+
+namespace PicklesDoc.Pickles.Test
+{
+    [TestFixture]
+    public class WhenParsingMultipleNUnitResultsFilesForASingleFeature : WhenParsingTestResultFiles<NUnitResults>
+    {
+        public WhenParsingMultipleNUnitResultsFilesForASingleFeature()
+            : base(@"results-example-nunit - Run 1.xml;results-example-nunit - Run 2.xml")
+        {
+        }
+
+        [Test]
+        public void ThenCanReadFeatureResultSuccessfully()
+        {
+            // Write out the embedded test results file
+            var results = ParseResultsFile();
+
+            var feature = new Feature { Name = "FeatureWithMultipleResultsFiles" };
+            TestResult result = results.GetFeatureResult(feature);
+
+            result.WasExecuted.ShouldBeTrue();
+            result.WasSuccessful.ShouldBeTrue();
+        }
+
+        [Test]
+        public void ThenCanReadScenarioOutlineResultSuccessfully()
+        {
+            var results = ParseResultsFile();
+
+            var feature = new Feature { Name = "FeatureWithMultipleResultsFiles" };
+            var scenarioOutline = new ScenarioOutline { Name = "Some scenario outline", Feature = feature };
+            
+            TestResult result = results.GetScenarioOutlineResult(scenarioOutline);
+
+            result.WasExecuted.ShouldBeTrue();
+            result.WasSuccessful.ShouldBeTrue();
+
+            TestResult exampleResult1 = results.GetExampleResult(scenarioOutline, new[] { "false" });
+            exampleResult1.WasExecuted.ShouldBeTrue();
+            exampleResult1.WasSuccessful.ShouldBeTrue();
+
+            TestResult exampleResult2 = results.GetExampleResult(scenarioOutline, new[] { "true" });
+            exampleResult2.WasExecuted.ShouldBeTrue();
+            exampleResult2.WasSuccessful.ShouldBeTrue();
+        }
+        
+    }
+}

--- a/src/Pickles/Pickles.Test/results-example-nunit - Run 1.xml
+++ b/src/Pickles/Pickles.Test/results-example-nunit - Run 1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\Debug\FeatureWithMultipleResultsFiles.dll" total="1" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-06-06" time="11:46:16">
+  <environment nunit-version="2.6.0.12051" clr-version="2.0.50727.5477" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\Debug" machine-name="NVMBSNB-1265" user="tom.davis" user-domain="GENERAL" />
+  <culture-info current-culture="en-GB" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\Debug\FeatureWithMultipleResultsFiles.dll" executed="True" result="Success" success="True" time="0.329" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="FeatureWithMultipleResultsFiles" executed="True" result="Success" success="True" time="0.323" asserts="0">
+        <results>
+          <test-suite type="TestFixture" name="FeatureWithMultipleResultsFilesFeature" description="FeatureWithMultipleResultsFiles" executed="True" result="Success" success="True" time="0.322" asserts="0">
+            <results>
+              <test-case name="PicklesBug.PicklesBugFeature.SomeScenario" description="Some scenario" executed="True" result="Success" success="True" time="0.118" asserts="0">
+              </test-case>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/Pickles/Pickles.Test/results-example-nunit - Run 2.xml
+++ b/src/Pickles/Pickles.Test/results-example-nunit - Run 2.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\Debug\FeatureWithMultipleResultsFiles.dll" total="2" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2014-06-06" time="11:46:34">
+  <environment nunit-version="2.6.0.12051" clr-version="2.0.50727.5477" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\FeatureWithMultipleResultsFiles" machine-name="NVMBSNB-1265" user="tom.davis" user-domain="GENERAL" />
+  <culture-info current-culture="en-GB" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="C:\Users\tom.davis\Documents\Visual Studio 2013\Projects\FeatureWithMultipleResultsFiles\FeatureWithMultipleResultsFiles\bin\Debug\FeatureWithMultipleResultsFiles.dll" executed="True" result="Success" success="True" time="0.341" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="FeatureWithMultipleResultsFiles" executed="True" result="Success" success="True" time="0.336" asserts="0">
+        <results>
+          <test-suite type="TestFixture" name="FeatureWithMultipleResultsFilesFeature" description="FeatureWithMultipleResultsFiles" executed="True" result="Success" success="True" time="0.336" asserts="0">
+            <results>
+              <test-suite type="ParameterizedTest" name="SomeScenarioOutline" description="Some scenario outline" executed="True" result="Success" success="True" time="0.132" asserts="0">
+                <results>
+                  <test-case name="PicklesBug.PicklesBugFeature.SomeScenarioOutline(&quot;False&quot;,null)" executed="True" result="Success" success="True" time="0.123" asserts="0" />
+                  <test-case name="PicklesBug.PicklesBugFeature.SomeScenarioOutline(&quot;True&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>


### PR DESCRIPTION
A bit of an edge case here, but hey, this is how I'm using it!

I run NUnit with two passes. The first pass only runs tests from a "work in progress" category - this test run does not fail the build if any test fails. The second pass runs tests from all categories except for those that were run in the first pass - this test run does fail the build if any test fails. The two passes generate two NUnit results files for a single SpecFlow feature file.

When running Pickles against a single feature, but with two NUnit results files, I noticed that an exception was thrown when trying to parse test examples from Scenario Outlines.

The following commit should fix this problem. Try running the unit test without the changes in NUnitSingleResults.cs - the test should fail. Apply my changes and the test should pass.
