### PR TITLE
Patch 1

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
@@ -27,7 +27,7 @@ function matchesFeatureName(searchString, feature) {
 }
 
 function matchesFeatureTag(searchString, feature) {
-    var foundMatch = false    
+    var foundMatch = false;    
     $.each(feature.Feature.Tags, function (key, scenarioTag) {
         var lowerCasedTag = scenarioTag.toLowerCase();
         if (lowerCasedTag.indexOf(searchString) > -1) {

--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
@@ -27,8 +27,14 @@ function matchesFeatureName(searchString, feature) {
 }
 
 function matchesFeatureTag(searchString, feature) {
-    var featureTags = feature.Feature.Tags;
-    return (_.indexOf(featureTags, searchString) > -1);
+    var foundMatch = false    
+    $.each(feature.Feature.Tags, function (key, scenarioTag) {
+        var lowerCasedTag = scenarioTag.toLowerCase();
+        if (lowerCasedTag.indexOf(searchString) > -1) {
+            foundMatch = true;
+        }
+    });
+    return foundMatch;
 }
 
 function matchesScenarioName(searchString, feature) {


### PR DESCRIPTION
- Added case insensitive search for feature tags: In the DHtml version, feature wide tags with capitals could not be filtered on because they where compared with the lower cased search criteria. Scenario tags worked as expected before, so I implemented the same functionality to the feature tags.