### PR TITLE
Fixed bug #191 for Word. (Tables in Background)

### DIFF
--- a/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenAddingAFeatureToAWorksheet.cs
+++ b/src/Pickles/Pickles.Test/DocumentationBuilders/Excel/WhenAddingAFeatureToAWorksheet.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using ClosedXML.Excel;
 using NFluent;
 using NUnit.Framework;
@@ -29,6 +30,70 @@ namespace PicklesDoc.Pickles.Test.DocumentationBuilders.Excel
 
                 Check.That(worksheet.Cell("A1").Value).IsEqualTo(feature.Name);
                 Check.That(worksheet.Cell("B2").Value).IsEqualTo(feature.Description);
+            }
+        }
+
+        [Test]
+        public void Then_feature_with_background_is_added_successfully()
+        {
+            var excelFeatureFormatter = Container.Resolve<ExcelFeatureFormatter>();
+
+            var feature = new Feature
+                              {
+                                  Name = "Test Feature",
+                                  Description =
+                                      "In order to test this feature,\nAs a developer\nI want to test this feature",
+                              };
+            var background = new Scenario
+            {
+                Name = "Test Background Scenario",
+                Description =
+                    "In order to test this background,\nAs a developer\nI want to test this background"
+            };
+            var given = new Step { NativeKeyword = "Given", Name = "a precondition" };
+            background.Steps = new List<Step>(new[] { given });
+            feature.AddBackground(background);
+
+            using (var workbook = new XLWorkbook())
+            {
+                IXLWorksheet worksheet = workbook.AddWorksheet("SHEET1");
+                excelFeatureFormatter.Format(worksheet, feature);
+
+                Check.That(worksheet.Cell("B4").Value).IsEqualTo(background.Name);
+                Check.That(worksheet.Cell("C5").Value).IsEqualTo(background.Description);
+                Check.That(worksheet.Cell("D6").Value).IsEqualTo(given.Name);
+            }
+        }
+
+        [Test]
+        public void Then_feature_without_background_adds_first_scenario_on_correct_row()
+        {
+            var excelFeatureFormatter = Container.Resolve<ExcelFeatureFormatter>();
+
+            var feature = new Feature
+                              {
+                                  Name = "Test Feature",
+                                  Description =
+                                      "In order to test this feature,\nAs a developer\nI want to test this feature",
+                              };
+            var scenario = new Scenario
+            {
+                Name = "Test Scenario",
+                Description =
+                    "In order to test this scenario,\nAs a developer\nI want to test this scenario"
+            };
+            var given = new Step { NativeKeyword = "Given", Name = "a precondition" };
+            scenario.Steps = new List<Step>(new[] { given });
+            feature.AddFeatureElement(scenario);
+
+            using (var workbook = new XLWorkbook())
+            {
+                IXLWorksheet worksheet = workbook.AddWorksheet("SHEET1");
+                excelFeatureFormatter.Format(worksheet, feature);
+
+                Check.That(worksheet.Cell("B4").Value).IsEqualTo(scenario.Name);
+                Check.That(worksheet.Cell("C5").Value).IsEqualTo(scenario.Description);
+                Check.That(worksheet.Cell("D6").Value).IsEqualTo(given.Name);
             }
         }
     }

--- a/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelFeatureFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Excel/ExcelFeatureFormatter.cs
@@ -18,81 +18,86 @@
 
 #endregion
 
-using System;
-using System.Reflection;
 using ClosedXML.Excel;
 using NLog;
-
 using PicklesDoc.Pickles.ObjectModel;
-using PicklesDoc.Pickles.Parser;
 using PicklesDoc.Pickles.TestFrameworks;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace PicklesDoc.Pickles.DocumentationBuilders.Excel
 {
-  public class ExcelFeatureFormatter
-  {
-    private static readonly Logger log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType.Name);
-
-    private readonly ExcelScenarioFormatter excelScenarioFormatter;
-    private readonly ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter;
-    private readonly Configuration configuration;
-    private readonly ITestResults testResults;
-
-    public ExcelFeatureFormatter(ExcelScenarioFormatter excelScenarioFormatter,
-                                 ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter,
-                                 Configuration configuration,
-                                 ITestResults testResults)
+    public class ExcelFeatureFormatter
     {
-      this.excelScenarioFormatter = excelScenarioFormatter;
-      this.excelScenarioOutlineFormatter = excelScenarioOutlineFormatter;
-      this.configuration = configuration;
-      this.testResults = testResults;
-    }
+        private static readonly Logger log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType.Name);
 
-    public void Format(IXLWorksheet worksheet, Feature feature)
-    {
-      worksheet.Cell("A1").Style.Font.SetBold();
-      worksheet.Cell("A1").Value = feature.Name;
+        private readonly ExcelScenarioFormatter excelScenarioFormatter;
+        private readonly ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter;
+        private readonly Configuration configuration;
+        private readonly ITestResults testResults;
 
-      if (feature.Description.Length <= short.MaxValue)
-      {
-        worksheet.Cell("B2").Value = feature.Description;
-      }
-      else
-      {
-        var description = feature.Description.Substring(0, short.MaxValue);
-        log.Warn("The description of feature {0} was truncated because of cell size limitations in Excel.", feature.Name);
-        worksheet.Cell("B2").Value = description;
-      }
-
-      worksheet.Cell("B2").Style.Alignment.WrapText = false;
-
-      var results = this.testResults.GetFeatureResult(feature);
-
-      if (this.configuration.HasTestResults && results.WasExecuted)
-      {
-        worksheet.Cell("A1").Style.Fill.SetBackgroundColor(results.WasSuccessful
-                                                               ? XLColor.AppleGreen
-                                                               : XLColor.CandyAppleRed);
-      }
-
-      int row = 4;
-      foreach (IFeatureElement featureElement in feature.FeatureElements)
-      {
-        var scenario = featureElement as Scenario;
-        if (scenario != null)
+        public ExcelFeatureFormatter(ExcelScenarioFormatter excelScenarioFormatter,
+                                     ExcelScenarioOutlineFormatter excelScenarioOutlineFormatter,
+                                     Configuration configuration,
+                                     ITestResults testResults)
         {
-          this.excelScenarioFormatter.Format(worksheet, scenario, ref row);
+            this.excelScenarioFormatter = excelScenarioFormatter;
+            this.excelScenarioOutlineFormatter = excelScenarioOutlineFormatter;
+            this.configuration = configuration;
+            this.testResults = testResults;
         }
 
-        var scenarioOutline = featureElement as ScenarioOutline;
-        if (scenarioOutline != null)
+        public void Format(IXLWorksheet worksheet, Feature feature)
         {
-          this.excelScenarioOutlineFormatter.Format(worksheet, scenarioOutline, ref row);
-        }
+            worksheet.Cell("A1").Style.Font.SetBold();
+            worksheet.Cell("A1").Value = feature.Name;
 
-        row++;
-      }
+            if (feature.Description.Length <= short.MaxValue)
+            {
+                worksheet.Cell("B2").Value = feature.Description;
+            }
+            else
+            {
+                var description = feature.Description.Substring(0, short.MaxValue);
+                log.Warn("The description of feature {0} was truncated because of cell size limitations in Excel.", feature.Name);
+                worksheet.Cell("B2").Value = description;
+            }
+
+            worksheet.Cell("B2").Style.Alignment.WrapText = false;
+
+            var results = this.testResults.GetFeatureResult(feature);
+
+            if (this.configuration.HasTestResults && results.WasExecuted)
+            {
+                worksheet.Cell("A1").Style.Fill.SetBackgroundColor(results.WasSuccessful
+                                                                       ? XLColor.AppleGreen
+                                                                       : XLColor.CandyAppleRed);
+            }
+
+            var featureElementsToRender = new List<IFeatureElement>();
+            if (feature.Background != null)
+            {
+                featureElementsToRender.Add(feature.Background);
+            }
+            featureElementsToRender.AddRange(feature.FeatureElements);
+
+            var row = 4;
+            foreach (var featureElement in featureElementsToRender)
+            {
+                var scenario = featureElement as Scenario;
+                if (scenario != null)
+                {
+                    this.excelScenarioFormatter.Format(worksheet, scenario, ref row);
+                }
+
+                var scenarioOutline = featureElement as ScenarioOutline;
+                if (scenarioOutline != null)
+                {
+                    this.excelScenarioOutlineFormatter.Format(worksheet, scenarioOutline, ref row);
+                }
+
+                row++;
+            }
+        }
     }
-  }
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordBackgroundFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordBackgroundFormatter.cs
@@ -1,8 +1,5 @@
-﻿
-using DocumentFormat.OpenXml.Wordprocessing;
-
+﻿using DocumentFormat.OpenXml.Wordprocessing;
 using PicklesDoc.Pickles.ObjectModel;
-using PicklesDoc.Pickles.Parser;
 using Table = DocumentFormat.OpenXml.Wordprocessing.Table;
 using TableRow = DocumentFormat.OpenXml.Wordprocessing.TableRow;
 
@@ -12,14 +9,16 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
 	{
         const string DefaultBackgroundKeyword = "Background";
 
-	    private readonly LanguageServices languageSevices;
+        private readonly LanguageServices languageSevices;
+        private readonly WordTableFormatter wordTableFormatter;
 
-	    public WordBackgroundFormatter(Configuration configuration)
+	    public WordBackgroundFormatter(Configuration configuration, WordTableFormatter wordTableFormatter)
 	    {
+	        this.wordTableFormatter = wordTableFormatter;
 	        this.languageSevices = new LanguageServices(configuration);
 	    }
 
-		public void Format(Body body, Scenario background)
+	    public void Format(Body body, Scenario background)
 		{
 			var headerParagraph   = new Paragraph(new ParagraphProperties(new ParagraphStyleId { Val = "Heading2" }));
 		    var backgroundKeyword = GetLocalizedBackgroundKeyword();
@@ -38,7 +37,12 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
 
 			foreach (var step in background.Steps)
 			{
-				cell.Append(WordStepFormatter.GenerateStepParagraph(step));
+                cell.Append(WordStepFormatter.GenerateStepParagraph(step));
+
+                if (step.TableArgument != null)
+                {
+                    cell.Append(this.wordTableFormatter.CreateWordTableFromPicklesTable(step.TableArgument));
+                }
 			}
 
 			cell.Append(CreateNormalParagraph("")); // Is there a better way to generate a new empty line?

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordTableFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordTableFormatter.cs
@@ -18,7 +18,6 @@
 
 #endregion
 
-using System;
 using DocumentFormat.OpenXml.Wordprocessing;
 using Table = PicklesDoc.Pickles.ObjectModel.Table;
 
@@ -40,6 +39,11 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
         }
 
         public void Format(Body body, Table table)
+        {
+            body.Append(this.CreateWordTableFromPicklesTable(table));
+        }
+
+        public DocumentFormat.OpenXml.Wordprocessing.Table CreateWordTableFromPicklesTable(Table table)
         {
             var wordTable = new DocumentFormat.OpenXml.Wordprocessing.Table();
             wordTable.Append(GenerateTableProperties());
@@ -65,8 +69,7 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
 
                 wordTable.Append(wordRow);
             }
-
-            body.Append(wordTable);
+            return wordTable;
         }
     }
 }


### PR DESCRIPTION
Extracted a method in the WordTableFormatter class so that it could be used to return a table to append to the cell in the Scenario Background built in the WordBackgroundFormatter.