### PR TITLE
Ensure description of feature is never null

### DIFF
--- a/src/Pickles/Pickles.Test/ObjectModel/MapperTestsForFeature.cs
+++ b/src/Pickles/Pickles.Test/ObjectModel/MapperTestsForFeature.cs
@@ -102,5 +102,17 @@ namespace PicklesDoc.Pickles.Test.ObjectModel
 
             Check.That(result.Tags).ContainsExactly("my tag 1", "my tag 2");
         }
+
+        [Test]
+        public void MapToFeature_FeatureWithNullDescription_ReturnsFeatureWithEmptyDescription()
+        {
+            var feature = this.factory.CreateFeature("My Feature", null);
+
+            var mapper = this.factory.CreateMapper();
+
+            var result = mapper.MapToFeature(feature);
+
+            Check.That(result.Description).Equals(string.Empty);
+        }
     }
 }

--- a/src/Pickles/Pickles/ObjectModel/Mapper.cs
+++ b/src/Pickles/Pickles/ObjectModel/Mapper.cs
@@ -96,6 +96,7 @@ namespace PicklesDoc.Pickles.ObjectModel
 
             configurationStore.CreateMap<G.Feature, Feature>()
                 .ForMember(t => t.FeatureElements, opt => opt.ResolveUsing(s => s.ScenarioDefinitions))
+                .ForMember(t => t.Description, opt => opt.NullSubstitute(string.Empty))
                 .AfterMap(
                     (sourceFeature, targetFeature) =>
                         {


### PR DESCRIPTION
Having a feature without a description crashes documentation generation to word and excel format.