### PR TITLE
SpecFlow conformant name mapping 

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenDeterminingTheSignatureOfAnNUnitExampleRow.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenDeterminingTheSignatureOfAnNUnitExampleRow.cs
@@ -48,5 +48,18 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit2
             var isMatch = signature.IsMatch("Pickles.TestHarness.AdditionFeature.AddingSeveralNumbers(\"40\",\"50\",\"90\",System.String[])".ToLowerInvariant());
             Check.That(isMatch).IsTrue();
         }
+
+        [Test]
+        public void ThenCanSuccessfullyMatchSpecialCharacters()
+        {
+            var scenarioOutline = new ScenarioOutline { Name = "Adding several numbers (foo-bar, foo bar)" };
+            var exampleRow = new[] { "40", "50", "90" };
+
+            var signatureBuilder = new NUnitExampleSignatureBuilder();
+            Regex signature = signatureBuilder.Build(scenarioOutline, exampleRow);
+
+            var isMatch = signature.IsMatch("Pickles.TestHarness.AdditionFeature.AddingSeveralNumbersFoo_BarFooBar(\"40\",\"50\",\"90\",System.String[])".ToLowerInvariant());
+            Check.That(isMatch).IsTrue();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenDeterminingTheSignatureOfAnNunit3ExampleRow.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenDeterminingTheSignatureOfAnNunit3ExampleRow.cs
@@ -48,5 +48,18 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit3
             var isMatch = signature.IsMatch("AddingSeveralNumbers(\"40\",\"50\",\"90\",System.String[])".ToLowerInvariant());
             Check.That(isMatch).IsTrue();
         }
+
+        [Test]
+        public void ThenCanSuccessfullyMatchSpecialCharacters()
+        {
+            var scenarioOutline = new ScenarioOutline { Name = "Adding several numbers (foo-bar, foo bar)" };
+            var exampleRow = new[] { "40", "50", "90" };
+
+            var signatureBuilder = new NUnitExampleSignatureBuilder();
+            Regex signature = signatureBuilder.Build(scenarioOutline, exampleRow);
+
+            var isMatch = signature.IsMatch("AddingSeveralNumbersFoo_BarFooBar(\"40\",\"50\",\"90\",System.String[])".ToLowerInvariant());
+            Check.That(isMatch).IsTrue();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
@@ -27,10 +27,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit
 {
     public class NUnitExampleSignatureBuilder
     {
+        private static readonly Regex PunctuationCharactersRegex = new Regex(@"[\n\.-]+", RegexOptions.Compiled);
+        private static readonly Regex NonIdentifierCharacterRegex = new Regex(@"[^\p{Ll}\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}\p{Pc}]", RegexOptions.Compiled);
+
         public Regex Build(ScenarioOutline scenarioOutline, string[] row)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(scenarioOutline.Name.ToLowerInvariant().Replace(" ", string.Empty) + "\\(");
+
+            var name = scenarioOutline.Name.ToLowerInvariant();
+            name = PunctuationCharactersRegex.Replace(name, "_");
+            name = NonIdentifierCharacterRegex.Replace(name, string.Empty);
+            stringBuilder.Append(name).Append("\\(");
 
             foreach (string value in row)
             {


### PR DESCRIPTION
The name mapping of the nunit signature builder fails on presence of special characters (e.g. comma, hyphen).
Added the same regular expression translation steps as used by the SpecFlow code generator along with a unit test for the matching.