### PR TITLE
Fix NULL reference in CucumberJSON results processing

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonResultsFile.cs
@@ -38,7 +38,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.CucumberJson
         }
 
         [Test]
-        public void ThenCanReadFeatureResultSuccesfully()
+        public void ThenCanReadFeatureResultSuccessfully()
         {
             var results = ParseResultsFile();
 

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
@@ -14,6 +14,20 @@
     ],
     "elements": [
       {
+        "name": "",
+        "keyword": "Background",
+        "description": "",
+        "type": "background",
+        "line": 8,
+        "steps": [
+          {
+            "name": "I have a system under test",
+            "line": 9,
+            "keyword": "Given "
+          }
+        ]
+      },
+      {
         "keyword": "Scenario",
         "id": "one-passing-scenario,-one-failing-scenario;passing",
         "name": "Passing",
@@ -27,6 +41,25 @@
         ],
         "type": "scenario",
         "steps": [
+          {
+            "keyword": "Before ",
+            "hidden": true,
+            "result": {
+              "duration": 570775,
+              "status": "passed"
+            },
+            "match": {}
+          },
+          {
+            "name": "I have a system under test",
+            "line": 4,
+            "keyword": "Given ",
+            "result": {
+              "duration": 344974,
+              "status": "passed"
+            },
+            "match": {}
+          },
           {
             "keyword": "Given ",
             "name": "a passing step",
@@ -54,6 +87,25 @@
         ],
         "type": "scenario",
         "steps": [
+                    {
+            "keyword": "Before ",
+            "hidden": true,
+            "result": {
+              "duration": 570775,
+              "status": "passed"
+            },
+            "match": {}
+          },
+          {
+            "name": "I have a system under test",
+            "line": 4,
+            "keyword": "Given ",
+            "result": {
+              "duration": 344974,
+              "status": "passed"
+            },
+            "match": {}
+          },
           {
             "keyword": "Given ",
             "name": "a failing step",

--- a/src/Pickles/Pickles.TestFrameworks/CucumberJson/CucumberJsonSingleResults.cs
+++ b/src/Pickles/Pickles.TestFrameworks/CucumberJson/CucumberJsonSingleResults.cs
@@ -118,6 +118,8 @@ namespace PicklesDoc.Pickles.TestFrameworks.CucumberJson
                 return TestResult.Inconclusive;
             }
 
+            cucumberFeature.elements.RemoveAll(e => e.type == "background");
+
             bool wasSuccessful = cucumberFeature.elements.All(CheckScenarioStatus);
 
             return wasSuccessful ? TestResult.Passed : TestResult.Failed;


### PR DESCRIPTION
Cucumber-JS creates JSON results files that may include a background step. The background step will have no results and so a null reference is raised on Line 111:CucumberJsonSingleResults.cs.

The actual results for this step are within the scenario elements of the JSON.

Suggested fix is to remove the background element from the feature when processing results.