### PR TITLE
Fix Issue with Scenario Outline Data Containing Parenthesis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 - Word document is corrupt if a Feature has no description ([#261](https://github.com/picklesdoc/pickles/issues/261)) (by [@dirkrombauts](https://github.com/dirkrombauts)).
 - The Cucumber JSON test result provider should deal with background steps correctly  ([#293](https://github.com/picklesdoc/pickles/issues/293)) (by [@dirkrombauts](https://github.com/dirkrombauts) based on [an idea by MikeThomas64](https://github.com/picklesdoc/pickles/pull/251)).
+- Scenario Outline with parenthesis parses correctly and reports the correct result ([PR#299](https://github.com/picklesdoc/pickles/pull/299)) (by [@ocsurfnut](https://github.com/ocsurfnut))
 
 ## [2.3.0] - 2016-01-27
 

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromJSResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromJSResultsFile.cs
@@ -107,6 +107,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.CucumberJson
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromRubyResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromRubyResultsFile.cs
@@ -107,6 +107,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.CucumberJson
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
@@ -5,7 +5,7 @@
     "description": "In order to avoid silly mistakes\r\nAs a math idiot\r\nI want to be told the sum of two numbers",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/Addition.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Addition.feature",
     "elements": [
       {
         "name": "",
@@ -41,7 +41,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 993975
+              "duration": 608780
             },
             "match": {}
           },
@@ -51,7 +51,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 549749
+              "duration": 328155
             },
             "match": {}
           },
@@ -61,7 +61,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 109052
+              "duration": 50375
             },
             "match": {}
           },
@@ -71,7 +71,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 79544
+              "duration": 43829
             },
             "match": {}
           },
@@ -81,7 +81,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 170955
+              "duration": 140882
             },
             "match": {}
           },
@@ -91,7 +91,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 211368
+              "duration": 1425323
             },
             "match": {}
           }
@@ -117,7 +117,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 110656
+              "duration": 90221
             },
             "match": {}
           },
@@ -127,7 +127,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 58054
+              "duration": 50376
             },
             "match": {}
           },
@@ -137,7 +137,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 82430
+              "duration": 43546
             },
             "match": {}
           },
@@ -147,7 +147,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 43942
+              "duration": 69729
             },
             "match": {}
           },
@@ -157,7 +157,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 104561
+              "duration": 56922
             },
             "match": {}
           },
@@ -167,7 +167,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 51640
+              "duration": 41553
             },
             "match": {}
           }
@@ -193,7 +193,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 123806
+              "duration": 45538
             },
             "match": {}
           },
@@ -203,7 +203,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 87241
+              "duration": 69160
             },
             "match": {}
           },
@@ -213,7 +213,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 42979
+              "duration": 130352
             },
             "match": {}
           },
@@ -223,7 +223,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 92694
+              "duration": 33015
             },
             "match": {}
           },
@@ -233,7 +233,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 46507
+              "duration": 36715
             },
             "match": {}
           }
@@ -259,7 +259,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 136315
+              "duration": 56637
             },
             "match": {}
           },
@@ -269,7 +269,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 151069
+              "duration": 41553
             },
             "match": {}
           },
@@ -316,7 +316,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 219066
+              "duration": 99044
             },
             "match": {}
           },
@@ -357,7 +357,7 @@
     "description": "This feature has a failing background.",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/FailingBackground.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/FailingBackground.feature",
     "elements": [
       {
         "name": "",
@@ -392,8 +392,8 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 4917275,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 1778808,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           },
@@ -458,8 +458,8 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 744119,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 341816,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           },
@@ -533,8 +533,8 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 682215,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 330716,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           },
@@ -602,7 +602,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Failing.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Failing.feature",
     "elements": [
       {
         "name": "Failing Feature Passing Scenario",
@@ -618,7 +618,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 147861
+              "duration": 82537
             },
             "match": {}
           }
@@ -657,8 +657,8 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 1813146,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 233664,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           }
@@ -672,7 +672,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Inconclusive.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Inconclusive.feature",
     "elements": [
       {
         "name": "Inconclusive Feature Passing Scenario",
@@ -688,7 +688,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 135993
+              "duration": 38707
             },
             "match": {}
           }
@@ -721,7 +721,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Passing.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Passing.feature",
     "elements": [
       {
         "name": "Passing Feature Passing Scenario",
@@ -737,7 +737,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 215217
+              "duration": 36430
             },
             "match": {}
           }
@@ -751,7 +751,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/NotAutomatedAtAll.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/NotAutomatedAtAll.feature",
     "elements": [
       {
         "name": "",
@@ -913,7 +913,7 @@
     "description": "Here we demonstrate how we deal with scenario outlines",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/CucumberJS/features/ScenarioOutlines.feature",
+    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/ScenarioOutlines.feature",
     "elements": [
       {
         "name": "This is a scenario outline where all scenarios pass",
@@ -929,7 +929,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 258838
+              "duration": 92498
             },
             "match": {}
           }
@@ -949,7 +949,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 166785
+              "duration": 35860
             },
             "match": {}
           }
@@ -969,7 +969,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 184105
+              "duration": 40984
             },
             "match": {}
           }
@@ -989,7 +989,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 191482
+              "duration": 34438
             },
             "match": {}
           }
@@ -1009,7 +1009,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 179935
+              "duration": 33869
             },
             "match": {}
           }
@@ -1048,7 +1048,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 190520
+              "duration": 34437
             },
             "match": {}
           }
@@ -1068,7 +1068,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 647255
+              "duration": 32161
             },
             "match": {}
           }
@@ -1088,8 +1088,8 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 750213,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 220857,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           }
@@ -1109,7 +1109,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 126372
+              "duration": 33015
             },
             "match": {}
           }
@@ -1129,7 +1129,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 128938
+              "duration": 41268
             },
             "match": {}
           }
@@ -1187,8 +1187,8 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 444547,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 565803,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           }
@@ -1208,8 +1208,8 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 443264,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\Dev\\Code\\GitHub\\DirkRombauts\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:456:9)\n    at process._tickCallback (node.js:385:13)\n    at Function.Module.runMain (module.js:432:11)\n    at startup (node.js:141:18)\n    at node.js:1003:3"
+              "duration": 299125,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
           }
@@ -1229,7 +1229,27 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 192444
+              "duration": 64891
+            },
+            "match": {}
+          }
+        ]
+      },
+      {
+        "name": "Deal correctly with parenthesis in the examples",
+        "id": "Scenario-Outlines;deal-correctly-with-parenthesis-in-the-examples",
+        "line": 78,
+        "keyword": "Scenario",
+        "description": "",
+        "type": "scenario",
+        "steps": [
+          {
+            "name": "I have parenthesis in the value, for example a 'This is a description (and more)'",
+            "line": 74,
+            "keyword": "When ",
+            "result": {
+              "status": "passed",
+              "duration": 59483
             },
             "match": {}
           }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
@@ -41,7 +41,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 608780
+              "duration": 699285
             },
             "match": {}
           },
@@ -51,7 +51,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 328155
+              "duration": 367430
             },
             "match": {}
           },
@@ -61,7 +61,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 50375
+              "duration": 48668
             },
             "match": {}
           },
@@ -71,7 +71,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 43829
+              "duration": 48952
             },
             "match": {}
           },
@@ -81,7 +81,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 140882
+              "duration": 151412
             },
             "match": {}
           },
@@ -91,7 +91,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 1425323
+              "duration": 97906
             },
             "match": {}
           }
@@ -117,7 +117,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 90221
+              "duration": 75706
             },
             "match": {}
           },
@@ -127,7 +127,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 50376
+              "duration": 40414
             },
             "match": {}
           },
@@ -137,7 +137,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 43546
+              "duration": 37284
             },
             "match": {}
           },
@@ -147,7 +147,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 69729
+              "duration": 58060
             },
             "match": {}
           },
@@ -157,7 +157,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 56922
+              "duration": 198942
             },
             "match": {}
           },
@@ -167,7 +167,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 41553
+              "duration": 48099
             },
             "match": {}
           }
@@ -193,7 +193,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 45538
+              "duration": 53506
             },
             "match": {}
           },
@@ -203,7 +203,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 69160
+              "duration": 40415
             },
             "match": {}
           },
@@ -213,7 +213,7 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 130352
+              "duration": 36999
             },
             "match": {}
           },
@@ -223,7 +223,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 33015
+              "duration": 39845
             },
             "match": {}
           },
@@ -233,7 +233,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 36715
+              "duration": 37853
             },
             "match": {}
           }
@@ -259,7 +259,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 56637
+              "duration": 48668
             },
             "match": {}
           },
@@ -269,7 +269,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 41553
+              "duration": 36430
             },
             "match": {}
           },
@@ -316,7 +316,7 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 99044
+              "duration": 76845
             },
             "match": {}
           },
@@ -392,7 +392,7 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 1778808,
+              "duration": 1630811,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -458,7 +458,7 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 341816,
+              "duration": 383654,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -533,7 +533,7 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 330716,
+              "duration": 346939,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -618,7 +618,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 82537
+              "duration": 120390
             },
             "match": {}
           }
@@ -657,7 +657,7 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 233664,
+              "duration": 223418,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -688,7 +688,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 38707
+              "duration": 44114
             },
             "match": {}
           }
@@ -737,7 +737,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 36430
+              "duration": 60622
             },
             "match": {}
           }
@@ -929,7 +929,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 92498
+              "duration": 96482
             },
             "match": {}
           }
@@ -949,7 +949,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 35860
+              "duration": 36145
             },
             "match": {}
           }
@@ -969,7 +969,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 40984
+              "duration": 33583
             },
             "match": {}
           }
@@ -989,7 +989,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 34438
+              "duration": 34437
             },
             "match": {}
           }
@@ -1009,7 +1009,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 33869
+              "duration": 45538
             },
             "match": {}
           }
@@ -1048,7 +1048,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 34437
+              "duration": 39845
             },
             "match": {}
           }
@@ -1068,7 +1068,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 32161
+              "duration": 36430
             },
             "match": {}
           }
@@ -1088,7 +1088,7 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 220857,
+              "duration": 287740,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -1109,7 +1109,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 33015
+              "duration": 37853
             },
             "match": {}
           }
@@ -1129,7 +1129,7 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 41268
+              "duration": 36430
             },
             "match": {}
           }
@@ -1187,7 +1187,7 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 565803,
+              "duration": 499489,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -1208,7 +1208,7 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 299125,
+              "duration": 353200,
               "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
             },
             "match": {}
@@ -1229,7 +1229,7 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 64891
+              "duration": 142020
             },
             "match": {}
           }
@@ -1244,12 +1244,12 @@
         "type": "scenario",
         "steps": [
           {
-            "name": "I have parenthesis in the value, for example a 'This is a description (and more)'",
+            "name": "I have parenthesis in the value, for example an 'This is a description (and more)'",
             "line": 74,
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 59483
+              "duration": 78837
             },
             "match": {}
           }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
@@ -99,7 +99,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 999000
+              "duration": 1000000
             }
           }
         ]
@@ -343,7 +343,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"fail\"\n     got: \"this is a hacky way of making the scenario with a non-integer number\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/AdditionSteps.rb:11:in `/^I have entered (\\d+)\\.(\\d+) into the calculator$/'\nfeatures/Addition.feature:32:in `And I have entered 2.2 into the calculator'",
-              "duration": 11999000
+              "duration": 12991000
             }
           },
           {
@@ -777,7 +777,7 @@
             "result": {
               "status": "pending",
               "error_message": "TODO (Cucumber::Pending)\n./features/step_definitions/MinimalSteps.rb:6:in `/^inconclusive step$/'\nfeatures/Minimal Features/Failing.feature:7:in `Then inconclusive step'",
-              "duration": 0
+              "duration": 999000
             }
           }
         ]
@@ -1409,7 +1409,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"false\"\n     got: \"true\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/ScenarioOutlineSteps.rb:10:in `/^the scenario will 'fail_(\\d+)'$/'\nfeatures/ScenarioOutlines.feature:59:in `Then the scenario will 'fail_1''\nfeatures/ScenarioOutlines.feature:45:in `Then the scenario will '<result>''",
-              "duration": 500000
+              "duration": 0
             }
           }
         ]
@@ -1451,6 +1451,28 @@
             "line": 69,
             "match": {
               "location": "features/step_definitions/ScenarioOutlineSteps.rb:13"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          }
+        ]
+      },
+      {
+        "id": "scenario-outlines;deal-correctly-with-parenthesis-in-the-examples;;2",
+        "keyword": "Scenario Outline",
+        "name": "Deal correctly with parenthesis in the examples",
+        "description": "",
+        "line": 78,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "When ",
+            "name": "I have parenthesis in the value, for example a 'This is a description (and more)'",
+            "line": 78,
+            "match": {
+              "location": "features/step_definitions/ScenarioOutlineSteps.rb:17"
             },
             "result": {
               "status": "passed",

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
@@ -343,7 +343,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"fail\"\n     got: \"this is a hacky way of making the scenario with a non-integer number\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/AdditionSteps.rb:11:in `/^I have entered (\\d+)\\.(\\d+) into the calculator$/'\nfeatures/Addition.feature:32:in `And I have entered 2.2 into the calculator'",
-              "duration": 12991000
+              "duration": 15003000
             }
           },
           {
@@ -777,7 +777,7 @@
             "result": {
               "status": "pending",
               "error_message": "TODO (Cucumber::Pending)\n./features/step_definitions/MinimalSteps.rb:6:in `/^inconclusive step$/'\nfeatures/Minimal Features/Failing.feature:7:in `Then inconclusive step'",
-              "duration": 999000
+              "duration": 0
             }
           }
         ]
@@ -1162,7 +1162,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 0
+              "duration": 1011000
             }
           }
         ]
@@ -1229,7 +1229,7 @@
             "result": {
               "status": "pending",
               "error_message": "TODO (Cucumber::Pending)\n./features/step_definitions/ScenarioOutlineSteps.rb:6:in `/^the scenario will 'inconclusive_(\\d+)'$/'\nfeatures/ScenarioOutlines.feature:27:in `Then the scenario will 'inconclusive_1''\nfeatures/ScenarioOutlines.feature:21:in `Then the scenario will '<result>''",
-              "duration": 0
+              "duration": 994000
             }
           }
         ]
@@ -1340,7 +1340,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 0
+              "duration": 1000000
             }
           }
         ]
@@ -1469,7 +1469,7 @@
         "steps": [
           {
             "keyword": "When ",
-            "name": "I have parenthesis in the value, for example a 'This is a description (and more)'",
+            "name": "I have parenthesis in the value, for example an 'This is a description (and more)'",
             "line": 78,
             "match": {
               "location": "features/step_definitions/ScenarioOutlineSteps.rb:17"

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/WhenParsingMsTestResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/WhenParsingMsTestResultsFile.cs
@@ -113,6 +113,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.MsTest
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="572f9160-0c8b-400b-8f4e-28ea619549cc" name="Dirk@SHUTTLEPC 2016-02-21 10:23:01" runUser="SHUTTLEPC\Dirk" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<TestRun id="cd498d6a-190a-4482-bb7f-72542dae224c" name="ocsur@DESKTOP-AIFNJPI 2016-02-26 13:29:30" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestSettings name="TestSettings" id="3d90c4f8-ccdc-4663-bad3-9f4c55f42318">
     <Description>These are default test settings for a local test run.</Description>
-    <Deployment userDeploymentRoot="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="Dirk_SHUTTLEPC 2016-02-21 10_23_01" />
+    <Deployment userDeploymentRoot="C:\src\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-26 13_29_30" />
     <Execution>
       <TestTypeSpecific />
       <AgentRule name="Execution Agents">
@@ -10,28 +10,28 @@
     </Execution>
     <Properties />
   </TestSettings>
-  <Times creation="2016-02-21T10:23:01.1349500+01:00" queuing="2016-02-21T10:23:01.4669656+01:00" start="2016-02-21T10:23:01.5729771+01:00" finish="2016-02-21T10:23:02.2171555+01:00" />
+  <Times creation="2016-02-26T13:29:30.0878846-05:00" queuing="2016-02-26T13:29:30.3899641-05:00" start="2016-02-26T13:29:30.4720024-05:00" finish="2016-02-26T13:29:30.9409642-05:00" />
   <ResultSummary outcome="Failed">
-    <Counters total="34" executed="34" passed="17" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="35" executed="35" passed="18" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
   <TestDefinitions>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
+    <UnitTest name="NotAutomatedScenario1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
       <Description>Not automated scenario 1</Description>
-      <Execution id="c4cdec79-c180-454e-b012-ffe2ddad06bd" />
+      <Execution id="326ff8a3-e758-42f0-8bda-b260030d0a35" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="2abad81c-f023-4e21-8dcd-b2f10a55cc69" />
+      <Execution id="7fe31cbe-4c84-4da6-b418-eead0e6a7992" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -58,11 +58,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="6b312864-8561-417a-8287-1171158305fb" />
+      <Execution id="b92646d2-7d31-4e82-913a-09f9f2418fe2" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -77,66 +77,66 @@
           <Value>fail_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
+    <UnitTest name="NotAutomatedScenario3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
       <Description>Not automated scenario 3</Description>
-      <Execution id="6e481d01-8204-459e-afc3-03b815ea2586" />
+      <Execution id="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
+    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
       <Description>Add two numbers</Description>
-      <Execution id="b62885ee-e2d8-4b1e-82aa-60c6e1651924" />
+      <Execution id="40d77687-6bcf-4add-8ec0-76b641aa90a9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
       <Description>Failing Feature Inconclusive Scenario</Description>
-      <Execution id="a1ecdb5c-56da-48b2-8243-973c62b097c5" />
+      <Execution id="3e152a18-e71b-4591-af65-c8d61b4d5034" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
       <Description>Inconclusive Feature Inconclusive Scenario</Description>
-      <Execution id="dc9eb68c-0556-4fbc-b908-e1ca8cad8727" />
+      <Execution id="137f7569-9430-4d13-a05d-759a234eb464" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
+    <UnitTest name="FailingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
       <Description>Failing Feature Passing Scenario</Description>
-      <Execution id="d151dea1-acc8-40c3-b073-1fff4cc4b595" />
+      <Execution id="b8bb47fd-5be1-4379-971e-965f5200f874" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
       <Description>Deal correctly with backslashes in the examples</Description>
-      <Execution id="e3a0885b-5486-47b9-9109-3a0af6214a96" />
+      <Execution id="8df7bbbc-3f38-49a3-9594-8864a381a90f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -151,11 +151,11 @@
           <Value>c:\Temp\</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="ecb3cf16-fe6c-4b43-99cd-bc17c1eb01e8" />
+      <Execution id="ab22f5f6-0dae-4a24-838d-e039559bd18c" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -170,11 +170,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="09313672-0f21-437d-958f-714c5d7e20cc" />
+      <Execution id="4faa5750-d1ad-4555-baad-92b8d80b3681" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -189,14 +189,14 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="74a7291b-b797-40d2-b87c-4f5d496e0fc7" />
+      <Execution id="d8a81083-b6a6-48a5-8806-e839e57ff9f2" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -223,11 +223,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="3152e879-1a8c-44a4-8f4f-f479f4cfd563" />
+      <Execution id="63aae32d-b2ba-4055-9b70-2c3dd1deb829" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -242,22 +242,41 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
+    <UnitTest name="FailingFeatureFailingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
       <Description>Failing Feature Failing Scenario</Description>
-      <Execution id="9b5d22fb-5123-4700-bff0-48522782bf0c" />
+      <Execution id="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
+      <Description>Deal correctly with parenthesis in the examples</Description>
+      <Execution id="422b76b4-5249-4f76-b4a7-43f83408e83a" />
+      <Properties>
+        <Property>
+          <Key>FeatureTitle</Key>
+          <Value>Scenario Outlines</Value>
+        </Property>
+        <Property>
+          <Key>VariantName</Key>
+          <Value>This is a description (and more)</Value>
+        </Property>
+        <Property>
+          <Key>Parameter:overly descriptive field</Key>
+          <Value>This is a description (and more)</Value>
+        </Property>
+      </Properties>
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
+    </UnitTest>
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="76bf7a0f-5af1-4ff1-b13d-585d697a376e" />
+      <Execution id="d785ea5e-732c-404b-936b-e982d7bf6cf9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -272,11 +291,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="12d05f27-72f9-4ffd-8fc7-87840292d758" />
+      <Execution id="9903f019-a8b0-40aa-939a-45c4eb24ff04" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -291,22 +310,22 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
       <Description>Inconclusive Feature Passing Scenario</Description>
-      <Execution id="9cd5324c-5f43-4c37-86d7-b598eff32a55" />
+      <Execution id="366a7bc5-dafe-4691-b7ad-f59dad93c972" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="f84ef13d-013a-44ac-a10c-0e852eb62117" />
+      <Execution id="1911f0a9-5caf-4856-aa23-77ecb5517b46" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -321,35 +340,35 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
-      <Execution id="66438ce1-1e4b-4abc-8bf9-ff5183f19268" />
+    <UnitTest name="TestMethod" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
+      <Execution id="28850158-c04e-4d34-8806-de2a81f3d648" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
+    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
       <Description>Add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="028db2c7-3488-4022-80ff-b6aa8d1d93aa" />
+      <Execution id="a87f23d2-a120-4c61-8c6c-bb71f59b7259" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="62d2e4e8-6b19-48ff-9eed-c913e1aaee2c" />
+      <Execution id="c42f16f0-9583-454a-9832-b7e7837dd78b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -364,11 +383,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="7144616d-90e6-4927-9144-1e9c7a1d9309" />
+      <Execution id="f3b7392c-434a-48ce-a8ea-0d7e120f7972" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -383,11 +402,11 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="4fcfa010-31d8-483f-83f1-b25529e45827" />
+      <Execution id="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -402,11 +421,11 @@
           <Value>inconclusive_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
       <Description>Adding several numbers</Description>
-      <Execution id="a1cb0ee7-248e-48c8-96fe-6447a9a984ba" />
+      <Execution id="9d358154-21b9-4559-b9ac-66637ee84fdc" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -433,22 +452,22 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
+    <UnitTest name="NotAutomatedScenario2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
       <Description>Not automated scenario 2</Description>
-      <Execution id="1e48153a-89d8-4621-87e1-8dc8f5c66ba1" />
+      <Execution id="c73982e2-d8da-42c1-b2ab-38b896540858" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="a98a6e9c-0a63-4622-b8cf-f5594ed76c8e" />
+      <Execution id="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -463,11 +482,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="42703328-9515-44c3-89fc-db9b63fd6319" />
+      <Execution id="964f747a-4194-4233-81b2-dd6be69b215d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -482,22 +501,22 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
+    <UnitTest name="PassingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
       <Description>Passing Feature Passing Scenario</Description>
-      <Execution id="1e97939e-200c-4aeb-a477-e76f75138033" />
+      <Execution id="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Passing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="df91b9f3-2f10-4e7c-9586-317b29ad83ac" />
+      <Execution id="33cb498b-9452-47f2-8d84-bb85de1f7e99" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -512,11 +531,11 @@
           <Value>pass_3</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="df23bc08-8e65-4b4a-84fb-e54e1f06f0b3" />
+      <Execution id="e3db021c-01e8-4047-b513-301c4b925298" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -531,11 +550,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
       <Description>Adding several numbers</Description>
-      <Execution id="d9b1e852-782d-44fe-8e2e-3349050c2d97" />
+      <Execution id="be3afc74-441a-43b2-9c71-edd28d8a4152" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -562,36 +581,36 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
+    <UnitTest name="FailToAddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
       <Description>Fail to add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="ff3fd3cd-00ee-4e5e-8e3f-11406677626d" />
+      <Execution id="d8dea341-c2d5-40c2-9477-37430de901f9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
       <Description>Not automated adding two numbers</Description>
-      <Execution id="287decd0-845f-447b-9223-787ea7715374" />
+      <Execution id="82c5079b-949d-411c-8f3f-c8a9b404e78f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="c6d971c3-c9fb-4fff-94ce-a49b613e17fd" />
+      <Execution id="ba414847-62a0-4a75-8b4f-23502381b947" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -606,7 +625,7 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/Dev/Code/GitHub/DirkRombauts/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
   </TestDefinitions>
   <TestLists>
@@ -614,98 +633,99 @@
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <TestEntries>
-    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="2abad81c-f023-4e21-8dcd-b2f10a55cc69" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="74a7291b-b797-40d2-b87c-4f5d496e0fc7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="028db2c7-3488-4022-80ff-b6aa8d1d93aa" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="ff3fd3cd-00ee-4e5e-8e3f-11406677626d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="287decd0-845f-447b-9223-787ea7715374" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="d9b1e852-782d-44fe-8e2e-3349050c2d97" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="a1cb0ee7-248e-48c8-96fe-6447a9a984ba" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="b62885ee-e2d8-4b1e-82aa-60c6e1651924" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="9b5d22fb-5123-4700-bff0-48522782bf0c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="a1ecdb5c-56da-48b2-8243-973c62b097c5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="d151dea1-acc8-40c3-b073-1fff4cc4b595" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="dc9eb68c-0556-4fbc-b908-e1ca8cad8727" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="9cd5324c-5f43-4c37-86d7-b598eff32a55" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="1e97939e-200c-4aeb-a477-e76f75138033" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="c4cdec79-c180-454e-b012-ffe2ddad06bd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="1e48153a-89d8-4621-87e1-8dc8f5c66ba1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="6e481d01-8204-459e-afc3-03b815ea2586" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="66438ce1-1e4b-4abc-8bf9-ff5183f19268" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="42703328-9515-44c3-89fc-db9b63fd6319" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="3152e879-1a8c-44a4-8f4f-f479f4cfd563" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="c6d971c3-c9fb-4fff-94ce-a49b613e17fd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="4fcfa010-31d8-483f-83f1-b25529e45827" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="09313672-0f21-437d-958f-714c5d7e20cc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="6b312864-8561-417a-8287-1171158305fb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="e3a0885b-5486-47b9-9109-3a0af6214a96" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="a98a6e9c-0a63-4622-b8cf-f5594ed76c8e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="12d05f27-72f9-4ffd-8fc7-87840292d758" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="df91b9f3-2f10-4e7c-9586-317b29ad83ac" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="7144616d-90e6-4927-9144-1e9c7a1d9309" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="df23bc08-8e65-4b4a-84fb-e54e1f06f0b3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="ecb3cf16-fe6c-4b43-99cd-bc17c1eb01e8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="f84ef13d-013a-44ac-a10c-0e852eb62117" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="76bf7a0f-5af1-4ff1-b13d-585d697a376e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="62d2e4e8-6b19-48ff-9eed-c913e1aaee2c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="7fe31cbe-4c84-4da6-b418-eead0e6a7992" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="d8a81083-b6a6-48a5-8806-e839e57ff9f2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="a87f23d2-a120-4c61-8c6c-bb71f59b7259" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="d8dea341-c2d5-40c2-9477-37430de901f9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="82c5079b-949d-411c-8f3f-c8a9b404e78f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="be3afc74-441a-43b2-9c71-edd28d8a4152" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="9d358154-21b9-4559-b9ac-66637ee84fdc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="40d77687-6bcf-4add-8ec0-76b641aa90a9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="3e152a18-e71b-4591-af65-c8d61b4d5034" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="b8bb47fd-5be1-4379-971e-965f5200f874" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="137f7569-9430-4d13-a05d-759a234eb464" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="366a7bc5-dafe-4691-b7ad-f59dad93c972" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="326ff8a3-e758-42f0-8bda-b260030d0a35" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="c73982e2-d8da-42c1-b2ab-38b896540858" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="28850158-c04e-4d34-8806-de2a81f3d648" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="964f747a-4194-4233-81b2-dd6be69b215d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="63aae32d-b2ba-4055-9b70-2c3dd1deb829" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="ba414847-62a0-4a75-8b4f-23502381b947" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="4faa5750-d1ad-4555-baad-92b8d80b3681" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="b92646d2-7d31-4e82-913a-09f9f2418fe2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="8df7bbbc-3f38-49a3-9594-8864a381a90f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="422b76b4-5249-4f76-b4a7-43f83408e83a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="9903f019-a8b0-40aa-939a-45c4eb24ff04" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="33cb498b-9452-47f2-8d84-bb85de1f7e99" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="f3b7392c-434a-48ce-a8ea-0d7e120f7972" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="e3db021c-01e8-4047-b513-301c4b925298" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="ab22f5f6-0dae-4a24-838d-e039559bd18c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="1911f0a9-5caf-4856-aa23-77ecb5517b46" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="d785ea5e-732c-404b-936b-e982d7bf6cf9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="c42f16f0-9583-454a-9832-b7e7837dd78b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <Results>
-    <UnitTestResult executionId="2abad81c-f023-4e21-8dcd-b2f10a55cc69" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="SHUTTLEPC" duration="00:00:00.0434982" startTime="2016-02-21T10:23:01.6139963+01:00" endTime="2016-02-21T10:23:01.8800943+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2abad81c-f023-4e21-8dcd-b2f10a55cc69">
+    <UnitTestResult executionId="7fe31cbe-4c84-4da6-b418-eead0e6a7992" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0441409" startTime="2016-02-26T13:29:30.4930029-05:00" endTime="2016-02-26T13:29:30.7320536-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7fe31cbe-4c84-4da6-b418-eead0e6a7992">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="74a7291b-b797-40d2-b87c-4f5d496e0fc7" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="SHUTTLEPC" duration="00:00:00.0004387" startTime="2016-02-21T10:23:01.8836067+01:00" endTime="2016-02-21T10:23:01.8861095+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="74a7291b-b797-40d2-b87c-4f5d496e0fc7">
+    <UnitTestResult executionId="d8a81083-b6a6-48a5-8806-e839e57ff9f2" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002772" startTime="2016-02-26T13:29:30.7330532-05:00" endTime="2016-02-26T13:29:30.7350528-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8a81083-b6a6-48a5-8806-e839e57ff9f2">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="028db2c7-3488-4022-80ff-b6aa8d1d93aa" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0002787" startTime="2016-02-21T10:23:01.8886090+01:00" endTime="2016-02-21T10:23:01.8906098+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="028db2c7-3488-4022-80ff-b6aa8d1d93aa">
+    <UnitTestResult executionId="a87f23d2-a120-4c61-8c6c-bb71f59b7259" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002584" startTime="2016-02-26T13:29:30.7350528-05:00" endTime="2016-02-26T13:29:30.7370548-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a87f23d2-a120-4c61-8c6c-bb71f59b7259">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ff3fd3cd-00ee-4e5e-8e3f-11406677626d" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0237662" startTime="2016-02-21T10:23:01.8930946+01:00" endTime="2016-02-21T10:23:01.9186133+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ff3fd3cd-00ee-4e5e-8e3f-11406677626d">
+    <UnitTestResult executionId="d8dea341-c2d5-40c2-9477-37430de901f9" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0193596" startTime="2016-02-26T13:29:30.7370548-05:00" endTime="2016-02-26T13:29:30.7580589-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8dea341-c2d5-40c2-9477-37430de901f9">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -&gt; error: Input string was not in a correct format.</StdOut>
         <ErrorInfo>
@@ -727,16 +747,16 @@ System.FormatException: Input string was not in a correct format.</Message>
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="287decd0-845f-447b-9223-787ea7715374" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0264344" startTime="2016-02-21T10:23:01.9220995+01:00" endTime="2016-02-21T10:23:01.9506002+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="287decd0-845f-447b-9223-787ea7715374">
+    <UnitTestResult executionId="82c5079b-949d-411c-8f3f-c8a9b404e78f" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0248589" startTime="2016-02-26T13:29:30.7590588-05:00" endTime="2016-02-26T13:29:30.7850780-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="82c5079b-949d-411c-8f3f-c8a9b404e78f">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -796,13 +816,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d9b1e852-782d-44fe-8e2e-3349050c2d97" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="SHUTTLEPC" duration="00:00:00.0097922" startTime="2016-02-21T10:23:01.9535939+01:00" endTime="2016-02-21T10:23:01.9661282+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d9b1e852-782d-44fe-8e2e-3349050c2d97">
+    <UnitTestResult executionId="be3afc74-441a-43b2-9c71-edd28d8a4152" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0100615" startTime="2016-02-26T13:29:30.7860762-05:00" endTime="2016-02-26T13:29:30.7990819-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="be3afc74-441a-43b2-9c71-edd28d8a4152">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -833,21 +853,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a1cb0ee7-248e-48c8-96fe-6447a9a984ba" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="SHUTTLEPC" duration="00:00:00.0021675" startTime="2016-02-21T10:23:01.9691107+01:00" endTime="2016-02-21T10:23:01.9731117+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a1cb0ee7-248e-48c8-96fe-6447a9a984ba">
+    <UnitTestResult executionId="9d358154-21b9-4559-b9ac-66637ee84fdc" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017887" startTime="2016-02-26T13:29:30.8000695-05:00" endTime="2016-02-26T13:29:30.8030830-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9d358154-21b9-4559-b9ac-66637ee84fdc">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -878,21 +898,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b62885ee-e2d8-4b1e-82aa-60c6e1651924" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0020520" startTime="2016-02-21T10:23:01.9761147+01:00" endTime="2016-02-21T10:23:01.9791117+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b62885ee-e2d8-4b1e-82aa-60c6e1651924">
+    <UnitTestResult executionId="40d77687-6bcf-4add-8ec0-76b641aa90a9" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0019982" startTime="2016-02-26T13:29:30.8040711-05:00" endTime="2016-02-26T13:29:30.8070715-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="40d77687-6bcf-4add-8ec0-76b641aa90a9">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -921,20 +941,20 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9b5d22fb-5123-4700-bff0-48522782bf0c" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="SHUTTLEPC" duration="00:00:00.0050590" startTime="2016-02-21T10:23:01.9831111+01:00" endTime="2016-02-21T10:23:01.9901115+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9b5d22fb-5123-4700-bff0-48522782bf0c">
+    <UnitTestResult executionId="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0045910" startTime="2016-02-26T13:29:30.8080716-05:00" endTime="2016-02-26T13:29:30.8140735-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -953,20 +973,20 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a1ecdb5c-56da-48b2-8243-973c62b097c5" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="SHUTTLEPC" duration="00:00:00.0019828" startTime="2016-02-21T10:23:01.9931130+01:00" endTime="2016-02-21T10:23:01.9961110+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a1ecdb5c-56da-48b2-8243-973c62b097c5">
+    <UnitTestResult executionId="3e152a18-e71b-4591-af65-c8d61b4d5034" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018610" startTime="2016-02-26T13:29:30.8150739-05:00" endTime="2016-02-26T13:29:30.8180745-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3e152a18-e71b-4591-af65-c8d61b4d5034">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -979,19 +999,19 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d151dea1-acc8-40c3-b073-1fff4cc4b595" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0005484" startTime="2016-02-21T10:23:01.9991115+01:00" endTime="2016-02-21T10:23:02.0021217+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d151dea1-acc8-40c3-b073-1fff4cc4b595">
+    <UnitTestResult executionId="b8bb47fd-5be1-4379-971e-965f5200f874" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003830" startTime="2016-02-26T13:29:30.8190743-05:00" endTime="2016-02-26T13:29:30.8210751-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b8bb47fd-5be1-4379-971e-965f5200f874">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="dc9eb68c-0556-4fbc-b908-e1ca8cad8727" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="SHUTTLEPC" duration="00:00:00.0016120" startTime="2016-02-21T10:23:02.0051119+01:00" endTime="2016-02-21T10:23:02.0091116+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dc9eb68c-0556-4fbc-b908-e1ca8cad8727">
+    <UnitTestResult executionId="137f7569-9430-4d13-a05d-759a234eb464" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017105" startTime="2016-02-26T13:29:30.8210751-05:00" endTime="2016-02-26T13:29:30.8250776-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="137f7569-9430-4d13-a05d-759a234eb464">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -1004,25 +1024,25 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9cd5324c-5f43-4c37-86d7-b598eff32a55" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0002059" startTime="2016-02-21T10:23:02.0121131+01:00" endTime="2016-02-21T10:23:02.0141116+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9cd5324c-5f43-4c37-86d7-b598eff32a55">
+    <UnitTestResult executionId="366a7bc5-dafe-4691-b7ad-f59dad93c972" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002322" startTime="2016-02-26T13:29:30.8260763-05:00" endTime="2016-02-26T13:29:30.8280899-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="366a7bc5-dafe-4691-b7ad-f59dad93c972">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1e97939e-200c-4aeb-a477-e76f75138033" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0005545" startTime="2016-02-21T10:23:02.0171115+01:00" endTime="2016-02-21T10:23:02.0201127+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e97939e-200c-4aeb-a477-e76f75138033">
+    <UnitTestResult executionId="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004135" startTime="2016-02-26T13:29:30.8290837-05:00" endTime="2016-02-26T13:29:30.8310900-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c4cdec79-c180-454e-b012-ffe2ddad06bd" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="SHUTTLEPC" duration="00:00:00.0042151" startTime="2016-02-21T10:23:02.0231109+01:00" endTime="2016-02-21T10:23:02.0301220+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c4cdec79-c180-454e-b012-ffe2ddad06bd">
+    <UnitTestResult executionId="326ff8a3-e758-42f0-8bda-b260030d0a35" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0044088" startTime="2016-02-26T13:29:30.8310900-05:00" endTime="2016-02-26T13:29:30.8380822-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="326ff8a3-e758-42f0-8bda-b260030d0a35">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1091,13 +1111,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1e48153a-89d8-4621-87e1-8dc8f5c66ba1" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="SHUTTLEPC" duration="00:00:00.0038456" startTime="2016-02-21T10:23:02.0331126+01:00" endTime="2016-02-21T10:23:02.0381216+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e48153a-89d8-4621-87e1-8dc8f5c66ba1">
+    <UnitTestResult executionId="c73982e2-d8da-42c1-b2ab-38b896540858" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0034395" startTime="2016-02-26T13:29:30.8390801-05:00" endTime="2016-02-26T13:29:30.8430808-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c73982e2-d8da-42c1-b2ab-38b896540858">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1166,13 +1186,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6e481d01-8204-459e-afc3-03b815ea2586" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="SHUTTLEPC" duration="00:00:00.0038097" startTime="2016-02-21T10:23:02.0421193+01:00" endTime="2016-02-21T10:23:02.0471242+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6e481d01-8204-459e-afc3-03b815ea2586">
+    <UnitTestResult executionId="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0037050" startTime="2016-02-26T13:29:30.8440824-05:00" endTime="2016-02-26T13:29:30.8501004-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0c2e4c98-2351-4ca5-88e3-ed9f953b530e">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1241,27 +1261,27 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="66438ce1-1e4b-4abc-8bf9-ff5183f19268" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="SHUTTLEPC" duration="00:00:00.0001600" startTime="2016-02-21T10:23:02.0506244+01:00" endTime="2016-02-21T10:23:02.0526236+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="66438ce1-1e4b-4abc-8bf9-ff5183f19268">
+    <UnitTestResult executionId="28850158-c04e-4d34-8806-de2a81f3d648" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001454" startTime="2016-02-26T13:29:30.8510829-05:00" endTime="2016-02-26T13:29:30.8520830-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="28850158-c04e-4d34-8806-de2a81f3d648">
     </UnitTestResult>
-    <UnitTestResult executionId="42703328-9515-44c3-89fc-db9b63fd6319" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0011107" startTime="2016-02-21T10:23:02.0551260+01:00" endTime="2016-02-21T10:23:02.0581256+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="42703328-9515-44c3-89fc-db9b63fd6319">
+    <UnitTestResult executionId="964f747a-4194-4233-81b2-dd6be69b215d" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012662" startTime="2016-02-26T13:29:30.8530834-05:00" endTime="2016-02-26T13:29:30.8560846-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="964f747a-4194-4233-81b2-dd6be69b215d">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3152e879-1a8c-44a4-8f4f-f479f4cfd563" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0002437" startTime="2016-02-21T10:23:02.0611315+01:00" endTime="2016-02-21T10:23:02.0641263+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3152e879-1a8c-44a4-8f4f-f479f4cfd563">
+    <UnitTestResult executionId="63aae32d-b2ba-4055-9b70-2c3dd1deb829" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001872" startTime="2016-02-26T13:29:30.8570845-05:00" endTime="2016-02-26T13:29:30.8580857-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="63aae32d-b2ba-4055-9b70-2c3dd1deb829">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c6d971c3-c9fb-4fff-94ce-a49b613e17fd" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="SHUTTLEPC" duration="00:00:00.0014962" startTime="2016-02-21T10:23:02.0671265+01:00" endTime="2016-02-21T10:23:02.0701261+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c6d971c3-c9fb-4fff-94ce-a49b613e17fd">
+    <UnitTestResult executionId="ba414847-62a0-4a75-8b4f-23502381b947" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013200" startTime="2016-02-26T13:29:30.8590856-05:00" endTime="2016-02-26T13:29:30.8620859-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ba414847-62a0-4a75-8b4f-23502381b947">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1274,14 +1294,14 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4fcfa010-31d8-483f-83f1-b25529e45827" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="SHUTTLEPC" duration="00:00:00.0014930" startTime="2016-02-21T10:23:02.0731272+01:00" endTime="2016-02-21T10:23:02.0761310+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4fcfa010-31d8-483f-83f1-b25529e45827">
+    <UnitTestResult executionId="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010405" startTime="2016-02-26T13:29:30.8630860-05:00" endTime="2016-02-26T13:29:30.8650865-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fab2fe36-6c70-4b55-8449-02c93f4a5bf9">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
@@ -1294,14 +1314,14 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="09313672-0f21-437d-958f-714c5d7e20cc" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="SHUTTLEPC" duration="00:00:00.0024969" startTime="2016-02-21T10:23:02.0791305+01:00" endTime="2016-02-21T10:23:02.0841261+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="09313672-0f21-437d-958f-714c5d7e20cc">
+    <UnitTestResult executionId="4faa5750-d1ad-4555-baad-92b8d80b3681" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022225" startTime="2016-02-26T13:29:30.8660867-05:00" endTime="2016-02-26T13:29:30.8690879-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4faa5750-d1ad-4555-baad-92b8d80b3681">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1320,21 +1340,21 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6b312864-8561-417a-8287-1171158305fb" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="SHUTTLEPC" duration="00:00:00.0020418" startTime="2016-02-21T10:23:02.0881296+01:00" endTime="2016-02-21T10:23:02.0911362+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6b312864-8561-417a-8287-1171158305fb">
+    <UnitTestResult executionId="b92646d2-7d31-4e82-913a-09f9f2418fe2" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018991" startTime="2016-02-26T13:29:30.8700877-05:00" endTime="2016-02-26T13:29:30.8731063-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b92646d2-7d31-4e82-913a-09f9f2418fe2">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -1353,45 +1373,51 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e3a0885b-5486-47b9-9109-3a0af6214a96" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="SHUTTLEPC" duration="00:00:00.0006693" startTime="2016-02-21T10:23:02.0951355+01:00" endTime="2016-02-21T10:23:02.0971273+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e3a0885b-5486-47b9-9109-3a0af6214a96">
+    <UnitTestResult executionId="8df7bbbc-3f38-49a3-9594-8864a381a90f" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0006938" startTime="2016-02-26T13:29:30.8740887-05:00" endTime="2016-02-26T13:29:30.8761072-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8df7bbbc-3f38-49a3-9594-8864a381a90f">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a98a6e9c-0a63-4622-b8cf-f5594ed76c8e" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0003124" startTime="2016-02-21T10:23:02.1011269+01:00" endTime="2016-02-21T10:23:02.1021376+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a98a6e9c-0a63-4622-b8cf-f5594ed76c8e">
+    <UnitTestResult executionId="422b76b4-5249-4f76-b4a7-43f83408e83a" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0006417" startTime="2016-02-26T13:29:30.8770899-05:00" endTime="2016-02-26T13:29:30.8790907-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="422b76b4-5249-4f76-b4a7-43f83408e83a">
+      <Output>
+        <StdOut>When I have parenthesis in the value, for example a 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003045" startTime="2016-02-26T13:29:30.8800909-05:00" endTime="2016-02-26T13:29:30.8810913-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a60c8773-24a0-4ce2-a1a8-4dd6beab917b">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="12d05f27-72f9-4ffd-8fc7-87840292d758" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0001921" startTime="2016-02-21T10:23:02.1051301+01:00" endTime="2016-02-21T10:23:02.1071399+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12d05f27-72f9-4ffd-8fc7-87840292d758">
+    <UnitTestResult executionId="9903f019-a8b0-40aa-939a-45c4eb24ff04" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001425" startTime="2016-02-26T13:29:30.8820905-05:00" endTime="2016-02-26T13:29:30.8830912-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9903f019-a8b0-40aa-939a-45c4eb24ff04">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="df91b9f3-2f10-4e7c-9586-317b29ad83ac" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="SHUTTLEPC" duration="00:00:00.0002200" startTime="2016-02-21T10:23:02.1101266+01:00" endTime="2016-02-21T10:23:02.1111376+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="df91b9f3-2f10-4e7c-9586-317b29ad83ac">
+    <UnitTestResult executionId="33cb498b-9452-47f2-8d84-bb85de1f7e99" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001394" startTime="2016-02-26T13:29:30.8840919-05:00" endTime="2016-02-26T13:29:30.8850920-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="33cb498b-9452-47f2-8d84-bb85de1f7e99">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="7144616d-90e6-4927-9144-1e9c7a1d9309" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="SHUTTLEPC" duration="00:00:00.0023481" startTime="2016-02-21T10:23:02.1161280+01:00" endTime="2016-02-21T10:23:02.1201363+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7144616d-90e6-4927-9144-1e9c7a1d9309">
+    <UnitTestResult executionId="f3b7392c-434a-48ce-a8ea-0d7e120f7972" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0023833" startTime="2016-02-26T13:29:30.8860918-05:00" endTime="2016-02-26T13:29:30.8900940-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f3b7392c-434a-48ce-a8ea-0d7e120f7972">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1410,33 +1436,33 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="df23bc08-8e65-4b4a-84fb-e54e1f06f0b3" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0002084" startTime="2016-02-21T10:23:02.1231301+01:00" endTime="2016-02-21T10:23:02.1251299+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="df23bc08-8e65-4b4a-84fb-e54e1f06f0b3">
+    <UnitTestResult executionId="e3db021c-01e8-4047-b513-301c4b925298" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001869" startTime="2016-02-26T13:29:30.8910933-05:00" endTime="2016-02-26T13:29:30.8921068-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e3db021c-01e8-4047-b513-301c4b925298">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ecb3cf16-fe6c-4b43-99cd-bc17c1eb01e8" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0001709" startTime="2016-02-21T10:23:02.1281259+01:00" endTime="2016-02-21T10:23:02.1291282+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ecb3cf16-fe6c-4b43-99cd-bc17c1eb01e8">
+    <UnitTestResult executionId="ab22f5f6-0dae-4a24-838d-e039559bd18c" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001542" startTime="2016-02-26T13:29:30.8930935-05:00" endTime="2016-02-26T13:29:30.8940948-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ab22f5f6-0dae-4a24-838d-e039559bd18c">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f84ef13d-013a-44ac-a10c-0e852eb62117" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="SHUTTLEPC" duration="00:00:00.0014795" startTime="2016-02-21T10:23:02.1331301+01:00" endTime="2016-02-21T10:23:02.1361393+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f84ef13d-013a-44ac-a10c-0e852eb62117">
+    <UnitTestResult executionId="1911f0a9-5caf-4856-aa23-77ecb5517b46" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0014552" startTime="2016-02-26T13:29:30.8950994-05:00" endTime="2016-02-26T13:29:30.8980952-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1911f0a9-5caf-4856-aa23-77ecb5517b46">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1449,23 +1475,23 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="76bf7a0f-5af1-4ff1-b13d-585d697a376e" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0002033" startTime="2016-02-21T10:23:02.1401274+01:00" endTime="2016-02-21T10:23:02.1421378+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="76bf7a0f-5af1-4ff1-b13d-585d697a376e">
+    <UnitTestResult executionId="d785ea5e-732c-404b-936b-e982d7bf6cf9" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002083" startTime="2016-02-26T13:29:30.8990954-05:00" endTime="2016-02-26T13:29:30.9010964-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d785ea5e-732c-404b-936b-e982d7bf6cf9">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="62d2e4e8-6b19-48ff-9eed-c913e1aaee2c" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0002177" startTime="2016-02-21T10:23:02.1451463+01:00" endTime="2016-02-21T10:23:02.1466448+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="62d2e4e8-6b19-48ff-9eed-c913e1aaee2c">
+    <UnitTestResult executionId="c42f16f0-9583-454a-9832-b7e7837dd78b" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001733" startTime="2016-02-26T13:29:30.9010964-05:00" endTime="2016-02-26T13:29:30.9030967-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c42f16f0-9583-454a-9832-b7e7837dd78b">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="cd498d6a-190a-4482-bb7f-72542dae224c" name="ocsur@DESKTOP-AIFNJPI 2016-02-26 13:29:30" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<TestRun id="8b057389-ab82-44cd-869d-cd4fea1405c3" name="ocsur@DESKTOP-AIFNJPI 2016-02-29 13:31:17" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestSettings name="TestSettings" id="3d90c4f8-ccdc-4663-bad3-9f4c55f42318">
     <Description>These are default test settings for a local test run.</Description>
-    <Deployment userDeploymentRoot="C:\src\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-26 13_29_30" />
+    <Deployment userDeploymentRoot="C:\src\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-29 13_31_17" />
     <Execution>
       <TestTypeSpecific />
       <AgentRule name="Execution Agents">
@@ -10,14 +10,14 @@
     </Execution>
     <Properties />
   </TestSettings>
-  <Times creation="2016-02-26T13:29:30.0878846-05:00" queuing="2016-02-26T13:29:30.3899641-05:00" start="2016-02-26T13:29:30.4720024-05:00" finish="2016-02-26T13:29:30.9409642-05:00" />
+  <Times creation="2016-02-29T13:31:17.8508854-05:00" queuing="2016-02-29T13:31:18.1769705-05:00" start="2016-02-29T13:31:18.2649927-05:00" finish="2016-02-29T13:31:18.8281545-05:00" />
   <ResultSummary outcome="Failed">
     <Counters total="35" executed="35" passed="18" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
   <TestDefinitions>
     <UnitTest name="NotAutomatedScenario1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
       <Description>Not automated scenario 1</Description>
-      <Execution id="326ff8a3-e758-42f0-8bda-b260030d0a35" />
+      <Execution id="84b87db1-b1a6-4bd5-8628-48cdde807b27" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -31,7 +31,7 @@
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="7fe31cbe-4c84-4da6-b418-eead0e6a7992" />
+      <Execution id="827b4f24-27de-43dd-9afa-a2659ded2a1c" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -62,7 +62,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="b92646d2-7d31-4e82-913a-09f9f2418fe2" />
+      <Execution id="3d59785c-3405-4625-9544-f7ba5f664fe1" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -81,7 +81,7 @@
     </UnitTest>
     <UnitTest name="NotAutomatedScenario3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
       <Description>Not automated scenario 3</Description>
-      <Execution id="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" />
+      <Execution id="570e9634-242d-41bf-88bf-ea10800527e1" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -92,7 +92,7 @@
     </UnitTest>
     <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
       <Description>Add two numbers</Description>
-      <Execution id="40d77687-6bcf-4add-8ec0-76b641aa90a9" />
+      <Execution id="41b67f13-9fce-438b-a8dc-dbd6388e8934" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -103,7 +103,7 @@
     </UnitTest>
     <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
       <Description>Failing Feature Inconclusive Scenario</Description>
-      <Execution id="3e152a18-e71b-4591-af65-c8d61b4d5034" />
+      <Execution id="0a75715a-b55a-472c-9ab4-719e75bfc680" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -114,7 +114,7 @@
     </UnitTest>
     <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
       <Description>Inconclusive Feature Inconclusive Scenario</Description>
-      <Execution id="137f7569-9430-4d13-a05d-759a234eb464" />
+      <Execution id="c14a24e4-f357-4e54-bff6-72b4c302dc21" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -125,7 +125,7 @@
     </UnitTest>
     <UnitTest name="FailingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
       <Description>Failing Feature Passing Scenario</Description>
-      <Execution id="b8bb47fd-5be1-4379-971e-965f5200f874" />
+      <Execution id="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -136,7 +136,7 @@
     </UnitTest>
     <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
       <Description>Deal correctly with backslashes in the examples</Description>
-      <Execution id="8df7bbbc-3f38-49a3-9594-8864a381a90f" />
+      <Execution id="2f709cc6-9269-4107-934f-343e4a914966" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -155,7 +155,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="ab22f5f6-0dae-4a24-838d-e039559bd18c" />
+      <Execution id="3727f45e-675e-4c11-93b8-17c0d3a607d8" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -174,7 +174,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="4faa5750-d1ad-4555-baad-92b8d80b3681" />
+      <Execution id="027e534e-d111-4fb7-88d5-2fa8e793fe3d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -196,7 +196,7 @@
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="d8a81083-b6a6-48a5-8806-e839e57ff9f2" />
+      <Execution id="d933299c-beea-4829-a906-a6de2623b895" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -227,7 +227,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="63aae32d-b2ba-4055-9b70-2c3dd1deb829" />
+      <Execution id="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -246,7 +246,7 @@
     </UnitTest>
     <UnitTest name="FailingFeatureFailingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
       <Description>Failing Feature Failing Scenario</Description>
-      <Execution id="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" />
+      <Execution id="3a186856-41de-4034-b4a8-feade31a112f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -257,7 +257,7 @@
     </UnitTest>
     <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
       <Description>Deal correctly with parenthesis in the examples</Description>
-      <Execution id="422b76b4-5249-4f76-b4a7-43f83408e83a" />
+      <Execution id="0cdaf90e-7083-4a5c-b98e-f68272057f57" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -276,7 +276,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="d785ea5e-732c-404b-936b-e982d7bf6cf9" />
+      <Execution id="1d5f63e8-3036-4422-92d6-d60ba1ae151b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -295,7 +295,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="9903f019-a8b0-40aa-939a-45c4eb24ff04" />
+      <Execution id="17553853-0683-4145-9d61-74031017021a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -314,7 +314,7 @@
     </UnitTest>
     <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
       <Description>Inconclusive Feature Passing Scenario</Description>
-      <Execution id="366a7bc5-dafe-4691-b7ad-f59dad93c972" />
+      <Execution id="beda5beb-f73a-4471-94ee-56da009212bb" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -325,7 +325,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="1911f0a9-5caf-4856-aa23-77ecb5517b46" />
+      <Execution id="05f537a2-462a-4a54-8a89-c50ee92ee819" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -343,7 +343,7 @@
       <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
     <UnitTest name="TestMethod" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
-      <Execution id="28850158-c04e-4d34-8806-de2a81f3d648" />
+      <Execution id="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -357,7 +357,7 @@
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="a87f23d2-a120-4c61-8c6c-bb71f59b7259" />
+      <Execution id="2c348320-9cb3-4902-a6f0-e8ce76519fa9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -368,7 +368,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="c42f16f0-9583-454a-9832-b7e7837dd78b" />
+      <Execution id="31eb3903-2072-4aa5-beb1-aa68da5cef6c" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -387,7 +387,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="f3b7392c-434a-48ce-a8ea-0d7e120f7972" />
+      <Execution id="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -406,7 +406,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" />
+      <Execution id="e7670bb6-9523-4594-9760-d1d941205633" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -425,7 +425,7 @@
     </UnitTest>
     <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
       <Description>Adding several numbers</Description>
-      <Execution id="9d358154-21b9-4559-b9ac-66637ee84fdc" />
+      <Execution id="65cce851-fe31-4e22-b9db-b45daa8902f4" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -456,7 +456,7 @@
     </UnitTest>
     <UnitTest name="NotAutomatedScenario2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
       <Description>Not automated scenario 2</Description>
-      <Execution id="c73982e2-d8da-42c1-b2ab-38b896540858" />
+      <Execution id="40db28a5-6f62-4207-9029-39db08667250" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -467,7 +467,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" />
+      <Execution id="5bc6395d-9425-4db6-be59-68cb956cddb3" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -486,7 +486,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="964f747a-4194-4233-81b2-dd6be69b215d" />
+      <Execution id="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -505,7 +505,7 @@
     </UnitTest>
     <UnitTest name="PassingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
       <Description>Passing Feature Passing Scenario</Description>
-      <Execution id="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" />
+      <Execution id="ee52d898-3893-4b11-aca2-690c962c9094" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -516,7 +516,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="33cb498b-9452-47f2-8d84-bb85de1f7e99" />
+      <Execution id="ee5409c4-d89a-4640-b17f-b8a1676aae7f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -535,7 +535,7 @@
     </UnitTest>
     <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="e3db021c-01e8-4047-b513-301c4b925298" />
+      <Execution id="4b0b1635-cf18-425b-bb46-0b3d893671fa" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -554,7 +554,7 @@
     </UnitTest>
     <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
       <Description>Adding several numbers</Description>
-      <Execution id="be3afc74-441a-43b2-9c71-edd28d8a4152" />
+      <Execution id="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -588,7 +588,7 @@
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="d8dea341-c2d5-40c2-9477-37430de901f9" />
+      <Execution id="49085209-3670-430a-b4e1-697177b97fae" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -599,7 +599,7 @@
     </UnitTest>
     <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
       <Description>Not automated adding two numbers</Description>
-      <Execution id="82c5079b-949d-411c-8f3f-c8a9b404e78f" />
+      <Execution id="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -610,7 +610,7 @@
     </UnitTest>
     <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="ba414847-62a0-4a75-8b4f-23502381b947" />
+      <Execution id="478620d9-8754-4ed6-a149-e6a5a812a4b5" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -633,44 +633,44 @@
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <TestEntries>
-    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="7fe31cbe-4c84-4da6-b418-eead0e6a7992" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="d8a81083-b6a6-48a5-8806-e839e57ff9f2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="a87f23d2-a120-4c61-8c6c-bb71f59b7259" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="d8dea341-c2d5-40c2-9477-37430de901f9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="82c5079b-949d-411c-8f3f-c8a9b404e78f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="be3afc74-441a-43b2-9c71-edd28d8a4152" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="9d358154-21b9-4559-b9ac-66637ee84fdc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="40d77687-6bcf-4add-8ec0-76b641aa90a9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="3e152a18-e71b-4591-af65-c8d61b4d5034" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="b8bb47fd-5be1-4379-971e-965f5200f874" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="137f7569-9430-4d13-a05d-759a234eb464" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="366a7bc5-dafe-4691-b7ad-f59dad93c972" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="326ff8a3-e758-42f0-8bda-b260030d0a35" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="c73982e2-d8da-42c1-b2ab-38b896540858" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="28850158-c04e-4d34-8806-de2a81f3d648" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="964f747a-4194-4233-81b2-dd6be69b215d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="63aae32d-b2ba-4055-9b70-2c3dd1deb829" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="ba414847-62a0-4a75-8b4f-23502381b947" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="4faa5750-d1ad-4555-baad-92b8d80b3681" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="b92646d2-7d31-4e82-913a-09f9f2418fe2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="8df7bbbc-3f38-49a3-9594-8864a381a90f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="422b76b4-5249-4f76-b4a7-43f83408e83a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="9903f019-a8b0-40aa-939a-45c4eb24ff04" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="33cb498b-9452-47f2-8d84-bb85de1f7e99" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="f3b7392c-434a-48ce-a8ea-0d7e120f7972" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="e3db021c-01e8-4047-b513-301c4b925298" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="ab22f5f6-0dae-4a24-838d-e039559bd18c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="1911f0a9-5caf-4856-aa23-77ecb5517b46" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="d785ea5e-732c-404b-936b-e982d7bf6cf9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="c42f16f0-9583-454a-9832-b7e7837dd78b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="827b4f24-27de-43dd-9afa-a2659ded2a1c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="d933299c-beea-4829-a906-a6de2623b895" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="2c348320-9cb3-4902-a6f0-e8ce76519fa9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="49085209-3670-430a-b4e1-697177b97fae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="65cce851-fe31-4e22-b9db-b45daa8902f4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="41b67f13-9fce-438b-a8dc-dbd6388e8934" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="3a186856-41de-4034-b4a8-feade31a112f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="0a75715a-b55a-472c-9ab4-719e75bfc680" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="c14a24e4-f357-4e54-bff6-72b4c302dc21" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="beda5beb-f73a-4471-94ee-56da009212bb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="ee52d898-3893-4b11-aca2-690c962c9094" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="84b87db1-b1a6-4bd5-8628-48cdde807b27" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="40db28a5-6f62-4207-9029-39db08667250" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="570e9634-242d-41bf-88bf-ea10800527e1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="478620d9-8754-4ed6-a149-e6a5a812a4b5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="e7670bb6-9523-4594-9760-d1d941205633" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="027e534e-d111-4fb7-88d5-2fa8e793fe3d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="3d59785c-3405-4625-9544-f7ba5f664fe1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="2f709cc6-9269-4107-934f-343e4a914966" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="0cdaf90e-7083-4a5c-b98e-f68272057f57" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="5bc6395d-9425-4db6-be59-68cb956cddb3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="17553853-0683-4145-9d61-74031017021a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="ee5409c4-d89a-4640-b17f-b8a1676aae7f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="4b0b1635-cf18-425b-bb46-0b3d893671fa" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="3727f45e-675e-4c11-93b8-17c0d3a607d8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="05f537a2-462a-4a54-8a89-c50ee92ee819" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="1d5f63e8-3036-4422-92d6-d60ba1ae151b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="31eb3903-2072-4aa5-beb1-aa68da5cef6c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <Results>
-    <UnitTestResult executionId="7fe31cbe-4c84-4da6-b418-eead0e6a7992" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0441409" startTime="2016-02-26T13:29:30.4930029-05:00" endTime="2016-02-26T13:29:30.7320536-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7fe31cbe-4c84-4da6-b418-eead0e6a7992">
+    <UnitTestResult executionId="827b4f24-27de-43dd-9afa-a2659ded2a1c" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0781946" startTime="2016-02-29T13:31:18.2870112-05:00" endTime="2016-02-29T13:31:18.5750765-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="827b4f24-27de-43dd-9afa-a2659ded2a1c">
       <Output>
         <StdOut>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
@@ -686,7 +686,7 @@ Then the result should be 180 on the screen
 -&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d8a81083-b6a6-48a5-8806-e839e57ff9f2" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002772" startTime="2016-02-26T13:29:30.7330532-05:00" endTime="2016-02-26T13:29:30.7350528-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8a81083-b6a6-48a5-8806-e839e57ff9f2">
+    <UnitTestResult executionId="d933299c-beea-4829-a906-a6de2623b895" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005919" startTime="2016-02-29T13:31:18.5770861-05:00" endTime="2016-02-29T13:31:18.5800748-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d933299c-beea-4829-a906-a6de2623b895">
       <Output>
         <StdOut>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
@@ -702,7 +702,7 @@ Then the result should be 260 on the screen
 -&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a87f23d2-a120-4c61-8c6c-bb71f59b7259" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002584" startTime="2016-02-26T13:29:30.7350528-05:00" endTime="2016-02-26T13:29:30.7370548-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a87f23d2-a120-4c61-8c6c-bb71f59b7259">
+    <UnitTestResult executionId="2c348320-9cb3-4902-a6f0-e8ce76519fa9" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005692" startTime="2016-02-29T13:31:18.5810749-05:00" endTime="2016-02-29T13:31:18.5850936-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2c348320-9cb3-4902-a6f0-e8ce76519fa9">
       <Output>
         <StdOut>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
@@ -716,7 +716,7 @@ Then the result should be 3 on the screen
 -&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d8dea341-c2d5-40c2-9477-37430de901f9" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0193596" startTime="2016-02-26T13:29:30.7370548-05:00" endTime="2016-02-26T13:29:30.7580589-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8dea341-c2d5-40c2-9477-37430de901f9">
+    <UnitTestResult executionId="49085209-3670-430a-b4e1-697177b97fae" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0347966" startTime="2016-02-29T13:31:18.5860937-05:00" endTime="2016-02-29T13:31:18.6240959-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="49085209-3670-430a-b4e1-697177b97fae">
       <Output>
         <StdOut>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
@@ -753,7 +753,7 @@ System.FormatException: Input string was not in a correct format.</Message>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="82c5079b-949d-411c-8f3f-c8a9b404e78f" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0248589" startTime="2016-02-26T13:29:30.7590588-05:00" endTime="2016-02-26T13:29:30.7850780-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="82c5079b-949d-411c-8f3f-c8a9b404e78f">
+    <UnitTestResult executionId="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0307554" startTime="2016-02-29T13:31:18.6250860-05:00" endTime="2016-02-29T13:31:18.6570943-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b4b846b0-aafb-4e0b-b82c-b81e74885ed4">
       <Output>
         <StdOut>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
@@ -822,7 +822,7 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="be3afc74-441a-43b2-9c71-edd28d8a4152" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0100615" startTime="2016-02-26T13:29:30.7860762-05:00" endTime="2016-02-26T13:29:30.7990819-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="be3afc74-441a-43b2-9c71-edd28d8a4152">
+    <UnitTestResult executionId="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0098841" startTime="2016-02-29T13:31:18.6580947-05:00" endTime="2016-02-29T13:31:18.6710980-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -867,7 +867,7 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9d358154-21b9-4559-b9ac-66637ee84fdc" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017887" startTime="2016-02-26T13:29:30.8000695-05:00" endTime="2016-02-26T13:29:30.8030830-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9d358154-21b9-4559-b9ac-66637ee84fdc">
+    <UnitTestResult executionId="65cce851-fe31-4e22-b9db-b45daa8902f4" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0019666" startTime="2016-02-29T13:31:18.6721163-05:00" endTime="2016-02-29T13:31:18.6751172-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65cce851-fe31-4e22-b9db-b45daa8902f4">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -912,7 +912,7 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="40d77687-6bcf-4add-8ec0-76b641aa90a9" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0019982" startTime="2016-02-26T13:29:30.8040711-05:00" endTime="2016-02-26T13:29:30.8070715-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="40d77687-6bcf-4add-8ec0-76b641aa90a9">
+    <UnitTestResult executionId="41b67f13-9fce-438b-a8dc-dbd6388e8934" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022040" startTime="2016-02-29T13:31:18.6760994-05:00" endTime="2016-02-29T13:31:18.6791009-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="41b67f13-9fce-438b-a8dc-dbd6388e8934">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -954,7 +954,7 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0045910" startTime="2016-02-26T13:29:30.8080716-05:00" endTime="2016-02-26T13:29:30.8140735-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f84edad0-56cf-4d3c-a04e-b99b9de5a8bd">
+    <UnitTestResult executionId="3a186856-41de-4034-b4a8-feade31a112f" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0042406" startTime="2016-02-29T13:31:18.6801002-05:00" endTime="2016-02-29T13:31:18.6871027-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3a186856-41de-4034-b4a8-feade31a112f">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -986,7 +986,7 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3e152a18-e71b-4591-af65-c8d61b4d5034" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018610" startTime="2016-02-26T13:29:30.8150739-05:00" endTime="2016-02-26T13:29:30.8180745-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3e152a18-e71b-4591-af65-c8d61b4d5034">
+    <UnitTestResult executionId="0a75715a-b55a-472c-9ab4-719e75bfc680" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021846" startTime="2016-02-29T13:31:18.6881091-05:00" endTime="2016-02-29T13:31:18.6921056-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0a75715a-b55a-472c-9ab4-719e75bfc680">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -1005,13 +1005,13 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b8bb47fd-5be1-4379-971e-965f5200f874" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003830" startTime="2016-02-26T13:29:30.8190743-05:00" endTime="2016-02-26T13:29:30.8210751-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b8bb47fd-5be1-4379-971e-965f5200f874">
+    <UnitTestResult executionId="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004721" startTime="2016-02-29T13:31:18.6931222-05:00" endTime="2016-02-29T13:31:18.6951164-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8">
       <Output>
         <StdOut>Then passing step
 -&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="137f7569-9430-4d13-a05d-759a234eb464" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017105" startTime="2016-02-26T13:29:30.8210751-05:00" endTime="2016-02-26T13:29:30.8250776-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="137f7569-9430-4d13-a05d-759a234eb464">
+    <UnitTestResult executionId="c14a24e4-f357-4e54-bff6-72b4c302dc21" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017543" startTime="2016-02-29T13:31:18.6951164-05:00" endTime="2016-02-29T13:31:18.6991061-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c14a24e4-f357-4e54-bff6-72b4c302dc21">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -1030,19 +1030,19 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="366a7bc5-dafe-4691-b7ad-f59dad93c972" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002322" startTime="2016-02-26T13:29:30.8260763-05:00" endTime="2016-02-26T13:29:30.8280899-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="366a7bc5-dafe-4691-b7ad-f59dad93c972">
+    <UnitTestResult executionId="beda5beb-f73a-4471-94ee-56da009212bb" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003426" startTime="2016-02-29T13:31:18.7001062-05:00" endTime="2016-02-29T13:31:18.7021079-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="beda5beb-f73a-4471-94ee-56da009212bb">
       <Output>
         <StdOut>Then passing step
 -&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004135" startTime="2016-02-26T13:29:30.8290837-05:00" endTime="2016-02-26T13:29:30.8310900-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dc1f5e48-3af5-4d22-a8e3-16a17bcdd278">
+    <UnitTestResult executionId="ee52d898-3893-4b11-aca2-690c962c9094" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004291" startTime="2016-02-29T13:31:18.7031114-05:00" endTime="2016-02-29T13:31:18.7051196-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ee52d898-3893-4b11-aca2-690c962c9094">
       <Output>
         <StdOut>Then passing step
 -&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="326ff8a3-e758-42f0-8bda-b260030d0a35" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0044088" startTime="2016-02-26T13:29:30.8310900-05:00" endTime="2016-02-26T13:29:30.8380822-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="326ff8a3-e758-42f0-8bda-b260030d0a35">
+    <UnitTestResult executionId="84b87db1-b1a6-4bd5-8628-48cdde807b27" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0044848" startTime="2016-02-29T13:31:18.7061251-05:00" endTime="2016-02-29T13:31:18.7131094-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="84b87db1-b1a6-4bd5-8628-48cdde807b27">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1117,7 +1117,7 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c73982e2-d8da-42c1-b2ab-38b896540858" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0034395" startTime="2016-02-26T13:29:30.8390801-05:00" endTime="2016-02-26T13:29:30.8430808-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c73982e2-d8da-42c1-b2ab-38b896540858">
+    <UnitTestResult executionId="40db28a5-6f62-4207-9029-39db08667250" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0036003" startTime="2016-02-29T13:31:18.7131094-05:00" endTime="2016-02-29T13:31:18.7181231-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="40db28a5-6f62-4207-9029-39db08667250">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1192,7 +1192,7 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0c2e4c98-2351-4ca5-88e3-ed9f953b530e" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0037050" startTime="2016-02-26T13:29:30.8440824-05:00" endTime="2016-02-26T13:29:30.8501004-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0c2e4c98-2351-4ca5-88e3-ed9f953b530e">
+    <UnitTestResult executionId="570e9634-242d-41bf-88bf-ea10800527e1" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0038319" startTime="2016-02-29T13:31:18.7191104-05:00" endTime="2016-02-29T13:31:18.7251120-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="570e9634-242d-41bf-88bf-ea10800527e1">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1267,21 +1267,21 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="28850158-c04e-4d34-8806-de2a81f3d648" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001454" startTime="2016-02-26T13:29:30.8510829-05:00" endTime="2016-02-26T13:29:30.8520830-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="28850158-c04e-4d34-8806-de2a81f3d648">
+    <UnitTestResult executionId="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001519" startTime="2016-02-29T13:31:18.7261124-05:00" endTime="2016-02-29T13:31:18.7271253-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6385cf85-f1b1-4e89-b2d7-ed3de7d43023">
     </UnitTestResult>
-    <UnitTestResult executionId="964f747a-4194-4233-81b2-dd6be69b215d" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012662" startTime="2016-02-26T13:29:30.8530834-05:00" endTime="2016-02-26T13:29:30.8560846-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="964f747a-4194-4233-81b2-dd6be69b215d">
+    <UnitTestResult executionId="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013681" startTime="2016-02-29T13:31:18.7281140-05:00" endTime="2016-02-29T13:31:18.7321136-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12b14fd2-ed0a-46c2-a19a-f9a4257d58af">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="63aae32d-b2ba-4055-9b70-2c3dd1deb829" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001872" startTime="2016-02-26T13:29:30.8570845-05:00" endTime="2016-02-26T13:29:30.8580857-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="63aae32d-b2ba-4055-9b70-2c3dd1deb829">
+    <UnitTestResult executionId="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002254" startTime="2016-02-29T13:31:18.7331143-05:00" endTime="2016-02-29T13:31:18.7351274-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ba414847-62a0-4a75-8b4f-23502381b947" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013200" startTime="2016-02-26T13:29:30.8590856-05:00" endTime="2016-02-26T13:29:30.8620859-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ba414847-62a0-4a75-8b4f-23502381b947">
+    <UnitTestResult executionId="478620d9-8754-4ed6-a149-e6a5a812a4b5" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0016441" startTime="2016-02-29T13:31:18.7361161-05:00" endTime="2016-02-29T13:31:18.7391167-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="478620d9-8754-4ed6-a149-e6a5a812a4b5">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1301,7 +1301,7 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fab2fe36-6c70-4b55-8449-02c93f4a5bf9" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010405" startTime="2016-02-26T13:29:30.8630860-05:00" endTime="2016-02-26T13:29:30.8650865-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fab2fe36-6c70-4b55-8449-02c93f4a5bf9">
+    <UnitTestResult executionId="e7670bb6-9523-4594-9760-d1d941205633" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018957" startTime="2016-02-29T13:31:18.7401169-05:00" endTime="2016-02-29T13:31:18.7441188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e7670bb6-9523-4594-9760-d1d941205633">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
@@ -1321,7 +1321,7 @@ namespace MyNamespace
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4faa5750-d1ad-4555-baad-92b8d80b3681" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022225" startTime="2016-02-26T13:29:30.8660867-05:00" endTime="2016-02-26T13:29:30.8690879-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4faa5750-d1ad-4555-baad-92b8d80b3681">
+    <UnitTestResult executionId="027e534e-d111-4fb7-88d5-2fa8e793fe3d" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018872" startTime="2016-02-29T13:31:18.7451180-05:00" endTime="2016-02-29T13:31:18.7481181-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="027e534e-d111-4fb7-88d5-2fa8e793fe3d">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1354,7 +1354,7 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b92646d2-7d31-4e82-913a-09f9f2418fe2" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018991" startTime="2016-02-26T13:29:30.8700877-05:00" endTime="2016-02-26T13:29:30.8731063-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b92646d2-7d31-4e82-913a-09f9f2418fe2">
+    <UnitTestResult executionId="3d59785c-3405-4625-9544-f7ba5f664fe1" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021872" startTime="2016-02-29T13:31:18.7491364-05:00" endTime="2016-02-29T13:31:18.7521188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3d59785c-3405-4625-9544-f7ba5f664fe1">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -1387,37 +1387,37 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="8df7bbbc-3f38-49a3-9594-8864a381a90f" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0006938" startTime="2016-02-26T13:29:30.8740887-05:00" endTime="2016-02-26T13:29:30.8761072-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8df7bbbc-3f38-49a3-9594-8864a381a90f">
+    <UnitTestResult executionId="2f709cc6-9269-4107-934f-343e4a914966" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005381" startTime="2016-02-29T13:31:18.7531198-05:00" endTime="2016-02-29T13:31:18.7551215-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2f709cc6-9269-4107-934f-343e4a914966">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
 -&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="422b76b4-5249-4f76-b4a7-43f83408e83a" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0006417" startTime="2016-02-26T13:29:30.8770899-05:00" endTime="2016-02-26T13:29:30.8790907-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="422b76b4-5249-4f76-b4a7-43f83408e83a">
+    <UnitTestResult executionId="0cdaf90e-7083-4a5c-b98e-f68272057f57" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005501" startTime="2016-02-29T13:31:18.7561207-05:00" endTime="2016-02-29T13:31:18.7581332-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0cdaf90e-7083-4a5c-b98e-f68272057f57">
       <Output>
-        <StdOut>When I have parenthesis in the value, for example a 'This is a description (and more)'
+        <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
 -&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a60c8773-24a0-4ce2-a1a8-4dd6beab917b" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003045" startTime="2016-02-26T13:29:30.8800909-05:00" endTime="2016-02-26T13:29:30.8810913-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a60c8773-24a0-4ce2-a1a8-4dd6beab917b">
+    <UnitTestResult executionId="5bc6395d-9425-4db6-be59-68cb956cddb3" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003187" startTime="2016-02-29T13:31:18.7591208-05:00" endTime="2016-02-29T13:31:18.7611213-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5bc6395d-9425-4db6-be59-68cb956cddb3">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9903f019-a8b0-40aa-939a-45c4eb24ff04" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001425" startTime="2016-02-26T13:29:30.8820905-05:00" endTime="2016-02-26T13:29:30.8830912-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9903f019-a8b0-40aa-939a-45c4eb24ff04">
+    <UnitTestResult executionId="17553853-0683-4145-9d61-74031017021a" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002496" startTime="2016-02-29T13:31:18.7621226-05:00" endTime="2016-02-29T13:31:18.7631227-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="17553853-0683-4145-9d61-74031017021a">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="33cb498b-9452-47f2-8d84-bb85de1f7e99" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001394" startTime="2016-02-26T13:29:30.8840919-05:00" endTime="2016-02-26T13:29:30.8850920-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="33cb498b-9452-47f2-8d84-bb85de1f7e99">
+    <UnitTestResult executionId="ee5409c4-d89a-4640-b17f-b8a1676aae7f" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001992" startTime="2016-02-29T13:31:18.7641219-05:00" endTime="2016-02-29T13:31:18.7661233-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ee5409c4-d89a-4640-b17f-b8a1676aae7f">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f3b7392c-434a-48ce-a8ea-0d7e120f7972" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0023833" startTime="2016-02-26T13:29:30.8860918-05:00" endTime="2016-02-26T13:29:30.8900940-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f3b7392c-434a-48ce-a8ea-0d7e120f7972">
+    <UnitTestResult executionId="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0020560" startTime="2016-02-29T13:31:18.7661233-05:00" endTime="2016-02-29T13:31:18.7701241-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5c0a8fb0-126d-490e-b036-2d0a26f9c66d">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1450,19 +1450,19 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e3db021c-01e8-4047-b513-301c4b925298" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001869" startTime="2016-02-26T13:29:30.8910933-05:00" endTime="2016-02-26T13:29:30.8921068-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e3db021c-01e8-4047-b513-301c4b925298">
+    <UnitTestResult executionId="4b0b1635-cf18-425b-bb46-0b3d893671fa" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003227" startTime="2016-02-29T13:31:18.7711253-05:00" endTime="2016-02-29T13:31:18.7721252-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4b0b1635-cf18-425b-bb46-0b3d893671fa">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ab22f5f6-0dae-4a24-838d-e039559bd18c" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001542" startTime="2016-02-26T13:29:30.8930935-05:00" endTime="2016-02-26T13:29:30.8940948-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ab22f5f6-0dae-4a24-838d-e039559bd18c">
+    <UnitTestResult executionId="3727f45e-675e-4c11-93b8-17c0d3a607d8" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002211" startTime="2016-02-29T13:31:18.7731253-05:00" endTime="2016-02-29T13:31:18.7751266-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3727f45e-675e-4c11-93b8-17c0d3a607d8">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1911f0a9-5caf-4856-aa23-77ecb5517b46" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0014552" startTime="2016-02-26T13:29:30.8950994-05:00" endTime="2016-02-26T13:29:30.8980952-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1911f0a9-5caf-4856-aa23-77ecb5517b46">
+    <UnitTestResult executionId="05f537a2-462a-4a54-8a89-c50ee92ee819" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012329" startTime="2016-02-29T13:31:18.7761268-05:00" endTime="2016-02-29T13:31:18.7781381-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05f537a2-462a-4a54-8a89-c50ee92ee819">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1482,13 +1482,13 @@ Shouldly.ChuckedAWobbly:
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d785ea5e-732c-404b-936b-e982d7bf6cf9" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002083" startTime="2016-02-26T13:29:30.8990954-05:00" endTime="2016-02-26T13:29:30.9010964-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d785ea5e-732c-404b-936b-e982d7bf6cf9">
+    <UnitTestResult executionId="1d5f63e8-3036-4422-92d6-d60ba1ae151b" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001761" startTime="2016-02-29T13:31:18.7791260-05:00" endTime="2016-02-29T13:31:18.7801389-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1d5f63e8-3036-4422-92d6-d60ba1ae151b">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c42f16f0-9583-454a-9832-b7e7837dd78b" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001733" startTime="2016-02-26T13:29:30.9010964-05:00" endTime="2016-02-26T13:29:30.9030967-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c42f16f0-9583-454a-9832-b7e7837dd78b">
+    <UnitTestResult executionId="31eb3903-2072-4aa5-beb1-aa68da5cef6c" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002074" startTime="2016-02-29T13:31:18.7811276-05:00" endTime="2016-02-29T13:31:18.7831282-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31eb3903-2072-4aa5-beb1-aa68da5cef6c">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
@@ -107,6 +107,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit2
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="34" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-02-26" time="13:29:14">
+<test-results name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="34" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-02-29" time="13:31:00">
   <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8669" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" />
   <culture-info current-culture="en-US" current-uiculture="en-US" />
-  <test-suite type="Assembly" name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.666" asserts="0">
+  <test-suite type="Assembly" name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.746" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.659" asserts="0">
+      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.739" asserts="0">
         <results>
-          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.659" asserts="0">
+          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.739" asserts="0">
             <results>
-              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.659" asserts="0">
+              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.739" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.531" asserts="0">
+                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.575" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.170" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.186" asserts="0">
                         <categories>
                           <category name="tag2" />
                         </categories>
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.162" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.178" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
@@ -27,7 +27,7 @@
                           <category name="tag1" />
                         </categories>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.008" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.009" asserts="0">
                         <categories>
                           <category name="tag1" />
                         </categories>
@@ -53,7 +53,7 @@ at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pic
                           <message><![CDATA[]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.090" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.101" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -88,11 +88,11 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.037" asserts="0">
+                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.041" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.025" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.027" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.016" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.018" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -156,11 +156,11 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.027" asserts="0">
+                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.024" asserts="0">
                     <results>
                       <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.015" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.006" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.005" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -180,7 +180,7 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()]]></message>
@@ -189,7 +189,7 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" description="Failing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.004" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" description="Inconclusive Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
                             <reason>
@@ -200,16 +200,16 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" description="Inconclusive Feature Passing Scenario" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="PassingFeature" description="Passing" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="TestFixture" name="PassingFeature" description="Passing" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" description="Passing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.019" asserts="0">
+                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.031" asserts="0">
                     <results>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.008" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.010" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -242,7 +242,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -275,7 +275,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.006" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -310,13 +310,13 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.034" asserts="0">
+                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.051" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.011" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.018" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -328,7 +328,7 @@ namespace MyNamespace
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
                             </reason>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -370,7 +370,7 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithBackslashesInTheExamples" description="Deal correctly with backslashes in the examples" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithBackslashesInTheExamples" description="Deal correctly with backslashes in the examples" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
@@ -380,18 +380,18 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.003" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.004" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.009" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -413,11 +413,11 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhere
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.005" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="33" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-02-21" time="10:22:45">
-  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8670" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults" machine-name="SHUTTLEPC" user="Dirk" user-domain="SHUTTLEPC" />
-  <culture-info current-culture="de-AT" current-uiculture="en-US" />
-  <test-suite type="Assembly" name="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.853" asserts="0">
+<test-results name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="34" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-02-26" time="13:29:14">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8669" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.666" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.846" asserts="0">
+      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.659" asserts="0">
         <results>
-          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.845" asserts="0">
+          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.659" asserts="0">
             <results>
-              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.845" asserts="0">
+              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.659" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.594" asserts="0">
+                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.531" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.185" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.170" asserts="0">
                         <categories>
                           <category name="tag2" />
                         </categories>
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.176" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.162" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
@@ -27,7 +27,7 @@
                           <category name="tag1" />
                         </categories>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.011" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.008" asserts="0">
                         <categories>
                           <category name="tag1" />
                         </categories>
@@ -43,8 +43,8 @@ at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\Addition.feature.cs:line 0
-at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\Addition.feature:line 34
+at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\Addition.feature.cs:line 0
+at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit\Addition.feature:line 34
 ]]></stack-trace>
                         </failure>
                       </test-case>
@@ -53,7 +53,7 @@ at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Cod
                           <message><![CDATA[]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.094" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.090" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -88,11 +88,11 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.051" asserts="0">
+                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.037" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.033" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.025" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.019" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.016" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -102,13 +102,13 @@ namespace MyNamespace
     1]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -122,13 +122,13 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     1]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -144,21 +144,21 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     1]]></message>
                           <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 12
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 12
 ]]></stack-trace>
                         </failure>
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.023" asserts="0">
+                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.027" asserts="0">
                     <results>
-                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.014" asserts="0">
+                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.015" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.006" asserts="0">
                             <failure>
@@ -170,13 +170,13 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature.cs:line 0
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature:line 10
+at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature.cs:line 0
+at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature:line 10
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -189,7 +189,7 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" description="Failing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.008" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" description="Inconclusive Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
                             <reason>
@@ -207,9 +207,9 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                       </test-suite>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.045" asserts="0">
+                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.019" asserts="0">
                     <results>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.009" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.008" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -242,7 +242,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -275,7 +275,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -310,13 +310,13 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.083" asserts="0">
+                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.034" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.047" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.011" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -338,13 +338,13 @@ namespace MyNamespace
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -358,13 +358,13 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -375,18 +375,23 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithParenthesisInTheExamples" description="Deal correctly with parenthesis in the examples" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.004" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.007" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.004" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.001" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -396,19 +401,19 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 34
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 34
 ]]></stack-trace>
                             </failure>
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.006" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenParsingNunit3ResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenParsingNunit3ResultsFile.cs
@@ -77,6 +77,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit3
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
@@ -1,44 +1,44 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="33" result="Failed" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.698253">
+<test-run id="2" testcasecount="33" result="Failed" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.843863">
   <command-line><![CDATA["C:\src\pickles-testresults\\TestHarness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\src\pickles-testresults\\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\src\pickles-testresults\\results-example-nunit3.xml"]]></command-line>
-  <test-suite type="Assembly" id="0-1048" name="nunit3Harness.dll" fullname="C:\src\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.597062" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+  <test-suite type="Assembly" id="0-1048" name="nunit3Harness.dll" fullname="C:\src\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.731461" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
     <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10240.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" culture="en-US" uiculture="en-US" os-architecture="x64" />
     <settings>
       <setting name="WorkDirectory" value="C:\src\pickles-testresults" />
       <setting name="NumberOfTestWorkers" value="8" />
     </settings>
     <properties>
-      <property name="_PID" value="19220" />
+      <property name="_PID" value="924" />
       <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
       <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="TestSuite" id="0-1049" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590860" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <test-suite type="TestSuite" id="0-1049" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724766" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
       <failure>
         <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="TestSuite" id="0-1050" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590783" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+      <test-suite type="TestSuite" id="0-1050" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724686" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
         <failure>
           <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="TestSuite" id="0-1051" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590776" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+        <test-suite type="TestSuite" id="0-1051" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724678" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
           <failure>
             <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.536180" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
+          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.662979" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
             <properties>
               <property name="Description" value="Addition" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.151573" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.168946" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
                 <property name="Category" value="tag2" />
               </properties>
-              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.147438" asserts="0">
+              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.164123" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
 -> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
@@ -53,7 +53,7 @@ Then the result should be 260 on the screen
 -> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000314" asserts="0">
+              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000426" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
 -> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
@@ -69,7 +69,7 @@ Then the result should be 180 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000409" asserts="0">
+            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000698" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="tag1" />
@@ -86,7 +86,7 @@ Then the result should be 3 on the screen
 -> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
 ]]></output>
             </test-case>
-            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.007623" asserts="0">
+            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.007835" asserts="0">
               <properties>
                 <property name="Description" value="Fail to add two numbers" />
                 <property name="Category" value="tag1" />
@@ -118,7 +118,7 @@ Then the result should be 3.2 on the screen
 -> error: Input string was not in a correct format.
 ]]></output>
             </test-case>
-            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000625" asserts="0">
+            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000661" asserts="0">
               <properties>
                 <property name="Description" value="Ignored adding two numbers" />
                 <property name="_SKIPREASON" value="" />
@@ -127,7 +127,7 @@ Then the result should be 3.2 on the screen
                 <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.077305" asserts="0">
+            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.085396" asserts="0">
               <properties>
                 <property name="Description" value="Not automated adding two numbers" />
               </properties>
@@ -191,21 +191,21 @@ Then unimplemented step
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.019197" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.020804" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Failing Background" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.016705" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.018041" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.014013" asserts="0">
+              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.015860" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -244,7 +244,7 @@ Then the result should be 260 on the screen
 -> skipped because of previous errors
 ]]></output>
               </test-case>
-              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002552" asserts="0">
+              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002024" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -284,7 +284,7 @@ Then the result should be 180 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001624" asserts="0">
+            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001855" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
               </properties>
@@ -325,18 +325,18 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestSuite" id="0-1052" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.570673" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
+          <test-suite type="TestSuite" id="0-1052" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.700935" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="TestFixture" id="0-1039" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.010987" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1039" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.012435" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Failing" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1042" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1072944492" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.004879" asserts="0">
+              <test-case id="0-1042" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1072944492" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.005648" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Failing Scenario" />
                 </properties>
@@ -366,7 +366,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1041" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="657009205" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.004844" asserts="0">
+              <test-case id="0-1041" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="657009205" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.005517" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Inconclusive Scenario" />
                 </properties>
@@ -378,7 +378,7 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1040" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="129833087" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000725" asserts="0">
+              <test-case id="0-1040" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="129833087" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000694" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Passing Scenario" />
                 </properties>
@@ -387,11 +387,11 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1043" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002679" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1043" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.003003" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Inconclusive" />
               </properties>
-              <test-case id="0-1045" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="980176457" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001826" asserts="0">
+              <test-case id="0-1045" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="980176457" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002119" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Inconclusive Scenario" />
                 </properties>
@@ -403,7 +403,7 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1044" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="105033491" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000272" asserts="0">
+              <test-case id="0-1044" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="105033491" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000352" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Passing Scenario" />
                 </properties>
@@ -412,11 +412,11 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1046" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001235" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1046" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001373" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Passing" />
               </properties>
-              <test-case id="0-1047" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000756" asserts="0">
+              <test-case id="0-1047" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000731" asserts="0">
                 <properties>
                   <property name="Description" value="Passing Feature Passing Scenario" />
                 </properties>
@@ -426,14 +426,14 @@ Then the result should be 120 on the screen
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002030" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002403" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="NotAutomatedAtAll" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001617" asserts="0">
+            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001886" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="mytag" />
@@ -460,31 +460,31 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="17" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.017013" total="17" passed="11" failed="3" inconclusive="3" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="17" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.020337" total="17" passed="11" failed="3" inconclusive="3" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Scenario Outlines" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.010409" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.013137" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="And we can go totally bonkers with multiple example sections." />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001265" asserts="0">
+              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001450" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000091" asserts="0">
+              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000112" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.005144" asserts="0">
+              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001235" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -493,7 +493,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 ]]></output>
               </test-case>
-              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001197" asserts="0">
+              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.007418" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
@@ -502,7 +502,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 ]]></output>
               </test-case>
-              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001081" asserts="0">
+              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001478" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -529,7 +529,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000943" asserts="0">
+              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000984" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -557,64 +557,64 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000916" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001171" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with backslashes in the examples" />
               </properties>
-              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000817" asserts="0">
+              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001053" asserts="0">
                 <output><![CDATA[When I have backslashes in the value, for example a 'c:\Temp\'
 -> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000693" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000893" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with parenthesis in the examples" />
               </properties>
-              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000619" asserts="0">
-                <output><![CDATA[When I have parenthesis in the value, for example a 'This is a description (and more)'
+              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000747" asserts="0">
+                <output><![CDATA[When I have parenthesis in the value, for example an 'This is a description (and more)'
 -> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000619" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000673" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where all scenarios pass" />
               </properties>
-              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000234" asserts="0">
+              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000287" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000098" asserts="0">
+              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000088" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000092" asserts="0">
+              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000079" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_3'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001976" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002219" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario fails" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000283" asserts="0">
+              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000320" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000091" asserts="0">
+              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000099" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001389" asserts="0">
+              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001599" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -642,21 +642,21 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001829" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001707" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario is inconclusive" />
               </properties>
-              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000334" asserts="0">
+              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000344" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000102" asserts="0">
+              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000093" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
 -> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001166" asserts="0">
+              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001035" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
@@ -1,92 +1,92 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="32" result="Failed" total="32" passed="16" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.823852">
-  <command-line><![CDATA["C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\\TestHarness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\\results-example-nunit3.xml"]]></command-line>
-  <test-suite type="Assembly" id="0-1046" name="nunit3Harness.dll" fullname="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="32" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.619987" total="32" passed="16" failed="9" inconclusive="6" skipped="1" asserts="0">
-    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10586.0" platform="Win32NT" cwd="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults" machine-name="SHUTTLEPC" user="Dirk" user-domain="SHUTTLEPC" culture="de-AT" uiculture="en-US" os-architecture="x64" />
+<test-run id="2" testcasecount="33" result="Failed" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.698253">
+  <command-line><![CDATA["C:\src\pickles-testresults\\TestHarness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\src\pickles-testresults\\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\src\pickles-testresults\\results-example-nunit3.xml"]]></command-line>
+  <test-suite type="Assembly" id="0-1048" name="nunit3Harness.dll" fullname="C:\src\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.597062" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10240.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" culture="en-US" uiculture="en-US" os-architecture="x64" />
     <settings>
-      <setting name="WorkDirectory" value="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults" />
+      <setting name="WorkDirectory" value="C:\src\pickles-testresults" />
       <setting name="NumberOfTestWorkers" value="8" />
     </settings>
     <properties>
-      <property name="_PID" value="10684" />
+      <property name="_PID" value="19220" />
       <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
       <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="TestSuite" id="0-1047" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="32" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.612987" total="32" passed="16" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <test-suite type="TestSuite" id="0-1049" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590860" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
       <failure>
         <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="TestSuite" id="0-1048" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="32" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.612867" total="32" passed="16" failed="9" inconclusive="6" skipped="1" asserts="0">
+      <test-suite type="TestSuite" id="0-1050" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590783" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
         <failure>
           <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="TestSuite" id="0-1049" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="32" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.612859" total="32" passed="16" failed="9" inconclusive="6" skipped="1" asserts="0">
+        <test-suite type="TestSuite" id="0-1051" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.590776" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
           <failure>
             <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.557170" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
+          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.536180" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
             <properties>
               <property name="Description" value="Addition" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.158770" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.151573" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
                 <property name="Category" value="tag2" />
               </properties>
-              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.154047" asserts="0">
+              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.147438" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000341" asserts="0">
+              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000314" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000438" asserts="0">
+            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000409" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="tag1" />
               </properties>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
 ]]></output>
             </test-case>
-            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.008526" asserts="0">
+            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.007623" asserts="0">
               <properties>
                 <property name="Description" value="Fail to add two numbers" />
                 <property name="Category" value="tag1" />
@@ -103,22 +103,22 @@ Then the result should be 3 on the screen
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\Addition.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\Addition.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\Addition.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\Addition.feature:line 34]]></stack-trace>
               </failure>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -> error: Input string was not in a correct format.
 ]]></output>
             </test-case>
-            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000768" asserts="0">
+            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000625" asserts="0">
               <properties>
                 <property name="Description" value="Ignored adding two numbers" />
                 <property name="_SKIPREASON" value="" />
@@ -127,7 +127,7 @@ Then the result should be 3.2 on the screen
                 <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.088915" asserts="0">
+            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.077305" asserts="0">
               <properties>
                 <property name="Description" value="Not automated adding two numbers" />
               </properties>
@@ -163,7 +163,7 @@ namespace MyNamespace
 ]]></message>
               </reason>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -> No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -191,21 +191,21 @@ Then unimplemented step
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.021986" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.019197" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Failing Background" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.019372" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.016705" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.016728" asserts="0">
+              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.014013" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -215,13 +215,13 @@ Then unimplemented step
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -244,7 +244,7 @@ Then the result should be 260 on the screen
 -> skipped because of previous errors
 ]]></output>
               </test-case>
-              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.002512" asserts="0">
+              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002552" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -254,13 +254,13 @@ Then the result should be 260 on the screen
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -284,7 +284,7 @@ Then the result should be 180 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001656" asserts="0">
+            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001624" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
               </properties>
@@ -297,13 +297,13 @@ Then the result should be 180 on the screen
     1]]></message>
                 <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 12]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 12]]></stack-trace>
               </failure>
               <output><![CDATA[Given the background step fails
 -> error: 
@@ -325,18 +325,18 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestSuite" id="0-1050" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-21 09:22:46Z" end-time="2016-02-21 09:22:47Z" duration="0.595943" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
+          <test-suite type="TestSuite" id="0-1052" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:15Z" end-time="2016-02-26 18:29:16Z" duration="0.570673" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="TestFixture" id="0-1037" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.012747" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1039" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.010987" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Failing" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1040" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="657009205" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.006118" asserts="0">
+              <test-case id="0-1042" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1072944492" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.004879" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Failing Scenario" />
                 </properties>
@@ -349,13 +349,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature:line 10]]></stack-trace>
+   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature:line 10]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then failing step
 -> error: 
@@ -366,7 +366,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1039" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="129833087" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.005192" asserts="0">
+              <test-case id="0-1041" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="657009205" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.004844" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Inconclusive Scenario" />
                 </properties>
@@ -378,20 +378,20 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1038" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="107278582" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000777" asserts="0">
+              <test-case id="0-1040" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="129833087" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000725" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1041" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.002554" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1043" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002679" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Inconclusive" />
               </properties>
-              <test-case id="0-1043" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="105033491" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001710" asserts="0">
+              <test-case id="0-1045" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="980176457" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001826" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Inconclusive Scenario" />
                 </properties>
@@ -403,51 +403,51 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1042" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1924427483" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000304" asserts="0">
+              <test-case id="0-1044" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="105033491" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000272" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1044" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001080" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1046" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001235" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Passing" />
               </properties>
-              <test-case id="0-1045" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="125979337" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000603" asserts="0">
+              <test-case id="0-1047" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000756" asserts="0">
                 <properties>
                   <property name="Description" value="Passing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.002390" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.002030" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="NotAutomatedAtAll" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001912" asserts="0">
+            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001617" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="mytag" />
               </properties>
               <failure>
                 <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object.]]></message>
-                <stack-trace><![CDATA[   at AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 31
+                <stack-trace><![CDATA[   at AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 31
    at lambda_method(Closure , IContextManager , Decimal )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature:line 11]]></stack-trace>
+   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature:line 11]]></stack-trace>
               </failure>
               <output><![CDATA[Given I have entered 50 into the calculator
 -> error: Object reference not set to an instance of an object.
@@ -460,31 +460,31 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="16" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.013410" total="16" passed="10" failed="3" inconclusive="3" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="17" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.017013" total="17" passed="11" failed="3" inconclusive="3" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Scenario Outlines" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.008169" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.010409" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="And we can go totally bonkers with multiple example sections." />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001379" asserts="0">
+              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001265" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000097" asserts="0">
+              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000091" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001156" asserts="0">
+              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.005144" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -493,7 +493,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 ]]></output>
               </test-case>
-              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001112" asserts="0">
+              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001197" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
@@ -502,7 +502,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 ]]></output>
               </test-case>
-              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001198" asserts="0">
+              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001081" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -512,13 +512,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -529,7 +529,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.002828" asserts="0">
+              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000943" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -539,13 +539,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_2'
 -> error: 
@@ -557,54 +557,64 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001040" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000916" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with backslashes in the examples" />
               </properties>
-              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000952" asserts="0">
+              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000817" asserts="0">
                 <output><![CDATA[When I have backslashes in the value, for example a 'c:\Temp\'
--> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000585" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000693" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties>
+                <property name="Description" value="Deal correctly with parenthesis in the examples" />
+              </properties>
+              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000619" asserts="0">
+                <output><![CDATA[When I have parenthesis in the value, for example a 'This is a description (and more)'
+-> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+]]></output>
+              </test-case>
+            </test-suite>
+            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000619" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where all scenarios pass" />
               </properties>
-              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000263" asserts="0">
+              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000234" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000074" asserts="0">
+              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000098" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000067" asserts="0">
+              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000092" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_3'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001635" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001976" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario fails" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000249" asserts="0">
+              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000283" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000089" asserts="0">
+              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000091" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001087" asserts="0">
+              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001389" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -614,13 +624,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 34]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -632,21 +642,21 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.001455" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001829" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario is inconclusive" />
               </properties>
-              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000261" asserts="0">
+              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000334" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000076" asserts="0">
+              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.000102" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-02-21 09:22:47Z" end-time="2016-02-21 09:22:47Z" duration="0.000939" asserts="0">
+              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-02-26 18:29:16Z" end-time="2016-02-26 18:29:16Z" duration="0.001166" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/results-example-specrun.html
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/results-example-specrun.html
@@ -178,6 +178,10 @@
                 &lt;title&gt;Deal correctly with backslashes in the examples, c:\Temp\&lt;/title&gt;
                 &lt;result&gt;Passed&lt;/result&gt;
             &lt;/scenario&gt;
+            &lt;scenario&gt;
+                &lt;title&gt;Deal correctly with parenthesis in the examples, This is a description (and more)&lt;/title&gt;
+                &lt;result&gt;Passed&lt;/result&gt;
+            &lt;/scenario&gt;
         &lt;/scenarios&gt;
     &lt;/feature&gt;
 &lt;/features&gt;

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
@@ -180,6 +180,21 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests
             Check.That(exampleResult1).IsEqualTo(TestResult.Passed);
         }
 
+        public void ThenCanReadResultsWithParenthesis()
+        {
+            var results = ParseResultsFile();
+
+            var feature = new Feature { Name = "Scenario Outlines" };
+
+            var scenarioOutline = new ScenarioOutline { Name = "Deal correctly with parenthesis in the examples", Feature = feature };
+
+            TestResult exampleResultOutline = results.GetScenarioOutlineResult(scenarioOutline);
+            Check.That(exampleResultOutline).IsEqualTo(TestResult.Passed);
+
+            TestResult exampleResult1 = results.GetExampleResult(scenarioOutline, new[] { @"This is a description (and more)" });
+            Check.That(exampleResult1).IsEqualTo(TestResult.Passed);
+        }
+
         public void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             var results = ParseResultsFile();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingVsTestResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingVsTestResultsFile.cs
@@ -113,6 +113,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.VsTest
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadResultOfScenarioWithFailingBackground()
         {
             base.ThenCanReadResultOfScenarioWithFailingBackground();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
@@ -1,70 +1,70 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="10789669-f60d-4730-85ba-98878ab08e51" name="Dirk@SHUTTLEPC 2016-02-23 17:08:34" runUser="SHUTTLEPC\Dirk" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-  <Times creation="2016-02-23T17:08:34.2990766+01:00" queuing="2016-02-23T17:08:34.2990766+01:00" start="2016-02-23T17:08:34.3030762+01:00" finish="2016-02-23T17:08:35.7281108+01:00" />
-  <TestSettings name="default" id="4a52e871-36b7-45c1-9877-a64f6ad276be">
+<TestRun id="82d39159-69f3-4cbd-a00d-d2d7649f2837" name="ocsur@DESKTOP-AIFNJPI 2016-02-29 13:31:23" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2016-02-29T13:31:23.0292278-05:00" queuing="2016-02-29T13:31:23.0292278-05:00" start="2016-02-29T13:31:23.0332416-05:00" finish="2016-02-29T13:31:24.0664977-05:00" />
+  <TestSettings name="default" id="fcc68539-05dd-4cc8-adb1-8bc418f40125">
     <Execution>
       <TestTypeSpecific />
     </Execution>
-    <Deployment runDeploymentRoot="Dirk_SHUTTLEPC 2016-02-23 17_08_34" />
+    <Deployment runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-29 13_31_23" />
     <Properties />
   </TestSettings>
   <Results>
-    <UnitTestResult executionId="a37abc8d-60ce-4f69-a991-29cf797bd99d" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="SHUTTLEPC" duration="00:00:00.1008328" startTime="2016-02-23T17:08:33.4969847+01:00" endTime="2016-02-23T17:08:33.8665344+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a37abc8d-60ce-4f69-a991-29cf797bd99d">
+    <UnitTestResult executionId="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.1018713" startTime="2016-02-29T13:31:22.1700049-05:00" endTime="2016-02-29T13:31:22.5811287-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c1269567-c1a5-4023-9688-487619bf0800" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="SHUTTLEPC" duration="00:00:00.0003014" startTime="2016-02-23T17:08:33.8735342+01:00" endTime="2016-02-23T17:08:33.8740352+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c1269567-c1a5-4023-9688-487619bf0800">
+    <UnitTestResult executionId="65361449-881c-4f34-8f1c-b3aec990f15e" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002712" startTime="2016-02-29T13:31:22.5881310-05:00" endTime="2016-02-29T13:31:22.5891262-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65361449-881c-4f34-8f1c-b3aec990f15e">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c4eba55a-c680-4f44-b91c-7b49e6f79085" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0002302" startTime="2016-02-23T17:08:33.8740352+01:00" endTime="2016-02-23T17:08:33.8745346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c4eba55a-c680-4f44-b91c-7b49e6f79085">
+    <UnitTestResult executionId="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002148" startTime="2016-02-29T13:31:22.5891262-05:00" endTime="2016-02-29T13:31:22.5891262-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f5d459f6-fcd4-460c-af5a-20bcf57ead8f">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="41fc0386-741c-4a00-8bcb-d63e520d0a15" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0162987" startTime="2016-02-23T17:08:33.8745346+01:00" endTime="2016-02-23T17:08:33.8910345+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="41fc0386-741c-4a00-8bcb-d63e520d0a15">
+    <UnitTestResult executionId="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0160539" startTime="2016-02-29T13:31:22.5891262-05:00" endTime="2016-02-29T13:31:22.6051301-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -&gt; error: Input string was not in a correct format.</StdOut>
         <ErrorInfo>
@@ -86,17 +86,17 @@ System.FormatException: Input string was not in a correct format.</Message>
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="153bd90e-cc1a-4f44-abdb-f830f9e86dc8" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="SHUTTLEPC" startTime="2016-02-23T17:08:33.8915349+01:00" endTime="2016-02-23T17:08:33.8915349+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="153bd90e-cc1a-4f44-abdb-f830f9e86dc8" />
-    <UnitTestResult executionId="74f4140f-2b27-4f7f-b40f-3ea33f5310c2" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0577865" startTime="2016-02-23T17:08:33.8915349+01:00" endTime="2016-02-23T17:08:33.9495347+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="74f4140f-2b27-4f7f-b40f-3ea33f5310c2">
+    <UnitTestResult executionId="8d70d6f0-76c2-43ea-9476-93b10f73bfed" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" startTime="2016-02-29T13:31:22.6061188-05:00" endTime="2016-02-29T13:31:22.6061188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8d70d6f0-76c2-43ea-9476-93b10f73bfed" />
+    <UnitTestResult executionId="29a76e0f-6591-45fa-96de-7719fe7b4a9c" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0548584" startTime="2016-02-29T13:31:22.6061188-05:00" endTime="2016-02-29T13:31:22.6611449-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="29a76e0f-6591-45fa-96de-7719fe7b4a9c">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -156,13 +156,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="25e1266d-8da1-4f29-b0e8-c603c187af1e" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="SHUTTLEPC" duration="00:00:00.0091151" startTime="2016-02-23T17:08:33.9495347+01:00" endTime="2016-02-23T17:08:33.9595348+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="25e1266d-8da1-4f29-b0e8-c603c187af1e">
+    <UnitTestResult executionId="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0096875" startTime="2016-02-29T13:31:22.6611449-05:00" endTime="2016-02-29T13:31:22.6721522-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -191,20 +191,20 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d14f4667-0fea-466f-9c20-bd9c24164d32" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="SHUTTLEPC" duration="00:00:00.0013204" startTime="2016-02-23T17:08:33.9600348+01:00" endTime="2016-02-23T17:08:33.9615346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d14f4667-0fea-466f-9c20-bd9c24164d32">
+    <UnitTestResult executionId="cea33f60-e243-4965-b63e-597c8a88d2f9" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013760" startTime="2016-02-29T13:31:22.6721522-05:00" endTime="2016-02-29T13:31:22.6741527-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cea33f60-e243-4965-b63e-597c8a88d2f9">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -235,21 +235,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6b69354d-f2bb-4b33-91c2-c3d423536d91" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="SHUTTLEPC" duration="00:00:00.0017082" startTime="2016-02-23T17:08:33.9615346+01:00" endTime="2016-02-23T17:08:33.9635350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6b69354d-f2bb-4b33-91c2-c3d423536d91">
+    <UnitTestResult executionId="9388824a-0969-41ed-a65f-944972aea091" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010644" startTime="2016-02-29T13:31:22.6741527-05:00" endTime="2016-02-29T13:31:22.6751534-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9388824a-0969-41ed-a65f-944972aea091">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -280,21 +280,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1e419543-e287-4bef-9a6b-68d0904a33c4" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="SHUTTLEPC" duration="00:00:00.0038148" startTime="2016-02-23T17:08:33.9635350+01:00" endTime="2016-02-23T17:08:33.9675343+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e419543-e287-4bef-9a6b-68d0904a33c4">
+    <UnitTestResult executionId="a5b25781-7d96-483c-8ea8-95e20603919f" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0040357" startTime="2016-02-29T13:31:22.6751534-05:00" endTime="2016-02-29T13:31:22.6801372-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a5b25781-7d96-483c-8ea8-95e20603919f">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -363,13 +363,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="885d2ea2-3190-4ede-af14-b7bb6a91669e" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="SHUTTLEPC" duration="00:00:00.0033735" startTime="2016-02-23T17:08:33.9680347+01:00" endTime="2016-02-23T17:08:33.9715346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="885d2ea2-3190-4ede-af14-b7bb6a91669e">
+    <UnitTestResult executionId="03240585-ad45-4dac-b760-9754938af626" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0033919" startTime="2016-02-29T13:31:22.6801372-05:00" endTime="2016-02-29T13:31:22.6831509-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="03240585-ad45-4dac-b760-9754938af626">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -438,13 +438,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="2584dbed-dcf7-4802-99cc-1e45265c8dae" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="SHUTTLEPC" duration="00:00:00.0032006" startTime="2016-02-23T17:08:33.9715346+01:00" endTime="2016-02-23T17:08:33.9750349+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2584dbed-dcf7-4802-99cc-1e45265c8dae">
+    <UnitTestResult executionId="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0032946" startTime="2016-02-29T13:31:22.6841507-05:00" endTime="2016-02-29T13:31:22.6871519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -513,43 +513,43 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1666a9d2-ad50-4d51-8106-c1991508019d" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0009096" startTime="2016-02-23T17:08:33.9750349+01:00" endTime="2016-02-23T17:08:33.9765346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1666a9d2-ad50-4d51-8106-c1991508019d">
+    <UnitTestResult executionId="5c954959-f9e2-4f11-a707-3391ee0382ad" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0009594" startTime="2016-02-29T13:31:22.6871519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5c954959-f9e2-4f11-a707-3391ee0382ad">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="683b95ea-ffec-473b-b2b2-46c4a6f9c35e" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0000965" startTime="2016-02-23T17:08:33.9765346+01:00" endTime="2016-02-23T17:08:33.9765346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="683b95ea-ffec-473b-b2b2-46c4a6f9c35e">
+    <UnitTestResult executionId="091433bf-fed1-470e-b06c-cb4b7b972e6e" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000942" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="091433bf-fed1-470e-b06c-cb4b7b972e6e">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ebd1721d-cfbb-4915-ae25-e0f56b382c18" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="SHUTTLEPC" duration="00:00:00.0000959" startTime="2016-02-23T17:08:33.9770347+01:00" endTime="2016-02-23T17:08:33.9770347+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ebd1721d-cfbb-4915-ae25-e0f56b382c18">
+    <UnitTestResult executionId="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000936" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="23ff0c73-6cc8-4e6f-b179-964f6547f7d1">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c2513100-03c6-4077-86bc-6154bc8e1557" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0001828" startTime="2016-02-23T17:08:33.9770347+01:00" endTime="2016-02-23T17:08:33.9775350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c2513100-03c6-4077-86bc-6154bc8e1557">
+    <UnitTestResult executionId="e8b916c9-e2cd-4024-b8db-066ec4c977db" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001832" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6901412-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e8b916c9-e2cd-4024-b8db-066ec4c977db">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ca72d8f0-4b05-411e-8122-03a0cfdb5dba" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0001157" startTime="2016-02-23T17:08:33.9775350+01:00" endTime="2016-02-23T17:08:33.9780348+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ca72d8f0-4b05-411e-8122-03a0cfdb5dba">
+    <UnitTestResult executionId="d40e68a2-8718-4471-ab2a-8edda2509a11" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000916" startTime="2016-02-29T13:31:22.6901412-05:00" endTime="2016-02-29T13:31:22.6901412-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d40e68a2-8718-4471-ab2a-8edda2509a11">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="07831673-3620-49d4-9a6f-345f78a5e118" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="SHUTTLEPC" duration="00:00:00.0026701" startTime="2016-02-23T17:08:33.9780348+01:00" endTime="2016-02-23T17:08:33.9810346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="07831673-3620-49d4-9a6f-345f78a5e118">
+    <UnitTestResult executionId="3f2955ce-7301-4d16-8632-62450d7586c0" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0028238" startTime="2016-02-29T13:31:22.6901412-05:00" endTime="2016-02-29T13:31:22.6931532-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3f2955ce-7301-4d16-8632-62450d7586c0">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -562,26 +562,26 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="bf311023-1a55-4fe1-ab6e-209d02e70ee6" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0002171" startTime="2016-02-23T17:08:33.9810346+01:00" endTime="2016-02-23T17:08:33.9815350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="bf311023-1a55-4fe1-ab6e-209d02e70ee6">
+    <UnitTestResult executionId="18072b05-d227-43a5-a03b-e7b5b137f8b0" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002433" startTime="2016-02-29T13:31:22.6931532-05:00" endTime="2016-02-29T13:31:22.6941533-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="18072b05-d227-43a5-a03b-e7b5b137f8b0">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f1d4483d-df98-45ec-91fc-7342cebf2bb5" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0002007" startTime="2016-02-23T17:08:33.9815350+01:00" endTime="2016-02-23T17:08:33.9820395+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f1d4483d-df98-45ec-91fc-7342cebf2bb5">
+    <UnitTestResult executionId="419f70e2-5e6a-48a8-930a-d55488701243" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001018" startTime="2016-02-29T13:31:22.6941533-05:00" endTime="2016-02-29T13:31:22.6941533-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="419f70e2-5e6a-48a8-930a-d55488701243">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fdc86495-521f-44ff-88c7-2e1065247375" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="SHUTTLEPC" duration="00:00:00.0030479" startTime="2016-02-23T17:08:33.9825370+01:00" endTime="2016-02-23T17:08:33.9855350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fdc86495-521f-44ff-88c7-2e1065247375">
+    <UnitTestResult executionId="58745bc6-950b-44fa-a5fe-478985e2ed78" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0058740" startTime="2016-02-29T13:31:22.6941533-05:00" endTime="2016-02-29T13:31:22.7001463-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="58745bc6-950b-44fa-a5fe-478985e2ed78">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -600,33 +600,33 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="31374bc6-9084-4f7a-b608-48c12f1a66b9" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="SHUTTLEPC" duration="00:00:00.0001959" startTime="2016-02-23T17:08:33.9860350+01:00" endTime="2016-02-23T17:08:33.9860350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31374bc6-9084-4f7a-b608-48c12f1a66b9">
+    <UnitTestResult executionId="f25d9785-df62-4803-9145-764d6ef67308" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004149" startTime="2016-02-29T13:31:22.7011470-05:00" endTime="2016-02-29T13:31:22.7011470-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f25d9785-df62-4803-9145-764d6ef67308">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="681df7fc-beb8-48a9-ba05-f81d1d9d5aac" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="SHUTTLEPC" duration="00:00:00.0000997" startTime="2016-02-23T17:08:33.9865350+01:00" endTime="2016-02-23T17:08:33.9865350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="681df7fc-beb8-48a9-ba05-f81d1d9d5aac">
+    <UnitTestResult executionId="760b0de1-dc3a-4559-a94c-c8cd867189f5" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002097" startTime="2016-02-29T13:31:22.7021471-05:00" endTime="2016-02-29T13:31:22.7021471-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="760b0de1-dc3a-4559-a94c-c8cd867189f5">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="752ee581-bbcd-4c89-8115-4d8c7fc5e43e" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="SHUTTLEPC" duration="00:00:00.0010501" startTime="2016-02-23T17:08:33.9865350+01:00" endTime="2016-02-23T17:08:33.9880348+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="752ee581-bbcd-4c89-8115-4d8c7fc5e43e">
+    <UnitTestResult executionId="00c36296-d9c2-4947-9035-214f41a64332" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022020" startTime="2016-02-29T13:31:22.7031438-05:00" endTime="2016-02-29T13:31:22.7051444-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="00c36296-d9c2-4947-9035-214f41a64332">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -639,14 +639,14 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ecdf8da8-064e-4a82-b7c6-b9c74e7160a9" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="SHUTTLEPC" duration="00:00:00.0010016" startTime="2016-02-23T17:08:33.9880348+01:00" endTime="2016-02-23T17:08:33.9890349+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ecdf8da8-064e-4a82-b7c6-b9c74e7160a9">
+    <UnitTestResult executionId="4f98e324-0a04-4175-afd5-5d704bc20564" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0020819" startTime="2016-02-29T13:31:22.7051444-05:00" endTime="2016-02-29T13:31:22.7081450-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4f98e324-0a04-4175-afd5-5d704bc20564">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
@@ -659,14 +659,14 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="278f5025-9008-4efd-b3fd-8e9a2c571b55" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="SHUTTLEPC" duration="00:00:00.0010796" startTime="2016-02-23T17:08:33.9895346+01:00" endTime="2016-02-23T17:08:33.9905347+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="278f5025-9008-4efd-b3fd-8e9a2c571b55">
+    <UnitTestResult executionId="0356259c-3cf9-4dbf-8fd3-baffefeb0883" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021986" startTime="2016-02-29T13:31:22.7081450-05:00" endTime="2016-02-29T13:31:22.7101455-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0356259c-3cf9-4dbf-8fd3-baffefeb0883">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -685,21 +685,21 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="78c23ae8-d6d8-4525-ac60-b4162ad34787" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="SHUTTLEPC" duration="00:00:00.0043187" startTime="2016-02-23T17:08:33.9905347+01:00" endTime="2016-02-23T17:08:33.9950340+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="78c23ae8-d6d8-4525-ac60-b4162ad34787">
+    <UnitTestResult executionId="47cca6d3-de44-47a4-806d-526a742a8099" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0070082" startTime="2016-02-29T13:31:22.7111459-05:00" endTime="2016-02-29T13:31:22.7181476-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="47cca6d3-de44-47a4-806d-526a742a8099">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -718,34 +718,40 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="26cf2b3b-ede7-4bc1-a684-f246d269f802" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="SHUTTLEPC" duration="00:00:00.0006244" startTime="2016-02-23T17:08:33.9955350+01:00" endTime="2016-02-23T17:08:33.9965351+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="26cf2b3b-ede7-4bc1-a684-f246d269f802">
+    <UnitTestResult executionId="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010482" startTime="2016-02-29T13:31:22.7181476-05:00" endTime="2016-02-29T13:31:22.7201481-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="88599dc4-7d1a-4de3-97b3-1a32ce5e9b7e" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="SHUTTLEPC" duration="00:00:00.0000410" startTime="2016-02-23T17:08:33.9965351+01:00" endTime="2016-02-23T17:08:33.9965351+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="88599dc4-7d1a-4de3-97b3-1a32ce5e9b7e" />
-    <UnitTestResult executionId="5aa37a70-13c5-4621-8ccf-423561240334" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0007011" startTime="2016-02-23T17:08:33.9970351+01:00" endTime="2016-02-23T17:08:33.9980352+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5aa37a70-13c5-4621-8ccf-423561240334">
+    <UnitTestResult executionId="879519fd-a94d-4ae5-9173-20591899e52b" testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0008580" startTime="2016-02-29T13:31:22.7201481-05:00" endTime="2016-02-29T13:31:22.7211482-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="879519fd-a94d-4ae5-9173-20591899e52b">
+      <Output>
+        <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="12c93c51-68b3-4578-bd2e-14b15f688d77" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000879" startTime="2016-02-29T13:31:22.7221486-05:00" endTime="2016-02-29T13:31:22.7221486-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12c93c51-68b3-4578-bd2e-14b15f688d77" />
+    <UnitTestResult executionId="31091b52-79e0-488f-a271-f704c0430d89" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013479" startTime="2016-02-29T13:31:22.7231670-05:00" endTime="2016-02-29T13:31:22.7241671-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31091b52-79e0-488f-a271-f704c0430d89">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="33c691ac-ba0c-42c9-97b8-f22571283d34" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="SHUTTLEPC" duration="00:00:00.0015235" startTime="2016-02-23T17:08:33.9980352+01:00" endTime="2016-02-23T17:08:34.0000350+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="33c691ac-ba0c-42c9-97b8-f22571283d34">
+    <UnitTestResult executionId="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017201" startTime="2016-02-29T13:31:22.7251672-05:00" endTime="2016-02-29T13:31:22.7271629-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -758,13 +764,13 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b6b95f4e-492e-4986-a770-1cf86d8094be" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="SHUTTLEPC" duration="00:00:00.0013807" startTime="2016-02-23T17:08:34.0000350+01:00" endTime="2016-02-23T17:08:34.0015348+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b6b95f4e-492e-4986-a770-1cf86d8094be">
+    <UnitTestResult executionId="f33041be-df5f-457c-8e78-b671ef333130" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0015784" startTime="2016-02-29T13:31:22.7271629-05:00" endTime="2016-02-29T13:31:22.7281630-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f33041be-df5f-457c-8e78-b671ef333130">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -783,26 +789,26 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e5d86ff5-275b-49a0-bc81-1d8904517f9b" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0003274" startTime="2016-02-23T17:08:34.0015348+01:00" endTime="2016-02-23T17:08:34.0020348+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e5d86ff5-275b-49a0-bc81-1d8904517f9b">
+    <UnitTestResult executionId="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004155" startTime="2016-02-29T13:31:22.7291506-05:00" endTime="2016-02-29T13:31:22.7291506-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e44a7b2-d4ab-4669-9675-5a72eaff53c7">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="492c184c-6577-421d-83e4-b122b1f6534e" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="SHUTTLEPC" duration="00:00:00.0010090" startTime="2016-02-23T17:08:34.0025345+01:00" endTime="2016-02-23T17:08:34.0035346+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="492c184c-6577-421d-83e4-b122b1f6534e">
+    <UnitTestResult executionId="765922f5-5658-4a15-96de-d06a70063d76" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012249" startTime="2016-02-29T13:31:22.7301507-05:00" endTime="2016-02-29T13:31:22.7311508-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="765922f5-5658-4a15-96de-d06a70063d76">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -815,204 +821,209 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="7bde167d-0b92-4357-b0e0-615df906cdab" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="SHUTTLEPC" duration="00:00:00.0003290" startTime="2016-02-23T17:08:34.0035346+01:00" endTime="2016-02-23T17:08:34.0045347+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7bde167d-0b92-4357-b0e0-615df906cdab">
+    <UnitTestResult executionId="ea8121e6-4daa-4421-b440-d02288bef8ef" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004038" startTime="2016-02-29T13:31:22.7311508-05:00" endTime="2016-02-29T13:31:22.7321515-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ea8121e6-4daa-4421-b440-d02288bef8ef">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>
   <TestDefinitions>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
-      <Execution id="a37abc8d-60ce-4f69-a991-29cf797bd99d" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
+      <Execution id="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
-      <Execution id="c1269567-c1a5-4023-9688-487619bf0800" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
+      <Execution id="65361449-881c-4f34-8f1c-b3aec990f15e" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
-      <Execution id="c4eba55a-c680-4f44-b91c-7b49e6f79085" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
+      <Execution id="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
-      <Execution id="41fc0386-741c-4a00-8bcb-d63e520d0a15" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
+    <UnitTest name="FailToAddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
+      <Execution id="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="IgnoredAddingTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
-      <Execution id="153bd90e-cc1a-4f44-abdb-f830f9e86dc8" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
+    <UnitTest name="IgnoredAddingTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
+      <Execution id="8d70d6f0-76c2-43ea-9476-93b10f73bfed" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
-      <Execution id="74f4140f-2b27-4f7f-b40f-3ea33f5310c2" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
+      <Execution id="29a76e0f-6591-45fa-96de-7719fe7b4a9c" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
-      <Execution id="25e1266d-8da1-4f29-b0e8-c603c187af1e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
+      <Execution id="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
-      <Execution id="d14f4667-0fea-466f-9c20-bd9c24164d32" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
+      <Execution id="cea33f60-e243-4965-b63e-597c8a88d2f9" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
-      <Execution id="6b69354d-f2bb-4b33-91c2-c3d423536d91" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
+      <Execution id="9388824a-0969-41ed-a65f-944972aea091" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
-      <Execution id="1e419543-e287-4bef-9a6b-68d0904a33c4" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
+    <UnitTest name="NotAutomatedScenario1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
+      <Execution id="a5b25781-7d96-483c-8ea8-95e20603919f" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
-      <Execution id="885d2ea2-3190-4ede-af14-b7bb6a91669e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
+    <UnitTest name="NotAutomatedScenario2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
+      <Execution id="03240585-ad45-4dac-b760-9754938af626" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
-      <Execution id="2584dbed-dcf7-4802-99cc-1e45265c8dae" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
+    <UnitTest name="NotAutomatedScenario3" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
+      <Execution id="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
-      <Execution id="1666a9d2-ad50-4d51-8106-c1991508019d" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
+      <Execution id="5c954959-f9e2-4f11-a707-3391ee0382ad" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
-      <Execution id="683b95ea-ffec-473b-b2b2-46c4a6f9c35e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
+      <Execution id="091433bf-fed1-470e-b06c-cb4b7b972e6e" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
-      <Execution id="ebd1721d-cfbb-4915-ae25-e0f56b382c18" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
+      <Execution id="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
-      <Execution id="c2513100-03c6-4077-86bc-6154bc8e1557" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
+      <Execution id="e8b916c9-e2cd-4024-b8db-066ec4c977db" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
-      <Execution id="ca72d8f0-4b05-411e-8122-03a0cfdb5dba" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
+      <Execution id="d40e68a2-8718-4471-ab2a-8edda2509a11" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
-      <Execution id="07831673-3620-49d4-9a6f-345f78a5e118" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
+      <Execution id="3f2955ce-7301-4d16-8632-62450d7586c0" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
-      <Execution id="bf311023-1a55-4fe1-ab6e-209d02e70ee6" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
+      <Execution id="18072b05-d227-43a5-a03b-e7b5b137f8b0" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
-      <Execution id="f1d4483d-df98-45ec-91fc-7342cebf2bb5" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
+      <Execution id="419f70e2-5e6a-48a8-930a-d55488701243" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
-      <Execution id="fdc86495-521f-44ff-88c7-2e1065247375" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
+      <Execution id="58745bc6-950b-44fa-a5fe-478985e2ed78" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
-      <Execution id="31374bc6-9084-4f7a-b608-48c12f1a66b9" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
+      <Execution id="f25d9785-df62-4803-9145-764d6ef67308" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
-      <Execution id="681df7fc-beb8-48a9-ba05-f81d1d9d5aac" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
+      <Execution id="760b0de1-dc3a-4559-a94c-c8cd867189f5" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
-      <Execution id="752ee581-bbcd-4c89-8115-4d8c7fc5e43e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
+      <Execution id="00c36296-d9c2-4947-9035-214f41a64332" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
-      <Execution id="ecdf8da8-064e-4a82-b7c6-b9c74e7160a9" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
+      <Execution id="4f98e324-0a04-4175-afd5-5d704bc20564" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
-      <Execution id="278f5025-9008-4efd-b3fd-8e9a2c571b55" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
+      <Execution id="0356259c-3cf9-4dbf-8fd3-baffefeb0883" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
-      <Execution id="78c23ae8-d6d8-4525-ac60-b4162ad34787" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
+      <Execution id="47cca6d3-de44-47a4-806d-526a742a8099" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
-      <Execution id="26cf2b3b-ede7-4bc1-a684-f246d269f802" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
+      <Execution id="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
-      <Execution id="88599dc4-7d1a-4de3-97b3-1a32ce5e9b7e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91">
+      <Execution id="879519fd-a94d-4ae5-9173-20591899e52b" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
-      <Execution id="5aa37a70-13c5-4621-8ccf-423561240334" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
+    <UnitTest name="TestMethod" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
+      <Execution id="12c93c51-68b3-4578-bd2e-14b15f688d77" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
-      <Execution id="33c691ac-ba0c-42c9-97b8-f22571283d34" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
+    <UnitTest name="FailingFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
+      <Execution id="31091b52-79e0-488f-a271-f704c0430d89" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
-      <Execution id="b6b95f4e-492e-4986-a770-1cf86d8094be" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
+      <Execution id="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
-      <Execution id="e5d86ff5-275b-49a0-bc81-1d8904517f9b" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
+    <UnitTest name="FailingFeatureFailingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
+      <Execution id="f33041be-df5f-457c-8e78-b671ef333130" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
-      <Execution id="492c184c-6577-421d-83e4-b122b1f6534e" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
+      <Execution id="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\dev\code\github\dirkrombauts\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
-      <Execution id="7bde167d-0b92-4357-b0e0-615df906cdab" />
-      <TestMethod codeBase="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
+      <Execution id="765922f5-5658-4a15-96de-d06a70063d76" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
+    </UnitTest>
+    <UnitTest name="PassingFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
+      <Execution id="ea8121e6-4daa-4421-b440-d02288bef8ef" />
+      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>
-    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="a37abc8d-60ce-4f69-a991-29cf797bd99d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="c1269567-c1a5-4023-9688-487619bf0800" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="c4eba55a-c680-4f44-b91c-7b49e6f79085" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="41fc0386-741c-4a00-8bcb-d63e520d0a15" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="153bd90e-cc1a-4f44-abdb-f830f9e86dc8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="74f4140f-2b27-4f7f-b40f-3ea33f5310c2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="25e1266d-8da1-4f29-b0e8-c603c187af1e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="d14f4667-0fea-466f-9c20-bd9c24164d32" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="6b69354d-f2bb-4b33-91c2-c3d423536d91" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="1e419543-e287-4bef-9a6b-68d0904a33c4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="885d2ea2-3190-4ede-af14-b7bb6a91669e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="2584dbed-dcf7-4802-99cc-1e45265c8dae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="1666a9d2-ad50-4d51-8106-c1991508019d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="683b95ea-ffec-473b-b2b2-46c4a6f9c35e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="ebd1721d-cfbb-4915-ae25-e0f56b382c18" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="c2513100-03c6-4077-86bc-6154bc8e1557" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="ca72d8f0-4b05-411e-8122-03a0cfdb5dba" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="07831673-3620-49d4-9a6f-345f78a5e118" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="bf311023-1a55-4fe1-ab6e-209d02e70ee6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="f1d4483d-df98-45ec-91fc-7342cebf2bb5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="fdc86495-521f-44ff-88c7-2e1065247375" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="31374bc6-9084-4f7a-b608-48c12f1a66b9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="681df7fc-beb8-48a9-ba05-f81d1d9d5aac" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="752ee581-bbcd-4c89-8115-4d8c7fc5e43e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="ecdf8da8-064e-4a82-b7c6-b9c74e7160a9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="278f5025-9008-4efd-b3fd-8e9a2c571b55" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="78c23ae8-d6d8-4525-ac60-b4162ad34787" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="26cf2b3b-ede7-4bc1-a684-f246d269f802" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="88599dc4-7d1a-4de3-97b3-1a32ce5e9b7e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="5aa37a70-13c5-4621-8ccf-423561240334" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="33c691ac-ba0c-42c9-97b8-f22571283d34" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="b6b95f4e-492e-4986-a770-1cf86d8094be" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="e5d86ff5-275b-49a0-bc81-1d8904517f9b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="492c184c-6577-421d-83e4-b122b1f6534e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="7bde167d-0b92-4357-b0e0-615df906cdab" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="65361449-881c-4f34-8f1c-b3aec990f15e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="8d70d6f0-76c2-43ea-9476-93b10f73bfed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="29a76e0f-6591-45fa-96de-7719fe7b4a9c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="cea33f60-e243-4965-b63e-597c8a88d2f9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="9388824a-0969-41ed-a65f-944972aea091" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="a5b25781-7d96-483c-8ea8-95e20603919f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="03240585-ad45-4dac-b760-9754938af626" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="5c954959-f9e2-4f11-a707-3391ee0382ad" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="091433bf-fed1-470e-b06c-cb4b7b972e6e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="e8b916c9-e2cd-4024-b8db-066ec4c977db" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="d40e68a2-8718-4471-ab2a-8edda2509a11" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="3f2955ce-7301-4d16-8632-62450d7586c0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="18072b05-d227-43a5-a03b-e7b5b137f8b0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="419f70e2-5e6a-48a8-930a-d55488701243" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="58745bc6-950b-44fa-a5fe-478985e2ed78" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="f25d9785-df62-4803-9145-764d6ef67308" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="760b0de1-dc3a-4559-a94c-c8cd867189f5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="00c36296-d9c2-4947-9035-214f41a64332" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="4f98e324-0a04-4175-afd5-5d704bc20564" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="0356259c-3cf9-4dbf-8fd3-baffefeb0883" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="47cca6d3-de44-47a4-806d-526a742a8099" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" executionId="879519fd-a94d-4ae5-9173-20591899e52b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="12c93c51-68b3-4578-bd2e-14b15f688d77" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="31091b52-79e0-488f-a271-f704c0430d89" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="f33041be-df5f-457c-8e78-b671ef333130" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="765922f5-5658-4a15-96de-d06a70063d76" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="ea8121e6-4daa-4421-b440-d02288bef8ef" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <TestLists>
     <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <ResultSummary outcome="Failed">
-    <Counters total="35" executed="25" passed="17" failed="8" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="36" executed="26" passed="18" failed="8" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
     <Output>
       <StdOut>Test 'IgnoredAddingTwoNumbers' was skipped in the test run.Test 'NotAutomatedAddingTwoNumbers' was skipped in the test run.Test 'NotAutomatedScenario1' was skipped in the test run.Test 'NotAutomatedScenario2' was skipped in the test run.Test 'NotAutomatedScenario3' was skipped in the test run.Test 'ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1' was skipped in the test run.Test 'AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1' was skipped in the test run.Test 'AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2' was skipped in the test run.Test 'FailingFeatureInconclusiveScenario' was skipped in the test run.Test 'InconclusiveFeatureInconclusiveScenario' was skipped in the test run.</StdOut>
     </Output>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/WhenParsingxUnitResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/WhenParsingxUnitResultsFile.cs
@@ -77,6 +77,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.XUnit.XUnit1
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadNotFoundFeatureCorrectly()
         {
             base.ThenCanReadNotFoundFeatureCorrectly();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
@@ -1,4 +1,4 @@
-<assembly name="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-02-26" run-time="13:29:26" configFile="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.288" total="35" passed="17" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.257" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.146"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
+<assembly name="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-02-29" run-time="13:31:14" configFile="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.334" total="35" passed="17" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.278" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.182"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
 -&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
@@ -19,31 +19,7 @@ Then the result should be 3.2 on the screen
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.014"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
-Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
-And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
-And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
-Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
-Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
-And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
-And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
-Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
+   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.014"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
 -&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
@@ -53,7 +29,7 @@ When I press add
 -&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
 -&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.078"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.081"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
 -&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -109,7 +85,31 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 46</stack-trace></failure></test></class><class time="0.019" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.016"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 46</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 60 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+And I have entered 130 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 260 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 40 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+And I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+And I have entered 90 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 180 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
+</output></test></class><class time="0.020" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.017"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -203,7 +203,7 @@ Then the result should be 120 on the screen
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.014" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.015" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -265,7 +265,7 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -327,7 +327,7 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -389,11 +389,46 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test></class><class time="0.012" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="17" passed="11" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test></class><class time="0.014" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="17" passed="11" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
+-&gt; error: 
+    true
+        should be
+    False
+        but was
+    True
+</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
+    true
+        should be
+    False
+        but was
+    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
+-&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
+  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
@@ -403,7 +438,7 @@ namespace MyNamespace
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -443,52 +478,15 @@ namespace MyNamespace
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
--&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example an 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_2'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_3'
 -&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
--&gt; error: 
-    true
-        should be
-    False
-        but was
-    True
-</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    true
-        should be
-    False
-        but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example a 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
-</output></test></class><class time="0.004" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+</output></test></class><class time="0.005" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
 -&gt; error: 
     true
         should be
@@ -508,7 +506,9 @@ namespace MyNamespace
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
@@ -520,6 +520,6 @@ namespace MyNamespace
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.000" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
+   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
 -&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
 </output></test></class></assembly>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
@@ -1,5 +1,60 @@
-<assembly name="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-02-21" run-time="10:22:56" configFile="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.315" total="34" passed="16" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.278" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.220"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+<assembly name="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-02-26" run-time="13:29:26" configFile="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.288" total="35" passed="17" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.257" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.146"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 1 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+And I have entered 2.2 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 3.2 on the screen
+-&gt; error: Input string was not in a correct format.
+</output><failure exception-type="System.FormatException"><message>System.FormatException : Input string was not in a correct format.</message><stack-trace>   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
+   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   at System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
+   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.014"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 60 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+And I have entered 130 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 260 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 40 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+And I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+And I have entered 90 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 180 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 1 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+And I have entered 2 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 3 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.078"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -53,63 +108,8 @@ namespace MyNamespace
     }
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Addition.feature:line 46</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.036"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
-And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
-And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
-And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
-And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
-And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
-And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 3.2 on the screen
--&gt; error: Input string was not in a correct format.
-</output><failure exception-type="System.FormatException"><message>System.FormatException : Input string was not in a correct format.</message><stack-trace>   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Addition.feature:line 34</stack-trace></failure></test></class><class time="0.022" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.018"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 46</stack-trace></failure></test></class><class time="0.019" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.016"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -135,13 +135,13 @@ Then the result should be 260 on the screen
         but was
     1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -167,13 +167,13 @@ Then the result should be 180 on the screen
         but was
     1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -197,13 +197,13 @@ Then the result should be 120 on the screen
         but was
     1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.015" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.014" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -264,8 +264,8 @@ namespace MyNamespace
     }
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -326,8 +326,8 @@ namespace MyNamespace
     }
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -388,54 +388,22 @@ namespace MyNamespace
     }
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test></class><class time="0.013" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="16" passed="10" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
--&gt; error: 
-    true
-        should be
-    False
-        but was
-    True
-</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    true
-        should be
-    False
-        but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test></class><class time="0.012" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="17" passed="11" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -449,13 +417,13 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
 -&gt; error: 
     true
         should be
@@ -469,22 +437,34 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test></class><class time="0.004" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_3'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -498,26 +478,48 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example a 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+</output></test></class><class time="0.004" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+-&gt; error: 
+    true
+        should be
+    False
+        but was
+    True
+</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
+    true
+        should be
+    False
+        but was
+    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 7</stack-trace></failure></test></class><class time="0.002" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
-</output></test></class><class time="0.000" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
+   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.000" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
 </output></test></class></assembly>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/WhenParsingxUnit2ResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/WhenParsingxUnit2ResultsFile.cs
@@ -77,6 +77,12 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.XUnit.XUnit2
         }
 
         [Test]
+        public new void ThenCanReadResultsWithParenthesis()
+        {
+            base.ThenCanReadResultsWithParenthesis();
+        }
+
+        [Test]
         public new void ThenCanReadNotFoundFeatureCorrectly()
         {
             base.ThenCanReadNotFoundFeatureCorrectly();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
@@ -1,47 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assemblies>
-  <assembly name="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-02-21" run-time="10:22:58" config-file="C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="34" passed="16" failed="17" skipped="1" time="1.127" errors="0">
+  <assembly name="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-02-26" run-time="13:29:28" config-file="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="35" passed="17" failed="17" skipped="1" time="0.856" errors="0">
     <errors />
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.060">
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.0224075" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 2" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0189694" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 3" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0184713" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 1" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.081">
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0596817" result="Fail">
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.053">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0445548" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
@@ -50,16 +12,16 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0115231" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0042403" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
@@ -68,16 +30,16 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.009767" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0037837" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Add two numbers" />
@@ -86,24 +48,62 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 12]]></stack-trace>
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 12]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.075">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0019403" result="Pass">
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.159">
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.1398261" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 2" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0075895" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 3" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0116133" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 1" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.006">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0009095" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Passing Scenario" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0702029" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0027045" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Failing Scenario" />
@@ -112,16 +112,16 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0028391" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0019517" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Inconclusive Scenario" />
@@ -129,25 +129,203 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.183">
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0234495" result="Pass">
+    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.002">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0010552" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0014186" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="17" passed="11" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.024">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0018572" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0002555" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0002094" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0005397" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003004" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0058828" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0006903" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0003485" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0044662" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0005238" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0002158" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.001111" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0012502" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0023023" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0024831" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0010594" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with parenthesis in the examples" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0008607" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with backslashes in the examples" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.017">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0057168" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0125925" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0017217" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0989061" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0046547" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Not automated adding two numbers" />
@@ -155,11 +333,11 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Addition.feature:line 46]]></stack-trace>
+   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature:line 46]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0219758" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0012341" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Add two numbers" />
@@ -172,7 +350,7 @@
         </traits>
         <reason><![CDATA[Ignored]]></reason>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0259153" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0032419" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Fail to add two numbers" />
@@ -189,188 +367,16 @@
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Addition.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature:line 34]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.002">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0023467" result="Pass">
+    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.088">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0878331" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Passing" />
           <trait name="Description" value="Passing Feature Passing Scenario" />
-        </traits>
-      </test>
-    </collection>
-    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.145">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.1256481" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0192484" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="16" passed="10" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.062">
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.004971" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0019923" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0018772" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0023929" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0018778" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0035421" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.002466" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0016376" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0032505" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0023149" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0019041" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0043035" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0100798" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0073942" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0050714" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Dev\Code\GitHub\DirkRombauts\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0065494" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="Deal correctly with backslashes in the examples" />
         </traits>
       </test>
     </collection>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assemblies>
-  <assembly name="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-02-26" run-time="13:29:28" config-file="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="35" passed="17" failed="17" skipped="1" time="0.856" errors="0">
+  <assembly name="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-02-29" run-time="13:31:15" config-file="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="35" passed="17" failed="17" skipped="1" time="0.922" errors="0">
     <errors />
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.053">
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0445548" result="Fail">
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.097">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0858221" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
@@ -21,7 +21,7 @@
    at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0042403" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0067753" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
@@ -39,7 +39,7 @@
    at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0037837" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0048399" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Add two numbers" />
@@ -58,274 +58,20 @@
         </failure>
       </test>
     </collection>
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.159">
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.1398261" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 2" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0075895" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 3" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0116133" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 1" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.006">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0009095" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0027045" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Failing Scenario" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0019517" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.002">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0010552" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0014186" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="17" passed="11" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.024">
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0018572" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0002555" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0002094" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0005397" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003004" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0058828" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0006903" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0003485" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0044662" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0005238" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0002158" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.001111" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0012502" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0023023" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0024831" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0010594" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="Deal correctly with parenthesis in the examples" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0008607" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="Deal correctly with backslashes in the examples" />
-        </traits>
-      </test>
-    </collection>
-    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.017">
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0057168" result="Pass">
+    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.021">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.006154" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0017217" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0019932" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0046547" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0066196" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Not automated adding two numbers" />
@@ -337,7 +83,7 @@
    at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature:line 46]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0012341" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0020522" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Add two numbers" />
@@ -350,7 +96,7 @@
         </traits>
         <reason><![CDATA[Ignored]]></reason>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0032419" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0038321" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Fail to add two numbers" />
@@ -372,8 +118,262 @@
         </failure>
       </test>
     </collection>
-    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.088">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0878331" result="Pass">
+    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.004">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0012419" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0025451" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="17" passed="11" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.033">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0038048" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0004233" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0005659" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0005764" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003229" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0070835" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0006553" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0003766" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0073032" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0007401" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0005" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0015254" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0016901" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0026199" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0026273" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0014107" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with parenthesis in the examples" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0009254" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with backslashes in the examples" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.006">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.001077" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0031601" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Failing Scenario" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0019713" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.102">
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.0862641" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 2" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.007645" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 3" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0080992" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 1" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.124">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.1237773" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Passing" />
           <trait name="Description" value="Passing Feature Passing Scenario" />

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
@@ -34,7 +34,11 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit
 
             foreach (string value in row)
             {
-                stringBuilder.AppendFormat("\"{0}\",", value.ToLowerInvariant().Replace(@"\", string.Empty).Replace(@"$", @"\$"));
+                stringBuilder.AppendFormat("\"{0}\",", value.ToLowerInvariant()
+                    .Replace(@"\", string.Empty)
+                    .Replace(@"$", @"\$")
+                    .Replace(@"(", @"\(")
+                    .Replace(@")", @"\)"));
             }
 
             stringBuilder.Remove(stringBuilder.Length - 1, 1);

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
@@ -35,8 +35,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit
             foreach (string value in row)
             {
                 stringBuilder.AppendFormat("\"{0}\",", value.ToLowerInvariant()
-                    .Replace(@"\", string.Empty)
-                    .Replace(@"$", @"\$")
+                    .Replace(@"\", string.Empty).Replace(@"$", @"\$")
                     .Replace(@"(", @"\(")
                     .Replace(@")", @"\)"));
             }

--- a/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestScenarioOutlineExampleMatcher.cs
+++ b/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestScenarioOutlineExampleMatcher.cs
@@ -31,7 +31,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.VsTest
         {
             var element = (XElement)scenarioElement;
 
-            var isMatch = element.Name().ToUpperInvariant().EndsWith(exampleValues[0].Replace(":", "").Replace("\\", "").ToUpperInvariant());
+            var isMatch = element.Name().ToUpperInvariant()
+                .EndsWith(
+                    exampleValues[0]
+                        .Replace(" ", string.Empty)
+                        .Replace(":", string.Empty)
+                        .Replace("\\", string.Empty)
+                        .Replace("(", string.Empty)
+                        .Replace(")", string.Empty)
+                        .ToUpperInvariant()
+                );
+
             return isMatch;
         }
     }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
@@ -35,7 +35,11 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit
 
             foreach (string value in row)
             {
-                stringBuilder.AppendFormat("(.*): \"{0}\", ", value.ToLowerInvariant().Replace(@"\", string.Empty).Replace(@"$", @"\$"));
+                stringBuilder.AppendFormat("(.*): \"{0}\", ", value.ToLowerInvariant()
+                    .Replace(@"\", string.Empty)
+                    .Replace(@"$", @"\$")
+                    .Replace(@"(", @"\(")
+                    .Replace(@")", @"\)"));
             }
 
             stringBuilder.Remove(stringBuilder.Length - 2, 2);


### PR DESCRIPTION
We found an issue when the scenario outline examples included `()` characters the Regex match did not work correctly, and the scenario was flagged as inconclusive.  Adding some `\` escaping fixed the issue.