### PR TITLE
Fixed #134 "Multi-line arguments are not rendered"

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featuresModel.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featuresModel.js
@@ -26,6 +26,7 @@ function Step(data) {
     this.Name = data.Name || '';
     this.Keyword = data.Keyword || '';
     this.NativeKeyword = data.NativeKeyword || '';
+    this.DocStringArgument = data.DocStringArgument || '';
     this.TableArgument = data.TableArgument == null ? null : new TableArgument(data.TableArgument.HeaderRow, data.TableArgument.DataRows);
 }
 
@@ -52,8 +53,6 @@ function Result(data) {
     this.WasExecuted = data.WasExecuted || false;
     this.WasSuccessful = data.WasSuccessful || false;
 }
-// putting it here to define it so I can check if it exists - it is an optional value
-var DocStringArgument = '';
 
 /* JSON Sample
         {


### PR DESCRIPTION
This was bumped when the view / data model was made more strongly typed (for the better!).  That property was left off which caused multiline args to be ignored.
