### PR TITLE
DHTML Changes: Usability changes to navigation. Added image support.

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/Index.html
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/Index.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <title>Features</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    
+
     <!-- Le styles -->
     <link href="css/bootstrap.min.css" rel="stylesheet" />
     <link href="css/styles.css" rel="stylesheet" />
@@ -26,11 +26,11 @@
 
     <script type="text/html" id="featuresByFolder-template">
         <div class="features-folder">
-            <div class="feature-folder-header" data-bind="click: toggleShowingFolderFeatures">
-                <span class="icon-chevron-down"></span>
+            <div class="feature-folder-header" data-bind="click: $root.toggleShowingFolderFeatures">
+                <span data-bind="css: { 'icon-chevron-down': IsExpanded() == true, 'icon-chevron-right': IsExpanded() == false }"></span>
                 <span data-bind="text: Name" style="padding: 5px"></span>
             </div>
-            <div class="feature-folder-contents" style="margin-left: 15px;display:none">
+            <div class="feature-folder-contents" data-bind="visible: IsExpanded">
                 <div data-bind="template: { name: 'features-template', foreach: features }"></div>
                 <div data-bind="template: { name: 'featuresByFolder-template', foreach: SubDirectories }"></div>
             </div>
@@ -49,7 +49,7 @@
 
     <script type="text/html" id="steps-template">
         <li class="step">
-            <span class="keyword" data-bind="text: NativeKeyword"></span><span data-bind="    text: Name"></span>
+            <span class="keyword" data-bind="text: NativeKeyword"></span><span data-bind="text: Name"></span>
             <div data-bind="if: DocStringArgument != ''">
                 <div data-bind="text: DocStringArgument" class="pre"></div>
             </div>
@@ -90,13 +90,16 @@
                 </div>
             </div>
         </div>
+        <div class="navbar-below">
+            <div data-bind="click: $root.hideShowNavigation"><i class="icon-white" data-bind="css: { 'icon-minus-sign': $root.navIsShown(), 'icon-plus-sign': !$root.navIsShown() }"></i> Navigation</div>
+            <div data-bind="click: $root.hideShowNavigationTree"><i class="icon-white" data-bind="css: { 'icon-minus-sign': $root.ShowAllLinks(), 'icon-plus-sign': !$root.ShowAllLinks() }"></i> Links</div>
+        </div>
     </div>
 
     <div class="container-fluid" id="MainContainer">
         <div class="row-fluid">
             <div class="span12">
                 <div class="span3" id="FolderNav" data-bind="visible: navIsShown, css: { span3 : navIsShown(), span0 : !navIsShown() }">
-                    <div id="HideIt" data-bind="click: hideNav"><i class="icon-chevron-left"></i></div>
                     <div id="InnerNav">
                         <div data-bind="template: { name: 'features-template', foreach: featuresByFolder().features }"></div>
                         <div data-bind="template: { name: 'featuresByFolder-template', foreach: featuresByFolder().SubDirectories }"></div>
@@ -109,7 +112,6 @@
                 </div>
 
                 <div id="Content" data-bind="with: currentFeature, css: { span12 : navIsHidden(), span9 : !navIsHidden() }">
-                    <div id="ShowIt" data-bind="visible: $root.navIsHidden, click: $root.showNav"><i class="icon-chevron-right"></i></div>
                     <div data-bind="with: Feature" id="featureDetails">
                         <div data-bind="template: { name: 'testResults-template', data: Result }"></div>
                         <div data-bind="if: Tags.length > 0" class="canHighlight inline">
@@ -118,7 +120,7 @@
                             <span data-bind="text: $data" class="inline"></span>
                             <!-- /ko -->
                         </div>
-                        <h1 data-bind="text: Name, click: $root.toggleDetails" class="canHighlight, clickable"></h1>
+                        <h1 data-bind="text: Name, click: $root.toggleDetails" class="canHighlight clickable"></h1>
                         <div class="description" data-bind="html: renderMarkdownBlock(Description)"></div>
                     </div>
 
@@ -182,11 +184,11 @@
         </div>
         <!--/row-->
 
-        <hr>
+        <!--<hr>
 
         <footer>
             <p></p>
-        </footer>
+        </footer>-->
 
     </div>
     <!--/.fluid-container-->
@@ -211,13 +213,14 @@
         function ViewModel(features, configuration) {
             var self = this;
 
-            features = $.map(features, function(el, i) { return new FeatureParent(el); });
+            features = $.map(features, function (el, i) { return new FeatureParent(el); });
 
             self.originalFeaturesList = ko.observableArray(features);
             self.featuresByFolder = ko.observable(buildFullHierarchy(getFeaturesFromScenariosList(features)));
             self.currentFeature = ko.observable();
             self.configuration = ko.observable(configuration);
-
+            self.ShowAllLinks = ko.observable(false);
+            
             self.setCurrentFeature = function () {
                 if (window.location.hash != '') {
                     var featureFromHashLocation = findFeatureByRelativeFolder(removeBeginningHash(window.location.hash), features);
@@ -274,6 +277,24 @@
             self.showNav = function () { self.navIsShown(true); self.navIsHidden(false); };
             self.isSelected = function (path) {
                 return self.currentFeature().RelativeFolder == path;
+            };
+            self.toggleShowingFolderFeatures = function (dir) {
+                dir.IsExpanded(!dir.IsExpanded());
+            };
+            self.hideShowNavigation = function () {
+                self.navIsShown(!self.navIsShown());
+                self.navIsHidden(!self.navIsHidden());
+            };
+            self.hideShowNavigationTree = function () {
+                self.ShowAllLinks(!self.ShowAllLinks());
+                expandContractDirectoryLinks(self.featuresByFolder().SubDirectories);
+            };
+
+            function expandContractDirectoryLinks(subDirs) {
+                $.each(subDirs, function (key, value) {
+                    value.IsExpanded(self.ShowAllLinks());
+                    expandContractDirectoryLinks(value.SubDirectories);
+                });
             };
 
             // Hide / show detailed areas
@@ -335,20 +356,6 @@
 
             setupSubmitSearchWhenEnterKeyPressed();
         });
-        
-        function toggleShowingFolderFeatures(element, event) {
-            var icon = $($(event.target).parent().children('span')[0]);
-            var folderContents = $($(event.target).parent().next('div'));
-            if (icon.hasClass("icon-chevron-right")) {
-                icon.removeClass("icon-chevron-right");
-                icon.addClass("icon-chevron-down");
-                folderContents.hide();
-            } else {
-                icon.addClass("icon-chevron-right");
-                icon.removeClass("icon-chevron-down");
-                folderContents.show();
-            }
-        };
     </script>
 </body>
 </html>

--- a/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
@@ -17,6 +17,34 @@
     margin-top: 5px;
 }
 
+    .feature-folder-header span {
+        cursor: pointer;
+    }
+
+.feature-folder-contents {
+    margin-left: 15px;
+}
+
+.navbar-below {
+    margin-top: -1px;
+    margin-left: 10px;
+    border-top: 0;
+    -ms-border-bottom-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    -ms-border-bottom-right-radius: 10px;
+    border-bottom-right-radius: 10px;
+    width: 180px;
+    background-color: black;
+    color: rgb(173, 173, 173);
+}
+
+    .navbar-below div {
+        display: inline-block;
+        padding-left: 8px;
+        padding-right: 8px;
+        cursor: pointer;
+    }
+
 #scenarios, .steps {
     list-style-type: none;
     margin: 0;
@@ -49,13 +77,13 @@ li.step {
     margin-bottom: 0px;
 }
 
-.steps table td {
-    color: #B21515;
-}
+    .steps table td {
+        color: #B21515;
+    }
 
-.steps table th {
-    font-style: italic;
-}
+    .steps table th {
+        font-style: italic;
+    }
 
 #SearchButton {
     margin-top: 0;
@@ -70,21 +98,21 @@ li.step {
     border-right: 1px lightgrey solid;
 }
 
-#FolderNav a:hover {
-    background-color: #EEEEEE;
-    color: #1A668C;
-    text-decoration: none;
-}
+    #FolderNav a:hover {
+        background-color: #EEEEEE;
+        color: #1A668C;
+        text-decoration: none;
+    }
 
 .feature {
     padding: 5px;
 }
 
-.feature:hover {
-    background-color: #EEEEEE;
-    cursor: pointer;
-    color: #1A668C;
-}
+    .feature:hover {
+        background-color: #EEEEEE;
+        cursor: pointer;
+        color: #1A668C;
+    }
 
 .canHighlight {
 }

--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/heirarchyBuilder.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/heirarchyBuilder.js
@@ -1,5 +1,6 @@
 ﻿function Directory(name) {
     this.Name = name;
+    this.IsExpanded = ko.observable(false);
     this.features = new Array();
     this.SubDirectories = new Array();
 }

--- a/src/Pickles/Pickles/DocumentationBuilders/DHTML/DhtmlDocumentationBuilder.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/DHTML/DhtmlDocumentationBuilder.cs
@@ -18,13 +18,16 @@
 
 #endregion
 
+using System.Collections.Generic;
 using System.IO.Abstractions;
+using System.Linq;
 using NLog;
 using NGenerics.DataStructures.Trees;
 using PicklesDoc.Pickles.DirectoryCrawler;
 using PicklesDoc.Pickles.DocumentationBuilders.JSON;
 using PicklesDoc.Pickles.TestFrameworks;
 using System.Reflection;
+using sun.awt.geom;
 
 namespace PicklesDoc.Pickles.DocumentationBuilders.DHTML
 {
@@ -53,14 +56,27 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.DHTML
                 log.Info("Writing DHTML files to {0}", this.configuration.OutputFolder.FullName);
             }
 
-            log.Info("WriteResources");
+            log.Info("Pull Down Feature Images ");
+            this.PullDownFeatureImages(features);
+
+            log.Info("Write Resources");
             this.WriteResources();
-            
-            log.Info("UtilizeJsonBuilderToDumpJsonFeatureFileNextToDthmlResources");
+
+            log.Info("Utilize JsonBuilder To Dump Json Feature File Next To Dthml Resources");
             UtilizeJsonBuilderToDumpJsonFeatureFileNextToDthmlResources(features);
 
             log.Info("Tweak Json file");
             TweakJsonFile();
+        }
+
+        private void PullDownFeatureImages(IEnumerable<INode> features)
+        {
+            foreach (var image in features.Where(p => p.GetType() == typeof (ImageNode)).Select(p => (ImageNode) p))
+            {
+                var source = image.OriginalLocation.FullName;
+                var dest = this.fileSystem.Path.Combine(this.configuration.OutputFolder.FullName, image.OriginalLocation.Name);
+                this.fileSystem.File.Copy(source, dest, true);
+            }
         }
 
         private void UtilizeJsonBuilderToDumpJsonFeatureFileNextToDthmlResources(GeneralTree<INode> features)


### PR DESCRIPTION
Minor changes to the left nav:
* Added expand / contract all links feature: We nest our specs under folders and now that all sub-folders are hidden/collapsed by default, it can be tedious to expand them all to get to the page you're looking for.  I added a quick way to expand/contract all sub-folders so as to reveal all the links underneath.
* Refactored the expand/contract code to be more Knockout-y so I could add the expand/contract feature
* Restyled and changed the UX around how to expand/contract links and the navigation, hopefully making that process cleaner and more intuitive

Added image support:
* All feature images are pull into the root folder.  To verify, please pickle the Example specs for HTML and DHTML and compare the output on the "Showing basic gherkin syntax" and "Sample Markdown Feature" features.