### PR TITLE
Add IMarkdownProvider to allow changing the MarkdownProvider used

### DIFF
--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlDescriptionFormatter.cs
@@ -27,11 +27,11 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.HTML
 {
     public class HtmlDescriptionFormatter
     {
-        private readonly MarkdownProvider markdown;
+        private readonly IMarkdownProvider markdown;
 
         private readonly XNamespace xmlns;
 
-        public HtmlDescriptionFormatter(MarkdownProvider markdown)
+        public HtmlDescriptionFormatter(IMarkdownProvider markdown)
         {
             this.markdown = markdown;
             this.xmlns = HtmlNamespace.Xhtml;

--- a/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/HTML/HtmlMarkdownFormatter.cs
@@ -26,11 +26,11 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.HTML
 {
     public class HtmlMarkdownFormatter
     {
-        private readonly MarkdownProvider markdown;
+        private readonly IMarkdownProvider markdown;
 
         private readonly XNamespace xmlns;
 
-        public HtmlMarkdownFormatter(MarkdownProvider markdown)
+        public HtmlMarkdownFormatter(IMarkdownProvider markdown)
         {
             this.markdown = markdown;
             this.xmlns = HtmlNamespace.Xhtml;

--- a/src/Pickles/Pickles/IMarkdownProvider.cs
+++ b/src/Pickles/Pickles/IMarkdownProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace PicklesDoc.Pickles
+{
+	public interface IMarkdownProvider
+    {
+        string Transform(string text);
+    }
+}

--- a/src/Pickles/Pickles/MarkdownProvider.cs
+++ b/src/Pickles/Pickles/MarkdownProvider.cs
@@ -20,7 +20,7 @@
 
 namespace PicklesDoc.Pickles
 {
-    public class MarkdownProvider
+    public class MarkdownProvider : IMarkdownProvider
     {
         private readonly MarkdownDeep.Markdown markdown;
 

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="FeatureParseException.cs" />
     <Compile Include="GlobalSuppressions.cs" />
+    <Compile Include="IMarkdownProvider.cs" />
     <Compile Include="LanguageServices.cs" />
     <Compile Include="MarkdownProvider.cs" />
     <Compile Include="ObjectModel\KeywordResolver.cs" />

--- a/src/Pickles/Pickles/PicklesModule.cs
+++ b/src/Pickles/Pickles/PicklesModule.cs
@@ -114,7 +114,7 @@ namespace PicklesDoc.Pickles
             builder.RegisterType<HtmlFooterFormatter>().SingleInstance();
             builder.RegisterType<HtmlDocumentFormatter>().SingleInstance();
             builder.RegisterType<HtmlFeatureFormatter>().As<IHtmlFeatureFormatter>().SingleInstance();
-            builder.RegisterType<MarkdownProvider>().SingleInstance();
+            builder.RegisterType<MarkdownProvider>().As<IMarkdownProvider>().SingleInstance();
         }
     }
 }


### PR DESCRIPTION
Adding an interface for MakrdownProvider will make it easier to change the Markdown parsing engine used.
(I will use Markdownify)