### PR TITLE
Given keyword in dutch overlaps text

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
@@ -68,7 +68,7 @@ li.step {
     font-weight: bold;
     color: #0000FF;
     float: left;
-    width: 40px;
+    width: 60px;
     text-align: right;
     margin-right: 4px;
 }

--- a/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
@@ -67,10 +67,6 @@ li.step {
 .keyword {
     font-weight: bold;
     color: #0000FF;
-    float: left;
-    width: 60px;
-    text-align: right;
-    margin-right: 4px;
 }
 
 .steps table {


### PR DESCRIPTION
We're using SpecFlow configured for the Dutch language. When generating documentation for the Dynamic HTML format the Given (Gegeven in Dutch) overlaps the text.
![image](https://cloud.githubusercontent.com/assets/1440089/10124691/9e95c48c-655b-11e5-9b30-814e221458db.png)

I've changed the width of the keyword class to 60px. This results in no overlapping text in Dutch.
![image](https://cloud.githubusercontent.com/assets/1440089/10124709/000ad7ca-655c-11e5-8988-60bbc269f963.png)

The English documentation will look like this with this change:
![image](https://cloud.githubusercontent.com/assets/1440089/10124716/41758d0e-655c-11e5-8b4f-2ea5752d9313.png)

Old (current)
![image](https://cloud.githubusercontent.com/assets/1440089/10124719/680964f4-655c-11e5-9cec-27b76a33d7f9.png)

 