### PR TITLE
Added hyphen to underscore Replace to ScenarioNames

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
+++ b/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
@@ -143,7 +143,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.VsTest
 
         private static string TransformName(string name)
         {
-            return name.Replace(" ", "").Replace(".", "_").ToUpperInvariant();
+            return name.Replace(" ", "").Replace(".", "_").Replace("-", "_").ToUpperInvariant();
         }
     }
 }


### PR DESCRIPTION
Pickles will fail when the Feature/Scenario Name has a hyphen '-' in the name
and there are test results. Changing the hyphens to Underscores to match
the test results solves this.