### PR TITLE
Scenarios with special characters

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromJSResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromJSResultsFile.cs
@@ -135,5 +135,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.CucumberJson
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromRubyResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/WhenParsingCucumberJsonFromRubyResultsFile.cs
@@ -135,5 +135,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.CucumberJson
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-cucumberjs-json.json
@@ -5,7 +5,7 @@
     "description": "In order to avoid silly mistakes\r\nAs a math idiot\r\nI want to be told the sum of two numbers",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Addition.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/Addition.feature",
     "elements": [
       {
         "name": "",
@@ -41,9 +41,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 699285
+              "duration": 19430688
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 60 into the calculator",
@@ -51,9 +53,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 367430
+              "duration": 1440123
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 70 into the calculator",
@@ -61,9 +65,11 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 48668
+              "duration": 267312
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 130 into the calculator",
@@ -71,9 +77,11 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 48952
+              "duration": 224858
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -81,9 +89,11 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 151412
+              "duration": 526225
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 260 on the screen",
@@ -91,9 +101,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 97906
+              "duration": 435256
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -117,9 +129,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 75706
+              "duration": 308830
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 40 into the calculator",
@@ -127,9 +141,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 40414
+              "duration": 232789
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 50 into the calculator",
@@ -137,9 +153,11 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 37284
+              "duration": 229523
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 90 into the calculator",
@@ -147,9 +165,11 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 58060
+              "duration": 220660
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -157,9 +177,11 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 198942
+              "duration": 318628
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 180 on the screen",
@@ -167,9 +189,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 48099
+              "duration": 248185
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -193,9 +217,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 53506
+              "duration": 156282
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 1 into the calculator",
@@ -203,9 +229,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 40415
+              "duration": 125026
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 2 into the calculator",
@@ -213,9 +241,11 @@
             "keyword": "And ",
             "result": {
               "status": "passed",
-              "duration": 36999
+              "duration": 133423
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -223,9 +253,11 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 39845
+              "duration": 118961
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 3 on the screen",
@@ -233,9 +265,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 37853
+              "duration": 125025
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -259,9 +293,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 48668
+              "duration": 2251386
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 1 into the calculator",
@@ -269,9 +305,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 36430
+              "duration": 134356
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 2.2 into the calculator",
@@ -279,8 +317,7 @@
             "keyword": "And ",
             "result": {
               "status": "ambiguous"
-            },
-            "match": {}
+            }
           },
           {
             "name": "I press add",
@@ -289,7 +326,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 3.2 on the screen",
@@ -298,7 +337,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -316,9 +357,11 @@
             "keyword": "Given ",
             "result": {
               "status": "passed",
-              "duration": 76845
+              "duration": 193603
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "unimplemented step",
@@ -326,8 +369,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -335,8 +377,7 @@
             "keyword": "When ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -344,8 +385,7 @@
             "keyword": "Then ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           }
         ]
       }
@@ -357,7 +397,7 @@
     "description": "This feature has a failing background.",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/FailingBackground.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/FailingBackground.feature",
     "elements": [
       {
         "name": "",
@@ -392,10 +432,12 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 1630811,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 1713498,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:35"
+            }
           },
           {
             "name": "the calculator has clean memory",
@@ -404,7 +446,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 50 into the calculator",
@@ -413,7 +457,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 70 into the calculator",
@@ -422,7 +468,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -431,7 +479,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 120 on the screen",
@@ -440,7 +490,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -458,10 +510,12 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 383654,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 309297,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:35"
+            }
           },
           {
             "name": "the calculator has clean memory",
@@ -470,7 +524,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 60 into the calculator",
@@ -479,7 +535,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 70 into the calculator",
@@ -488,7 +546,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 130 into the calculator",
@@ -497,7 +557,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -506,7 +568,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 260 on the screen",
@@ -515,7 +579,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       },
@@ -533,10 +599,12 @@
             "keyword": "Given ",
             "result": {
               "status": "failed",
-              "duration": 346939,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 171209,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:36:13)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:35"
+            }
           },
           {
             "name": "the calculator has clean memory",
@@ -545,7 +613,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
           },
           {
             "name": "I have entered 40 into the calculator",
@@ -554,7 +624,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 50 into the calculator",
@@ -563,7 +635,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I have entered 90 into the calculator",
@@ -572,7 +646,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
           },
           {
             "name": "I press add",
@@ -581,7 +657,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
           },
           {
             "name": "the result should be 180 on the screen",
@@ -590,7 +668,9 @@
             "result": {
               "status": "skipped"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
           }
         ]
       }
@@ -602,7 +682,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Failing.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Failing.feature",
     "elements": [
       {
         "name": "Failing Feature Passing Scenario",
@@ -618,9 +698,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 120390
+              "duration": 208997
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:7"
+            }
           }
         ]
       },
@@ -639,7 +721,9 @@
             "result": {
               "status": "pending"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:12"
+            }
           }
         ]
       },
@@ -657,10 +741,12 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 223418,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 197801,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:17"
+            }
           }
         ]
       }
@@ -672,7 +758,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Inconclusive.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Inconclusive.feature",
     "elements": [
       {
         "name": "Inconclusive Feature Passing Scenario",
@@ -688,9 +774,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 44114
+              "duration": 190803
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:7"
+            }
           }
         ]
       },
@@ -709,7 +797,9 @@
             "result": {
               "status": "pending"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:12"
+            }
           }
         ]
       }
@@ -721,7 +811,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Passing.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/Minimal Features/Passing.feature",
     "elements": [
       {
         "name": "Passing Feature Passing Scenario",
@@ -737,9 +827,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 60622
+              "duration": 121760
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\MinimalSteps.js:7"
+            }
           }
         ]
       }
@@ -751,7 +843,7 @@
     "description": "",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/NotAutomatedAtAll.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/NotAutomatedAtAll.feature",
     "elements": [
       {
         "name": "",
@@ -781,8 +873,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -790,8 +881,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -799,8 +889,7 @@
             "keyword": "When ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -808,8 +897,7 @@
             "keyword": "Then ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           }
         ]
       },
@@ -827,8 +915,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -836,8 +923,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -845,8 +931,7 @@
             "keyword": "When ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -854,8 +939,7 @@
             "keyword": "Then ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           }
         ]
       },
@@ -873,8 +957,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -882,8 +965,7 @@
             "keyword": "Given ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -891,8 +973,7 @@
             "keyword": "When ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           },
           {
             "name": "unimplemented step",
@@ -900,8 +981,7 @@
             "keyword": "Then ",
             "result": {
               "status": "undefined"
-            },
-            "match": {}
+            }
           }
         ]
       }
@@ -913,7 +993,7 @@
     "description": "Here we demonstrate how we deal with scenario outlines",
     "line": 1,
     "keyword": "Feature",
-    "uri": "C:/src/pickles-testresults/TestHarness/CucumberJS/features/ScenarioOutlines.feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/ScenarioOutlines.feature",
     "elements": [
       {
         "name": "This is a scenario outline where all scenarios pass",
@@ -929,9 +1009,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 96482
+              "duration": 210397
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -949,9 +1031,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 36145
+              "duration": 107297
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -969,9 +1053,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 33583
+              "duration": 113362
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -989,9 +1075,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 34437
+              "duration": 116629
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1009,9 +1097,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 45538
+              "duration": 122693
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1030,7 +1120,9 @@
             "result": {
               "status": "pending"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:12"
+            }
           }
         ]
       },
@@ -1048,9 +1140,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 39845
+              "duration": 102633
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1068,9 +1162,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 36430
+              "duration": 101233
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1088,10 +1184,12 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 287740,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 279907,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:17"
+            }
           }
         ]
       },
@@ -1109,9 +1207,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 37853
+              "duration": 125025
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1129,9 +1229,11 @@
             "keyword": "Then ",
             "result": {
               "status": "passed",
-              "duration": 36430
+              "duration": 104033
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       },
@@ -1150,7 +1252,9 @@
             "result": {
               "status": "pending"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:12"
+            }
           }
         ]
       },
@@ -1169,7 +1273,9 @@
             "result": {
               "status": "pending"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:12"
+            }
           }
         ]
       },
@@ -1187,10 +1293,12 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 499489,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 167944,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:17"
+            }
           }
         ]
       },
@@ -1208,10 +1316,12 @@
             "keyword": "Then ",
             "result": {
               "status": "failed",
-              "duration": 353200,
-              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (C:\\src\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at process._tickCallback (node.js:355:11)\n    at Function.Module.runMain (module.js:503:11)\n    at startup (node.js:129:16)\n    at node.js:814:3"
+              "duration": 178674,
+              "error_message": "AssertionError: 'true' == 'false'\n    at World.<anonymous> (D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:18:12)\n    at nextTickCallbackWith0Args (node.js:420:9)\n    at process._tickCallback (node.js:349:13)\n    at Function.Module.runMain (module.js:443:11)\n    at startup (node.js:139:18)"
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:17"
+            }
           }
         ]
       },
@@ -1229,9 +1339,11 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 142020
+              "duration": 188005
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:22"
+            }
           }
         ]
       },
@@ -1249,9 +1361,139 @@
             "keyword": "When ",
             "result": {
               "status": "passed",
-              "duration": 78837
+              "duration": 147418
             },
-            "match": {}
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:27"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "Scenarios-With-Special-Characters",
+    "name": "Scenarios With Special Characters",
+    "description": "Here we demonstrate usage of special characters in scenario names",
+    "line": 1,
+    "keyword": "Feature",
+    "uri": "D:/Work/pickles-testresults/TestHarness/CucumberJS/features/ScenariosWithSpecialCharacters.feature",
+    "elements": [
+      {
+        "name": "",
+        "keyword": "Background",
+        "description": "",
+        "type": "background",
+        "line": 4,
+        "steps": [
+          {
+            "name": "the calculator has clean memory",
+            "line": 5,
+            "keyword": "Given "
+          }
+        ]
+      },
+      {
+        "name": "This is a scenario with parentheses, hyphen and comma (10-20, 30-40)",
+        "id": "Scenarios-With-Special-Characters;this-is-a-scenario-with-parentheses,-hyphen-and-comma-(10-20,-30-40)",
+        "line": 7,
+        "keyword": "Scenario",
+        "description": "",
+        "type": "scenario",
+        "steps": [
+          {
+            "name": "the calculator has clean memory",
+            "line": 5,
+            "keyword": "Given ",
+            "result": {
+              "status": "passed",
+              "duration": 198267
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
+          },
+          {
+            "name": "I have entered 50 into the calculator",
+            "line": 8,
+            "keyword": "Given ",
+            "result": {
+              "status": "passed",
+              "duration": 118494
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
+          },
+          {
+            "name": "I have entered 70 into the calculator",
+            "line": 9,
+            "keyword": "And ",
+            "result": {
+              "status": "passed",
+              "duration": 102166
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:15"
+            }
+          },
+          {
+            "name": "I press add",
+            "line": 10,
+            "keyword": "When ",
+            "result": {
+              "status": "passed",
+              "duration": 112430
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:25"
+            }
+          },
+          {
+            "name": "the result should be 120 on the screen",
+            "line": 11,
+            "keyword": "Then ",
+            "result": {
+              "status": "passed",
+              "duration": 100767
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:30"
+            }
+          }
+        ]
+      },
+      {
+        "name": "This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)",
+        "id": "Scenarios-With-Special-Characters;this-is-a-scenario-outline-with-parentheses,-hyphen-and-comma-(10-20,-30-40)",
+        "line": 19,
+        "keyword": "Scenario",
+        "description": "",
+        "type": "scenario",
+        "steps": [
+          {
+            "name": "the calculator has clean memory",
+            "line": 5,
+            "keyword": "Given ",
+            "result": {
+              "status": "passed",
+              "duration": 149284
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\AdditionSteps.js:10"
+            }
+          },
+          {
+            "name": "the scenario will 'pass_1'",
+            "line": 15,
+            "keyword": "Then ",
+            "result": {
+              "status": "passed",
+              "duration": 106364
+            },
+            "match": {
+              "location": "D:\\Work\\pickles-testresults\\TestHarness\\CucumberJS\\features\\stepdefinitions\\ScenarioOutlineSteps.js:7"
+            }
           }
         ]
       }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/CucumberJson/results-example-json.json
@@ -99,7 +99,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 1000000
+              "duration": 38622000
             }
           }
         ]
@@ -330,7 +330,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 0
+              "duration": 500000
             }
           },
           {
@@ -343,7 +343,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"fail\"\n     got: \"this is a hacky way of making the scenario with a non-integer number\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/AdditionSteps.rb:11:in `/^I have entered (\\d+)\\.(\\d+) into the calculator$/'\nfeatures/Addition.feature:32:in `And I have entered 2.2 into the calculator'",
-              "duration": 15003000
+              "duration": 226570000
             }
           },
           {
@@ -800,7 +800,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"false\"\n     got: \"true\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/MinimalSteps.rb:10:in `/^failing step$/'\nfeatures/Minimal Features/Failing.feature:10:in `Then failing step'",
-              "duration": 0
+              "duration": 501000
             }
           }
         ]
@@ -1162,7 +1162,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 1011000
+              "duration": 0
             }
           }
         ]
@@ -1229,7 +1229,7 @@
             "result": {
               "status": "pending",
               "error_message": "TODO (Cucumber::Pending)\n./features/step_definitions/ScenarioOutlineSteps.rb:6:in `/^the scenario will 'inconclusive_(\\d+)'$/'\nfeatures/ScenarioOutlines.feature:27:in `Then the scenario will 'inconclusive_1''\nfeatures/ScenarioOutlines.feature:21:in `Then the scenario will '<result>''",
-              "duration": 994000
+              "duration": 500000
             }
           }
         ]
@@ -1296,7 +1296,7 @@
             "result": {
               "status": "failed",
               "error_message": "\nexpected: \"false\"\n     got: \"true\"\n\n(compared using eql?)\n (RSpec::Expectations::ExpectationNotMetError)\n./features/step_definitions/ScenarioOutlineSteps.rb:10:in `/^the scenario will 'fail_(\\d+)'$/'\nfeatures/ScenarioOutlines.feature:40:in `Then the scenario will 'fail_1''\nfeatures/ScenarioOutlines.feature:34:in `Then the scenario will '<result>''",
-              "duration": 0
+              "duration": 500000
             }
           }
         ]
@@ -1340,7 +1340,7 @@
             },
             "result": {
               "status": "passed",
-              "duration": 1000000
+              "duration": 0
             }
           }
         ]
@@ -1473,6 +1473,138 @@
             "line": 78,
             "match": {
               "location": "features/step_definitions/ScenarioOutlineSteps.rb:17"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "uri": "features/ScenariosWithSpecialCharacters.feature",
+    "id": "scenarios-with-special-characters",
+    "keyword": "Feature",
+    "name": "Scenarios With Special Characters",
+    "description": "  Here we demonstrate usage of special characters in scenario names",
+    "line": 1,
+    "elements": [
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 4,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "the calculator has clean memory",
+            "line": 5,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          }
+        ]
+      },
+      {
+        "id": "scenarios-with-special-characters;this-is-a-scenario-with-parentheses,-hyphen-and-comma-(10-20,-30-40)",
+        "keyword": "Scenario",
+        "name": "This is a scenario with parentheses, hyphen and comma (10-20, 30-40)",
+        "description": "",
+        "line": 7,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "I have entered 50 into the calculator",
+            "line": 8,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:6"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          },
+          {
+            "keyword": "And ",
+            "name": "I have entered 70 into the calculator",
+            "line": 9,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:6"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          },
+          {
+            "keyword": "When ",
+            "name": "I press add",
+            "line": 10,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:14"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          },
+          {
+            "keyword": "Then ",
+            "name": "the result should be 120 on the screen",
+            "line": 11,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:20"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          }
+        ]
+      },
+      {
+        "keyword": "Background",
+        "name": "",
+        "description": "",
+        "line": 4,
+        "type": "background",
+        "steps": [
+          {
+            "keyword": "Given ",
+            "name": "the calculator has clean memory",
+            "line": 5,
+            "match": {
+              "location": "features/step_definitions/AdditionSteps.rb:1"
+            },
+            "result": {
+              "status": "passed",
+              "duration": 0
+            }
+          }
+        ]
+      },
+      {
+        "id": "scenarios-with-special-characters;this-is-a-scenario-outline-with-parentheses,-hyphen-and-comma-(10-20,-30-40);;2",
+        "keyword": "Scenario Outline",
+        "name": "This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)",
+        "description": "",
+        "line": 19,
+        "type": "scenario",
+        "steps": [
+          {
+            "keyword": "Then ",
+            "name": "the scenario will 'pass_1'",
+            "line": 19,
+            "match": {
+              "location": "features/step_definitions/ScenarioOutlineSteps.rb:1"
             },
             "result": {
               "status": "passed",

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/WhenParsingMsTestResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/WhenParsingMsTestResultsFile.cs
@@ -141,5 +141,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.MsTest
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="8b057389-ab82-44cd-869d-cd4fea1405c3" name="ocsur@DESKTOP-AIFNJPI 2016-02-29 13:31:17" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<TestRun id="9c057346-79a7-40ab-a2c0-ef4445738933" name="Daniel@DANIEL-NOTEBOOK 2016-04-26 00:40:59" runUser="DANIEL-NOTEBOOK\Daniel" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestSettings name="TestSettings" id="3d90c4f8-ccdc-4663-bad3-9f4c55f42318">
     <Description>These are default test settings for a local test run.</Description>
-    <Deployment userDeploymentRoot="C:\src\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-29 13_31_17" />
+    <Deployment userDeploymentRoot="D:\Work\pickles-testresults" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="Daniel_DANIEL-NOTEBOOK 2016-04-26 00_40_59" />
     <Execution>
       <TestTypeSpecific />
       <AgentRule name="Execution Agents">
@@ -10,28 +10,28 @@
     </Execution>
     <Properties />
   </TestSettings>
-  <Times creation="2016-02-29T13:31:17.8508854-05:00" queuing="2016-02-29T13:31:18.1769705-05:00" start="2016-02-29T13:31:18.2649927-05:00" finish="2016-02-29T13:31:18.8281545-05:00" />
+  <Times creation="2016-04-26T00:40:59.5246005+02:00" queuing="2016-04-26T00:41:00.5570129+02:00" start="2016-04-26T00:41:00.7418201+02:00" finish="2016-04-26T00:41:02.6558392+02:00" />
   <ResultSummary outcome="Failed">
-    <Counters total="35" executed="35" passed="18" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="37" executed="37" passed="20" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
   <TestDefinitions>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
+    <UnitTest name="NotAutomatedScenario1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
       <Description>Not automated scenario 1</Description>
-      <Execution id="84b87db1-b1a6-4bd5-8628-48cdde807b27" />
+      <Execution id="19af94e1-f3c1-4656-94bf-380ab3734812" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
+    <UnitTest name="AddingSeveralNumbers_40" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="827b4f24-27de-43dd-9afa-a2659ded2a1c" />
+      <Execution id="a8f782e1-8c94-480c-b3f3-4f5d94d60b0d" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -58,11 +58,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="3d59785c-3405-4625-9544-f7ba5f664fe1" />
+      <Execution id="fd037e82-ee37-4076-8cda-d95ba7da728e" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -77,66 +77,77 @@
           <Value>fail_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
+    <UnitTest name="NotAutomatedScenario3" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
       <Description>Not automated scenario 3</Description>
-      <Execution id="570e9634-242d-41bf-88bf-ea10800527e1" />
+      <Execution id="6dcc8ea9-839b-4536-b416-88d31f85209a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
+    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3fe8806f-fabb-1deb-7e27-c59578f16da3">
+      <Description>This is a scenario with parentheses, hyphen and comma (10-20, 30-40)</Description>
+      <Execution id="23cc5923-00a0-42b4-8560-4cc48e52dbd7" />
+      <Properties>
+        <Property>
+          <Key>FeatureTitle</Key>
+          <Value>Scenarios With Special Characters</Value>
+        </Property>
+      </Properties>
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
+    </UnitTest>
+    <UnitTest name="AddTwoNumbers" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
       <Description>Add two numbers</Description>
-      <Execution id="41b67f13-9fce-438b-a8dc-dbd6388e8934" />
+      <Execution id="9e109765-6ba8-4671-bbb0-61b7fd8370f6" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
       <Description>Failing Feature Inconclusive Scenario</Description>
-      <Execution id="0a75715a-b55a-472c-9ab4-719e75bfc680" />
+      <Execution id="b71d3e94-6baf-4b45-8e37-8682eb5708a9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
       <Description>Inconclusive Feature Inconclusive Scenario</Description>
-      <Execution id="c14a24e4-f357-4e54-bff6-72b4c302dc21" />
+      <Execution id="fdd77e81-b70d-43ac-85ca-a1a99b931b7d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
+    <UnitTest name="FailingFeaturePassingScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
       <Description>Failing Feature Passing Scenario</Description>
-      <Execution id="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" />
+      <Execution id="36830909-a83d-4aef-b65a-d6be05b5d26e" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
       <Description>Deal correctly with backslashes in the examples</Description>
-      <Execution id="2f709cc6-9269-4107-934f-343e4a914966" />
+      <Execution id="e1d2ea77-0fa2-4e58-97e4-829779e1c3ee" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -151,11 +162,11 @@
           <Value>c:\Temp\</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="3727f45e-675e-4c11-93b8-17c0d3a607d8" />
+      <Execution id="6947c394-549d-46f1-85f2-3722e00fc1d1" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -170,11 +181,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="027e534e-d111-4fb7-88d5-2fa8e793fe3d" />
+      <Execution id="3fa9463f-93ff-4a58-b604-a33b510dd230" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -189,14 +200,14 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
+    <UnitTest name="AddingSeveralNumbers_60" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="d933299c-beea-4829-a906-a6de2623b895" />
+      <Execution id="1c120f35-76c8-43dd-9f5b-b5fe273a40e7" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -223,11 +234,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" />
+      <Execution id="473115a5-57b8-4543-ac20-5f0ae9d192ba" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -242,22 +253,22 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
+    <UnitTest name="FailingFeatureFailingScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
       <Description>Failing Feature Failing Scenario</Description>
-      <Execution id="3a186856-41de-4034-b4a8-feade31a112f" />
+      <Execution id="fed7bce5-8a69-4bd7-81ce-95f46d34c0b5" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
       <Description>Deal correctly with parenthesis in the examples</Description>
-      <Execution id="0cdaf90e-7083-4a5c-b98e-f68272057f57" />
+      <Execution id="aa54b9bc-f5b3-415a-892d-7172aaf1ff84" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -272,11 +283,11 @@
           <Value>This is a description (and more)</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="1d5f63e8-3036-4422-92d6-d60ba1ae151b" />
+      <Execution id="fbe09fe8-e01e-4751-8022-e9887c6ce29e" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -291,11 +302,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="17553853-0683-4145-9d61-74031017021a" />
+      <Execution id="cbfb8fb4-fc6d-48d2-be94-4d5226c45b66" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -310,22 +321,22 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
       <Description>Inconclusive Feature Passing Scenario</Description>
-      <Execution id="beda5beb-f73a-4471-94ee-56da009212bb" />
+      <Execution id="881a36b3-69db-4fea-92d0-599325f0ab4e" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="05f537a2-462a-4a54-8a89-c50ee92ee819" />
+      <Execution id="c16dd9f0-0fe2-4086-ab15-6f2738986c5c" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -340,35 +351,54 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
-      <Execution id="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" />
+    <UnitTest name="TestMethod" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
+      <Execution id="d5806c6f-7d40-4973-8674-d8a08b34c8fd" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
+    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="f8369e2e-c5ec-dade-ad85-e2c56909c853">
+      <Description>This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)</Description>
+      <Execution id="214e99b7-3777-4a80-8276-fe2fcee2c389" />
+      <Properties>
+        <Property>
+          <Key>FeatureTitle</Key>
+          <Value>Scenarios With Special Characters</Value>
+        </Property>
+        <Property>
+          <Key>VariantName</Key>
+          <Value>pass_1</Value>
+        </Property>
+        <Property>
+          <Key>Parameter:result</Key>
+          <Value>pass_1</Value>
+        </Property>
+      </Properties>
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
+    </UnitTest>
+    <UnitTest name="AddTwoNumbers" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
       <Description>Add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="2c348320-9cb3-4902-a6f0-e8ce76519fa9" />
+      <Execution id="559d2f7f-a14f-4bdd-a217-3cc4d5d55477" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="31eb3903-2072-4aa5-beb1-aa68da5cef6c" />
+      <Execution id="fbd43871-8867-4393-98ff-267b9055c690" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -383,11 +413,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" />
+      <Execution id="f4b3d175-6e04-45e5-b691-52df64db8ed2" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -402,11 +432,11 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="e7670bb6-9523-4594-9760-d1d941205633" />
+      <Execution id="1e6627d0-d9f2-4773-9682-0d64dc7ef54b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -421,11 +451,11 @@
           <Value>inconclusive_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
+    <UnitTest name="AddingSeveralNumbers_60" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
       <Description>Adding several numbers</Description>
-      <Execution id="65cce851-fe31-4e22-b9db-b45daa8902f4" />
+      <Execution id="2b6fefd5-1336-4aab-b5a3-6f1e21e42889" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -452,22 +482,22 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
+    <UnitTest name="NotAutomatedScenario2" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
       <Description>Not automated scenario 2</Description>
-      <Execution id="40db28a5-6f62-4207-9029-39db08667250" />
+      <Execution id="9a4a9b78-26eb-481c-8eed-89b7437afe25" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="5bc6395d-9425-4db6-be59-68cb956cddb3" />
+      <Execution id="9c13b464-1e41-4429-8312-afe32624883b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -482,11 +512,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" />
+      <Execution id="dd41ac17-4ff2-40a8-bb65-4477c0e0e90a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -501,22 +531,22 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
+    <UnitTest name="PassingFeaturePassingScenario" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
       <Description>Passing Feature Passing Scenario</Description>
-      <Execution id="ee52d898-3893-4b11-aca2-690c962c9094" />
+      <Execution id="a5b9c747-c35c-460f-ae5a-7982e23159b7" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Passing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="ee5409c4-d89a-4640-b17f-b8a1676aae7f" />
+      <Execution id="abe19b91-d119-4034-8975-50ec9f56ccbb" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -531,11 +561,11 @@
           <Value>pass_3</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="4b0b1635-cf18-425b-bb46-0b3d893671fa" />
+      <Execution id="e38ccc75-3056-4bc8-adb2-68400939dea4" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -550,11 +580,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
+    <UnitTest name="AddingSeveralNumbers_40" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
       <Description>Adding several numbers</Description>
-      <Execution id="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" />
+      <Execution id="e6e2138e-44c3-432b-bd23-83a81d115686" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -581,36 +611,36 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
+    <UnitTest name="FailToAddTwoNumbers" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
       <Description>Fail to add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="49085209-3670-430a-b4e1-697177b97fae" />
+      <Execution id="ff7f9def-c426-4b37-8547-5b348030f0d2" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
       <Description>Not automated adding two numbers</Description>
-      <Execution id="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" />
+      <Execution id="d9bf19bd-8cfa-44e1-be14-e10707edf9d8" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\src\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="d:\work\pickles-testresults\\testharness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="478620d9-8754-4ed6-a149-e6a5a812a4b5" />
+      <Execution id="d907562a-915a-4fa4-a8d1-9284d64c6a74" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -625,7 +655,7 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/src/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+      <TestMethod codeBase="D:/Work/pickles-testresults/TestHarness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
   </TestDefinitions>
   <TestLists>
@@ -633,130 +663,132 @@
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <TestEntries>
-    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="827b4f24-27de-43dd-9afa-a2659ded2a1c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="d933299c-beea-4829-a906-a6de2623b895" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="2c348320-9cb3-4902-a6f0-e8ce76519fa9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="49085209-3670-430a-b4e1-697177b97fae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="65cce851-fe31-4e22-b9db-b45daa8902f4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="41b67f13-9fce-438b-a8dc-dbd6388e8934" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="3a186856-41de-4034-b4a8-feade31a112f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="0a75715a-b55a-472c-9ab4-719e75bfc680" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="c14a24e4-f357-4e54-bff6-72b4c302dc21" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="beda5beb-f73a-4471-94ee-56da009212bb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="ee52d898-3893-4b11-aca2-690c962c9094" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="84b87db1-b1a6-4bd5-8628-48cdde807b27" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="40db28a5-6f62-4207-9029-39db08667250" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="570e9634-242d-41bf-88bf-ea10800527e1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="478620d9-8754-4ed6-a149-e6a5a812a4b5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="e7670bb6-9523-4594-9760-d1d941205633" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="027e534e-d111-4fb7-88d5-2fa8e793fe3d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="3d59785c-3405-4625-9544-f7ba5f664fe1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="2f709cc6-9269-4107-934f-343e4a914966" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="0cdaf90e-7083-4a5c-b98e-f68272057f57" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="5bc6395d-9425-4db6-be59-68cb956cddb3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="17553853-0683-4145-9d61-74031017021a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="ee5409c4-d89a-4640-b17f-b8a1676aae7f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="4b0b1635-cf18-425b-bb46-0b3d893671fa" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="3727f45e-675e-4c11-93b8-17c0d3a607d8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="05f537a2-462a-4a54-8a89-c50ee92ee819" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="1d5f63e8-3036-4422-92d6-d60ba1ae151b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="31eb3903-2072-4aa5-beb1-aa68da5cef6c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="a8f782e1-8c94-480c-b3f3-4f5d94d60b0d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="1c120f35-76c8-43dd-9f5b-b5fe273a40e7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="559d2f7f-a14f-4bdd-a217-3cc4d5d55477" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="ff7f9def-c426-4b37-8547-5b348030f0d2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="d9bf19bd-8cfa-44e1-be14-e10707edf9d8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="e6e2138e-44c3-432b-bd23-83a81d115686" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="2b6fefd5-1336-4aab-b5a3-6f1e21e42889" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="9e109765-6ba8-4671-bbb0-61b7fd8370f6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="fed7bce5-8a69-4bd7-81ce-95f46d34c0b5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="b71d3e94-6baf-4b45-8e37-8682eb5708a9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="36830909-a83d-4aef-b65a-d6be05b5d26e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="fdd77e81-b70d-43ac-85ca-a1a99b931b7d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="881a36b3-69db-4fea-92d0-599325f0ab4e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="a5b9c747-c35c-460f-ae5a-7982e23159b7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="19af94e1-f3c1-4656-94bf-380ab3734812" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="9a4a9b78-26eb-481c-8eed-89b7437afe25" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="6dcc8ea9-839b-4536-b416-88d31f85209a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="d5806c6f-7d40-4973-8674-d8a08b34c8fd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="dd41ac17-4ff2-40a8-bb65-4477c0e0e90a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="473115a5-57b8-4543-ac20-5f0ae9d192ba" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="d907562a-915a-4fa4-a8d1-9284d64c6a74" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="1e6627d0-d9f2-4773-9682-0d64dc7ef54b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="3fa9463f-93ff-4a58-b604-a33b510dd230" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="fd037e82-ee37-4076-8cda-d95ba7da728e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="e1d2ea77-0fa2-4e58-97e4-829779e1c3ee" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="aa54b9bc-f5b3-415a-892d-7172aaf1ff84" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="9c13b464-1e41-4429-8312-afe32624883b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="cbfb8fb4-fc6d-48d2-be94-4d5226c45b66" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="abe19b91-d119-4034-8975-50ec9f56ccbb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="f4b3d175-6e04-45e5-b691-52df64db8ed2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="e38ccc75-3056-4bc8-adb2-68400939dea4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="6947c394-549d-46f1-85f2-3722e00fc1d1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="c16dd9f0-0fe2-4086-ab15-6f2738986c5c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="fbe09fe8-e01e-4751-8022-e9887c6ce29e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="fbd43871-8867-4393-98ff-267b9055c690" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" executionId="214e99b7-3777-4a80-8276-fe2fcee2c389" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" executionId="23cc5923-00a0-42b4-8560-4cc48e52dbd7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <Results>
-    <UnitTestResult executionId="827b4f24-27de-43dd-9afa-a2659ded2a1c" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0781946" startTime="2016-02-29T13:31:18.2870112-05:00" endTime="2016-02-29T13:31:18.5750765-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="827b4f24-27de-43dd-9afa-a2659ded2a1c">
+    <UnitTestResult executionId="a8f782e1-8c94-480c-b3f3-4f5d94d60b0d" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.1720155" startTime="2016-04-26T00:41:00.9107702+02:00" endTime="2016-04-26T00:41:01.7886724+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a8f782e1-8c94-480c-b3f3-4f5d94d60b0d">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,1s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d933299c-beea-4829-a906-a6de2623b895" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005919" startTime="2016-02-29T13:31:18.5770861-05:00" endTime="2016-02-29T13:31:18.5800748-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d933299c-beea-4829-a906-a6de2623b895">
+    <UnitTestResult executionId="1c120f35-76c8-43dd-9f5b-b5fe273a40e7" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0004847" startTime="2016-04-26T00:41:01.7926779+02:00" endTime="2016-04-26T00:41:01.7951835+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1c120f35-76c8-43dd-9f5b-b5fe273a40e7">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="2c348320-9cb3-4902-a6f0-e8ce76519fa9" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005692" startTime="2016-02-29T13:31:18.5810749-05:00" endTime="2016-02-29T13:31:18.5850936-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2c348320-9cb3-4902-a6f0-e8ce76519fa9">
+    <UnitTestResult executionId="559d2f7f-a14f-4bdd-a217-3cc4d5d55477" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0004954" startTime="2016-04-26T00:41:01.7986856+02:00" endTime="2016-04-26T00:41:01.8011871+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="559d2f7f-a14f-4bdd-a217-3cc4d5d55477">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="49085209-3670-430a-b4e1-697177b97fae" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0347966" startTime="2016-02-29T13:31:18.5860937-05:00" endTime="2016-02-29T13:31:18.6240959-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="49085209-3670-430a-b4e1-697177b97fae">
+    <UnitTestResult executionId="ff7f9def-c426-4b37-8547-5b348030f0d2" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.1791354" startTime="2016-04-26T00:41:01.8046934+02:00" endTime="2016-04-26T00:41:01.9859412+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ff7f9def-c426-4b37-8547-5b348030f0d2">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3.2 on the screen
--&gt; error: Input string was not in a correct format.</StdOut>
+-&gt; error: Die Eingabezeichenfolge hat das falsche Format.</StdOut>
         <ErrorInfo>
           <Message>Test method Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers threw exception: 
-System.FormatException: Input string was not in a correct format.</Message>
-          <StackTrace>    at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(Type typeToConvertTo, Object value, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(IBindingType typeToConvertTo, Object value, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.Convert(Object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ConvertArg(Object value, IBindingType typeToConvertTo)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.&lt;&gt;c__DisplayClass5.&lt;GetExecuteArguments&gt;b__4(Object arg, Int32 argIndex)
-   at System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
+System.FormatException: Die Eingabezeichenfolge hat das falsche Format.</Message>
+          <StackTrace>    bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
+   bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(Type typeToConvertTo, Object value, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(IBindingType typeToConvertTo, Object value, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.Convert(Object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ConvertArg(Object value, IBindingType typeToConvertTo)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.&lt;&gt;c__DisplayClass5.&lt;GetExecuteArguments&gt;b__4(Object arg, Int32 argIndex)
+   bei System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
+   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature:Zeile 34.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b4b846b0-aafb-4e0b-b82c-b81e74885ed4" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0307554" startTime="2016-02-29T13:31:18.6250860-05:00" endTime="2016-02-29T13:31:18.6570943-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b4b846b0-aafb-4e0b-b82c-b81e74885ed4">
+    <UnitTestResult executionId="d9bf19bd-8cfa-44e1-be14-e10707edf9d8" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.2085406" startTime="2016-04-26T00:41:01.9899471+02:00" endTime="2016-04-26T00:41:02.2003113+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d9bf19bd-8cfa-44e1-be14-e10707edf9d8">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -810,19 +842,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature:Zeile 46.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0098841" startTime="2016-02-29T13:31:18.6580947-05:00" endTime="2016-02-29T13:31:18.6710980-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="08a864ff-1bab-4fda-b9c3-9442a9c5dbc2">
+    <UnitTestResult executionId="e6e2138e-44c3-432b-bd23-83a81d115686" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0986378" startTime="2016-04-26T00:41:02.2318657+02:00" endTime="2016-04-26T00:41:02.3397998+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e6e2138e-44c3-432b-bd23-83a81d115686">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -851,23 +883,23 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 19.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="65cce851-fe31-4e22-b9db-b45daa8902f4" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0019666" startTime="2016-02-29T13:31:18.6721163-05:00" endTime="2016-02-29T13:31:18.6751172-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65cce851-fe31-4e22-b9db-b45daa8902f4">
+    <UnitTestResult executionId="2b6fefd5-1336-4aab-b5a3-6f1e21e42889" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0036611" startTime="2016-04-26T00:41:02.3453139+02:00" endTime="2016-04-26T00:41:02.3533235+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2b6fefd5-1336-4aab-b5a3-6f1e21e42889">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -896,23 +928,23 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 19.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="41b67f13-9fce-438b-a8dc-dbd6388e8934" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022040" startTime="2016-02-29T13:31:18.6760994-05:00" endTime="2016-02-29T13:31:18.6791009-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="41b67f13-9fce-438b-a8dc-dbd6388e8934">
+    <UnitTestResult executionId="9e109765-6ba8-4671-bbb0-61b7fd8370f6" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0026563" startTime="2016-04-26T00:41:02.3568256+02:00" endTime="2016-04-26T00:41:02.3613265+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9e109765-6ba8-4671-bbb0-61b7fd8370f6">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -939,22 +971,22 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 12.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3a186856-41de-4034-b4a8-feade31a112f" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0042406" startTime="2016-02-29T13:31:18.6801002-05:00" endTime="2016-02-29T13:31:18.6871027-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3a186856-41de-4034-b4a8-feade31a112f">
+    <UnitTestResult executionId="fed7bce5-8a69-4bd7-81ce-95f46d34c0b5" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0057362" startTime="2016-04-26T00:41:02.3648286+02:00" endTime="2016-04-26T00:41:02.3732118+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fed7bce5-8a69-4bd7-81ce-95f46d34c0b5">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -971,78 +1003,78 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:Zeile 10.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0a75715a-b55a-472c-9ab4-719e75bfc680" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021846" startTime="2016-02-29T13:31:18.6881091-05:00" endTime="2016-02-29T13:31:18.6921056-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0a75715a-b55a-472c-9ab4-719e75bfc680">
+    <UnitTestResult executionId="b71d3e94-6baf-4b45-8e37-8682eb5708a9" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0022471" startTime="2016-04-26T00:41:02.3767139+02:00" endTime="2016-04-26T00:41:02.3812186+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b71d3e94-6baf-4b45-8e37-8682eb5708a9">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:Zeile 7.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004721" startTime="2016-02-29T13:31:18.6931222-05:00" endTime="2016-02-29T13:31:18.6951164-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="639cb5c4-04f2-44f2-9c1d-c04cbef0cad8">
+    <UnitTestResult executionId="36830909-a83d-4aef-b65a-d6be05b5d26e" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0006251" startTime="2016-04-26T00:41:02.3847235+02:00" endTime="2016-04-26T00:41:02.3872258+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="36830909-a83d-4aef-b65a-d6be05b5d26e">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c14a24e4-f357-4e54-bff6-72b4c302dc21" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017543" startTime="2016-02-29T13:31:18.6951164-05:00" endTime="2016-02-29T13:31:18.6991061-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c14a24e4-f357-4e54-bff6-72b4c302dc21">
+    <UnitTestResult executionId="fdd77e81-b70d-43ac-85ca-a1a99b931b7d" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0017400" startTime="2016-04-26T00:41:02.3907270+02:00" endTime="2016-04-26T00:41:02.3950483+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fdd77e81-b70d-43ac-85ca-a1a99b931b7d">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:Zeile 7.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="beda5beb-f73a-4471-94ee-56da009212bb" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003426" startTime="2016-02-29T13:31:18.7001062-05:00" endTime="2016-02-29T13:31:18.7021079-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="beda5beb-f73a-4471-94ee-56da009212bb">
+    <UnitTestResult executionId="881a36b3-69db-4fea-92d0-599325f0ab4e" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002929" startTime="2016-04-26T00:41:02.3985504+02:00" endTime="2016-04-26T00:41:02.4010542+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="881a36b3-69db-4fea-92d0-599325f0ab4e">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ee52d898-3893-4b11-aca2-690c962c9094" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004291" startTime="2016-02-29T13:31:18.7031114-05:00" endTime="2016-02-29T13:31:18.7051196-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ee52d898-3893-4b11-aca2-690c962c9094">
+    <UnitTestResult executionId="a5b9c747-c35c-460f-ae5a-7982e23159b7" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0005602" startTime="2016-04-26T00:41:02.4045605+02:00" endTime="2016-04-26T00:41:02.4080649+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a5b9c747-c35c-460f-ae5a-7982e23159b7">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="84b87db1-b1a6-4bd5-8628-48cdde807b27" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0044848" startTime="2016-02-29T13:31:18.7061251-05:00" endTime="2016-02-29T13:31:18.7131094-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="84b87db1-b1a6-4bd5-8628-48cdde807b27">
+    <UnitTestResult executionId="19af94e1-f3c1-4656-94bf-380ab3734812" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0058467" startTime="2016-04-26T00:41:02.4120690+02:00" endTime="2016-04-26T00:41:02.4205782+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="19af94e1-f3c1-4656-94bf-380ab3734812">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1105,19 +1137,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 9.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="40db28a5-6f62-4207-9029-39db08667250" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0036003" startTime="2016-02-29T13:31:18.7131094-05:00" endTime="2016-02-29T13:31:18.7181231-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="40db28a5-6f62-4207-9029-39db08667250">
+    <UnitTestResult executionId="9a4a9b78-26eb-481c-8eed-89b7437afe25" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0048829" startTime="2016-04-26T00:41:02.4240836+02:00" endTime="2016-04-26T00:41:02.4311004+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9a4a9b78-26eb-481c-8eed-89b7437afe25">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1180,19 +1212,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 14.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="570e9634-242d-41bf-88bf-ea10800527e1" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0038319" startTime="2016-02-29T13:31:18.7191104-05:00" endTime="2016-02-29T13:31:18.7251120-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="570e9634-242d-41bf-88bf-ea10800527e1">
+    <UnitTestResult executionId="6dcc8ea9-839b-4536-b416-88d31f85209a" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0053177" startTime="2016-04-26T00:41:02.4346673+02:00" endTime="2016-04-26T00:41:02.4416748+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6dcc8ea9-839b-4536-b416-88d31f85209a">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1255,73 +1287,73 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 19.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6385cf85-f1b1-4e89-b2d7-ed3de7d43023" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001519" startTime="2016-02-29T13:31:18.7261124-05:00" endTime="2016-02-29T13:31:18.7271253-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6385cf85-f1b1-4e89-b2d7-ed3de7d43023">
+    <UnitTestResult executionId="d5806c6f-7d40-4973-8674-d8a08b34c8fd" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001702" startTime="2016-04-26T00:41:02.4456826+02:00" endTime="2016-04-26T00:41:02.4476839+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d5806c6f-7d40-4973-8674-d8a08b34c8fd">
     </UnitTestResult>
-    <UnitTestResult executionId="12b14fd2-ed0a-46c2-a19a-f9a4257d58af" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013681" startTime="2016-02-29T13:31:18.7281140-05:00" endTime="2016-02-29T13:31:18.7321136-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12b14fd2-ed0a-46c2-a19a-f9a4257d58af">
+    <UnitTestResult executionId="dd41ac17-4ff2-40a8-bb65-4477c0e0e90a" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0013029" startTime="2016-04-26T00:41:02.4511865+02:00" endTime="2016-04-26T00:41:02.4556893+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dd41ac17-4ff2-40a8-bb65-4477c0e0e90a">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002254" startTime="2016-02-29T13:31:18.7331143-05:00" endTime="2016-02-29T13:31:18.7351274-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d138cd0f-06d4-4e6c-8c27-cf675ae7fd8a">
+    <UnitTestResult executionId="473115a5-57b8-4543-ac20-5f0ae9d192ba" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002393" startTime="2016-04-26T00:41:02.4596919+02:00" endTime="2016-04-26T00:41:02.4616933+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="473115a5-57b8-4543-ac20-5f0ae9d192ba">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="478620d9-8754-4ed6-a149-e6a5a812a4b5" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0016441" startTime="2016-02-29T13:31:18.7361161-05:00" endTime="2016-02-29T13:31:18.7391167-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="478620d9-8754-4ed6-a149-e6a5a812a4b5">
+    <UnitTestResult executionId="d907562a-915a-4fa4-a8d1-9284d64c6a74" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0018193" startTime="2016-04-26T00:41:02.4651958+02:00" endTime="2016-04-26T00:41:02.4686980+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d907562a-915a-4fa4-a8d1-9284d64c6a74">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e7670bb6-9523-4594-9760-d1d941205633" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018957" startTime="2016-02-29T13:31:18.7401169-05:00" endTime="2016-02-29T13:31:18.7441188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e7670bb6-9523-4594-9760-d1d941205633">
+    <UnitTestResult executionId="1e6627d0-d9f2-4773-9682-0d64dc7ef54b" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0013444" startTime="2016-04-26T00:41:02.4722075+02:00" endTime="2016-04-26T00:41:02.4760292+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e6627d0-d9f2-4773-9682-0d64dc7ef54b">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="027e534e-d111-4fb7-88d5-2fa8e793fe3d" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0018872" startTime="2016-02-29T13:31:18.7451180-05:00" endTime="2016-02-29T13:31:18.7481181-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="027e534e-d111-4fb7-88d5-2fa8e793fe3d">
+    <UnitTestResult executionId="3fa9463f-93ff-4a58-b604-a33b510dd230" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0025634" startTime="2016-04-26T00:41:02.4795332+02:00" endTime="2016-04-26T00:41:02.4839226+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3fa9463f-93ff-4a58-b604-a33b510dd230">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1338,23 +1370,23 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3d59785c-3405-4625-9544-f7ba5f664fe1" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021872" startTime="2016-02-29T13:31:18.7491364-05:00" endTime="2016-02-29T13:31:18.7521188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3d59785c-3405-4625-9544-f7ba5f664fe1">
+    <UnitTestResult executionId="fd037e82-ee37-4076-8cda-d95ba7da728e" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0025588" startTime="2016-04-26T00:41:02.4879234+02:00" endTime="2016-04-26T00:41:02.4919274+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fd037e82-ee37-4076-8cda-d95ba7da728e">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -1371,53 +1403,53 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="2f709cc6-9269-4107-934f-343e4a914966" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005381" startTime="2016-02-29T13:31:18.7531198-05:00" endTime="2016-02-29T13:31:18.7551215-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2f709cc6-9269-4107-934f-343e4a914966">
+    <UnitTestResult executionId="e1d2ea77-0fa2-4e58-97e4-829779e1c3ee" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0007002" startTime="2016-04-26T00:41:02.4958835+02:00" endTime="2016-04-26T00:41:02.4983854+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e1d2ea77-0fa2-4e58-97e4-829779e1c3ee">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0cdaf90e-7083-4a5c-b98e-f68272057f57" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0005501" startTime="2016-02-29T13:31:18.7561207-05:00" endTime="2016-02-29T13:31:18.7581332-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0cdaf90e-7083-4a5c-b98e-f68272057f57">
+    <UnitTestResult executionId="aa54b9bc-f5b3-415a-892d-7172aaf1ff84" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0008224" startTime="2016-04-26T00:41:02.5018879+02:00" endTime="2016-04-26T00:41:02.5048955+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="aa54b9bc-f5b3-415a-892d-7172aaf1ff84">
       <Output>
         <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5bc6395d-9425-4db6-be59-68cb956cddb3" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003187" startTime="2016-02-29T13:31:18.7591208-05:00" endTime="2016-02-29T13:31:18.7611213-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5bc6395d-9425-4db6-be59-68cb956cddb3">
+    <UnitTestResult executionId="9c13b464-1e41-4429-8312-afe32624883b" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0003769" startTime="2016-04-26T00:41:02.5088973+02:00" endTime="2016-04-26T00:41:02.5108996+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9c13b464-1e41-4429-8312-afe32624883b">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="17553853-0683-4145-9d61-74031017021a" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002496" startTime="2016-02-29T13:31:18.7621226-05:00" endTime="2016-02-29T13:31:18.7631227-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="17553853-0683-4145-9d61-74031017021a">
+    <UnitTestResult executionId="cbfb8fb4-fc6d-48d2-be94-4d5226c45b66" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002374" startTime="2016-04-26T00:41:02.5144012+02:00" endTime="2016-04-26T00:41:02.5164021+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cbfb8fb4-fc6d-48d2-be94-4d5226c45b66">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ee5409c4-d89a-4640-b17f-b8a1676aae7f" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001992" startTime="2016-02-29T13:31:18.7641219-05:00" endTime="2016-02-29T13:31:18.7661233-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ee5409c4-d89a-4640-b17f-b8a1676aae7f">
+    <UnitTestResult executionId="abe19b91-d119-4034-8975-50ec9f56ccbb" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002813" startTime="2016-04-26T00:41:02.5204057+02:00" endTime="2016-04-26T00:41:02.5234067+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="abe19b91-d119-4034-8975-50ec9f56ccbb">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5c0a8fb0-126d-490e-b036-2d0a26f9c66d" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0020560" startTime="2016-02-29T13:31:18.7661233-05:00" endTime="2016-02-29T13:31:18.7701241-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5c0a8fb0-126d-490e-b036-2d0a26f9c66d">
+    <UnitTestResult executionId="f4b3d175-6e04-45e5-b691-52df64db8ed2" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0029772" startTime="2016-04-26T00:41:02.5274173+02:00" endTime="2016-04-26T00:41:02.5324211+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f4b3d175-6e04-45e5-b691-52df64db8ed2">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1434,64 +1466,86 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 34.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4b0b1635-cf18-425b-bb46-0b3d893671fa" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0003227" startTime="2016-02-29T13:31:18.7711253-05:00" endTime="2016-02-29T13:31:18.7721252-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4b0b1635-cf18-425b-bb46-0b3d893671fa">
+    <UnitTestResult executionId="e38ccc75-3056-4bc8-adb2-68400939dea4" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002537" startTime="2016-04-26T00:41:02.5374310+02:00" endTime="2016-04-26T00:41:02.5394328+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e38ccc75-3056-4bc8-adb2-68400939dea4">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3727f45e-675e-4c11-93b8-17c0d3a607d8" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002211" startTime="2016-02-29T13:31:18.7731253-05:00" endTime="2016-02-29T13:31:18.7751266-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3727f45e-675e-4c11-93b8-17c0d3a607d8">
+    <UnitTestResult executionId="6947c394-549d-46f1-85f2-3722e00fc1d1" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002402" startTime="2016-04-26T00:41:02.5429340+02:00" endTime="2016-04-26T00:41:02.5448140+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6947c394-549d-46f1-85f2-3722e00fc1d1">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="05f537a2-462a-4a54-8a89-c50ee92ee819" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012329" startTime="2016-02-29T13:31:18.7761268-05:00" endTime="2016-02-29T13:31:18.7781381-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="05f537a2-462a-4a54-8a89-c50ee92ee819">
+    <UnitTestResult executionId="c16dd9f0-0fe2-4086-ab15-6f2738986c5c" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0016103" startTime="2016-04-26T00:41:02.5483166+02:00" endTime="2016-04-26T00:41:02.5518187+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c16dd9f0-0fe2-4086-ab15-6f2738986c5c">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 21.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1d5f63e8-3036-4422-92d6-d60ba1ae151b" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001761" startTime="2016-02-29T13:31:18.7791260-05:00" endTime="2016-02-29T13:31:18.7801389-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1d5f63e8-3036-4422-92d6-d60ba1ae151b">
+    <UnitTestResult executionId="fbe09fe8-e01e-4751-8022-e9887c6ce29e" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002449" startTime="2016-04-26T00:41:02.5558209+02:00" endTime="2016-04-26T00:41:02.5578223+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fbe09fe8-e01e-4751-8022-e9887c6ce29e">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="31eb3903-2072-4aa5-beb1-aa68da5cef6c" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002074" startTime="2016-02-29T13:31:18.7811276-05:00" endTime="2016-02-29T13:31:18.7831282-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31eb3903-2072-4aa5-beb1-aa68da5cef6c">
+    <UnitTestResult executionId="fbd43871-8867-4393-98ff-267b9055c690" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002439" startTime="2016-04-26T00:41:02.5613239+02:00" endTime="2016-04-26T00:41:02.5633252+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fbd43871-8867-4393-98ff-267b9055c690">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="214e99b7-3777-4a80-8276-fe2fcee2c389" testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0009801" startTime="2016-04-26T00:41:02.5668278+02:00" endTime="2016-04-26T00:41:02.5718311+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="214e99b7-3777-4a80-8276-fe2fcee2c389">
+      <Output>
+        <StdOut>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="23cc5923-00a0-42b4-8560-4cc48e52dbd7" testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0004753" startTime="2016-04-26T00:41:02.5755338+02:00" endTime="2016-04-26T00:41:02.5780357+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="23cc5923-00a0-42b4-8560-4cc48e52dbd7">
+      <Output>
+        <StdOut>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 120 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
@@ -135,5 +135,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit2
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="34" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-02-29" time="13:31:00">
-  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8669" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" />
-  <culture-info current-culture="en-US" current-uiculture="en-US" />
-  <test-suite type="Assembly" name="C:\src\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.746" asserts="0">
+<test-results name="D:\Work\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" total="36" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-04-26" time="00:40:28">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8670" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="D:\Work\pickles-testresults" machine-name="DANIEL-NOTEBOOK" user="Daniel" user-domain="DANIEL-NOTEBOOK" />
+  <culture-info current-culture="de-DE" current-uiculture="de-DE" />
+  <test-suite type="Assembly" name="D:\Work\pickles-testresults\TestHarness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="2.615" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.739" asserts="0">
+      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="2.594" asserts="0">
         <results>
-          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.739" asserts="0">
+          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="2.593" asserts="0">
             <results>
-              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.739" asserts="0">
+              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="2.592" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.575" asserts="0">
+                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="1.891" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.186" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.440" asserts="0">
                         <categories>
                           <category name="tag2" />
                         </categories>
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.178" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.415" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                       <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddTwoNumbers" description="Add two numbers" executed="True" result="Success" success="True" time="0.001" asserts="0">
@@ -27,24 +27,24 @@
                           <category name="tag1" />
                         </categories>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.009" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.094" asserts="0">
                         <categories>
                           <category name="tag1" />
                         </categories>
                         <failure>
-                          <message><![CDATA[System.FormatException : Input string was not in a correct format.]]></message>
-                          <stack-trace><![CDATA[at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
-at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-at System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
-at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\Addition.feature.cs:line 0
-at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit\Addition.feature:line 34
+                          <message><![CDATA[System.FormatException : Die Eingabezeichenfolge hat das falsche Format.]]></message>
+                          <stack-trace><![CDATA[bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
+bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+bei System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
+bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\Addition.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\nunit\Addition.feature:Zeile 34.
 ]]></stack-trace>
                         </failure>
                       </test-case>
@@ -53,7 +53,7 @@ at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pic
                           <message><![CDATA[]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.101" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.151" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -88,11 +88,11 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.041" asserts="0">
+                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.381" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.027" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.341" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.018" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.130" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -100,19 +100,19 @@ namespace MyNamespace
     2
         but was
     1]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature:Zeile 19.
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Error" success="False" time="0.003" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Error" success="False" time="0.007" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -120,21 +120,21 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     2
         but was
     1]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 19
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature:Zeile 19.
 ]]></stack-trace>
                             </failure>
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers" description="Add two numbers" executed="True" result="Error" success="False" time="0.002" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers" description="Add two numbers" executed="True" result="Error" success="False" time="0.003" asserts="0">
                         <failure>
                           <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -142,25 +142,25 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     2
         but was
     1]]></message>
-                          <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:line 0
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit\FailingBackground.feature:line 12
+                          <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\nunit\FailingBackground.feature:Zeile 12.
 ]]></stack-trace>
                         </failure>
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.024" asserts="0">
+                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.051" asserts="0">
                     <results>
-                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.015" asserts="0">
+                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.038" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.005" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.015" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -168,19 +168,19 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\
     False
         but was
     True]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature.cs:line 0
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature:line 10
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\nunit\Minimal Features\Failing.feature:Zeile 10.
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.006" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()]]></message>
@@ -189,7 +189,7 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" description="Failing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.005" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" description="Inconclusive Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
                             <reason>
@@ -197,7 +197,7 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
   MinimalSteps.ThenInconclusiveStep()]]></message>
                             </reason>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" description="Inconclusive Feature Passing Scenario" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" description="Inconclusive Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                       <test-suite type="TestFixture" name="PassingFeature" description="Passing" executed="True" result="Success" success="True" time="0.002" asserts="0">
@@ -207,9 +207,9 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                       </test-suite>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.031" asserts="0">
+                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.055" asserts="0">
                     <results>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.010" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.006" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -242,7 +242,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.005" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.006" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -310,9 +310,9 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.051" asserts="0">
+                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.148" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.018" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.072" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
@@ -328,7 +328,7 @@ namespace MyNamespace
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
                             </reason>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.041" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -336,19 +336,19 @@ namespace MyNamespace
     False
         but was
     True]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:Zeile 45.
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" executed="True" result="Error" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -356,15 +356,15 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     False
         but was
     True]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 45
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:Zeile 45.
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -372,24 +372,24 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
                       </test-suite>
                       <test-suite type="ParameterizedTest" name="DealCorrectlyWithBackslashesInTheExamples" description="Deal correctly with backslashes in the examples" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithParenthesisInTheExamples" description="Deal correctly with parenthesis in the examples" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithParenthesisInTheExamples" description="Deal correctly with parenthesis in the examples" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.008" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.009" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.011" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
@@ -399,25 +399,25 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     False
         but was
     True]]></message>
-                              <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:line 0
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:line 34
+                              <stack-trace><![CDATA[bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature.cs:Zeile 0.
+bei Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit\ScenarioOutlines.feature:Zeile 34.
 ]]></stack-trace>
                             </failure>
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.008" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -425,6 +425,16 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhere
                           </test-case>
                         </results>
                       </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ScenariosWithSpecialCharactersFeature" description="Scenarios With Special Characters" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" description="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" description="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                     </results>
                   </test-suite>
                 </results>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenParsingNunit3ResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/WhenParsingNunit3ResultsFile.cs
@@ -105,5 +105,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit3
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
@@ -1,124 +1,124 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="33" result="Failed" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.843863">
-  <command-line><![CDATA["C:\src\pickles-testresults\\TestHarness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\src\pickles-testresults\\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\src\pickles-testresults\\results-example-nunit3.xml"]]></command-line>
-  <test-suite type="Assembly" id="0-1048" name="nunit3Harness.dll" fullname="C:\src\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.731461" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
-    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10240.0" platform="Win32NT" cwd="C:\src\pickles-testresults" machine-name="DESKTOP-AIFNJPI" user="ocsur" user-domain="DESKTOP-AIFNJPI" culture="en-US" uiculture="en-US" os-architecture="x64" />
+<test-run id="2" testcasecount="35" result="Failed" total="35" passed="19" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:34Z" duration="1.786877">
+  <command-line><![CDATA["D:\Work\pickles-testresults\\TestHarness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "D:\Work\pickles-testresults\\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" /result="D:\Work\pickles-testresults\\results-example-nunit3.xml"]]></command-line>
+  <test-suite type="Assembly" id="0-1052" name="nunit3Harness.dll" fullname="D:\Work\pickles-testresults\TestHarness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="35" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.363861" total="35" passed="19" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10586.0" platform="Win32NT" cwd="D:\Work\pickles-testresults" machine-name="DANIEL-NOTEBOOK" user="Daniel" user-domain="DANIEL-NOTEBOOK" culture="de-DE" uiculture="de-DE" os-architecture="x64" />
     <settings>
-      <setting name="WorkDirectory" value="C:\src\pickles-testresults" />
+      <setting name="WorkDirectory" value="D:\Work\pickles-testresults" />
       <setting name="NumberOfTestWorkers" value="8" />
     </settings>
     <properties>
-      <property name="_PID" value="924" />
+      <property name="_PID" value="18252" />
       <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
       <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="TestSuite" id="0-1049" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724766" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <test-suite type="TestSuite" id="0-1053" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="35" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.353494" total="35" passed="19" failed="9" inconclusive="6" skipped="1" asserts="0">
       <failure>
         <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="TestSuite" id="0-1050" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724686" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+      <test-suite type="TestSuite" id="0-1054" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="35" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.353383" total="35" passed="19" failed="9" inconclusive="6" skipped="1" asserts="0">
         <failure>
           <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="TestSuite" id="0-1051" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="33" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.724678" total="33" passed="17" failed="9" inconclusive="6" skipped="1" asserts="0">
+        <test-suite type="TestSuite" id="0-1055" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="35" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.353371" total="35" passed="19" failed="9" inconclusive="6" skipped="1" asserts="0">
           <failure>
             <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.662979" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
+          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.179947" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
             <properties>
               <property name="Description" value="Addition" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.168946" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="0.300248" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
                 <property name="Category" value="tag2" />
               </properties>
-              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.164123" asserts="0">
+              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="0.293338" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 60 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
 And I have entered 70 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
 And I have entered 130 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0.0s)
+-> done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 260 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,1s)
 ]]></output>
               </test-case>
-              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000426" asserts="0">
+              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000569" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 40 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
 And I have entered 50 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
 And I have entered 90 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0.0s)
+-> done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 180 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000698" asserts="0">
+            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000604" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="tag1" />
               </properties>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0.0s)
+-> done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)
 ]]></output>
             </test-case>
-            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.007835" asserts="0">
+            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.120201" asserts="0">
               <properties>
                 <property name="Description" value="Fail to add two numbers" />
                 <property name="Category" value="tag1" />
               </properties>
               <failure>
-                <message><![CDATA[System.FormatException : Input string was not in a correct format.]]></message>
-                <stack-trace><![CDATA[   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\Addition.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\Addition.feature:line 34]]></stack-trace>
+                <message><![CDATA[System.FormatException : Die Eingabezeichenfolge hat das falsche Format.]]></message>
+                <stack-trace><![CDATA[   bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
+   bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   bei System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
+   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\nunit3\Addition.feature:Zeile 34.]]></stack-trace>
               </failure>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2.2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0.0s)
+-> done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3.2 on the screen
--> error: Input string was not in a correct format.
+-> error: Die Eingabezeichenfolge hat das falsche Format.
 ]]></output>
             </test-case>
-            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000661" asserts="0">
+            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001174" asserts="0">
               <properties>
                 <property name="Description" value="Ignored adding two numbers" />
                 <property name="_SKIPREASON" value="" />
@@ -127,7 +127,7 @@ Then the result should be 3.2 on the screen
                 <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.085396" asserts="0">
+            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.117819" asserts="0">
               <properties>
                 <property name="Description" value="Not automated adding two numbers" />
               </properties>
@@ -163,7 +163,7 @@ namespace MyNamespace
 ]]></message>
               </reason>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given unimplemented step
 -> No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -191,21 +191,21 @@ Then unimplemented step
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.020804" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.124208" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Failing Background" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.018041" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.120729" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.015860" asserts="0">
+              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.117219" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -213,15 +213,15 @@ Then unimplemented step
     2
         but was
     1]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:Zeile 19.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -244,7 +244,7 @@ Then the result should be 260 on the screen
 -> skipped because of previous errors
 ]]></output>
               </test-case>
-              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002024" asserts="0">
+              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.003106" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -252,15 +252,15 @@ Then the result should be 260 on the screen
     2
         but was
     1]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:Zeile 19.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -284,7 +284,7 @@ Then the result should be 180 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001855" asserts="0">
+            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001752" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
               </properties>
@@ -295,15 +295,15 @@ Then the result should be 180 on the screen
     2
         but was
     1]]></message>
-                <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:line 12]]></stack-trace>
+                <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\nunit3\FailingBackground.feature:Zeile 12.]]></stack-trace>
               </failure>
               <output><![CDATA[Given the background step fails
 -> error: 
@@ -325,18 +325,18 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestSuite" id="0-1052" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:01Z" end-time="2016-02-29 18:31:02Z" duration="0.700935" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
+          <test-suite type="TestSuite" id="0-1056" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-04-25 22:40:32Z" end-time="2016-04-25 22:40:33Z" duration="1.324765" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="TestFixture" id="0-1039" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.012435" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1043" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.016073" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Failing" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1042" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1072944492" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.005648" asserts="0">
+              <test-case id="0-1046" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="980176457" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.008383" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Failing Scenario" />
                 </properties>
@@ -347,15 +347,15 @@ Then the result should be 120 on the screen
     False
         but was
     True]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature:line 10]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\nunit3\Minimal Features\Failing.feature:Zeile 10.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then failing step
 -> error: 
@@ -366,7 +366,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1041" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="657009205" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.005517" asserts="0">
+              <test-case id="0-1045" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="105033491" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.006011" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Inconclusive Scenario" />
                 </properties>
@@ -378,20 +378,20 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1040" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="129833087" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000694" asserts="0">
+              <test-case id="0-1044" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1924427483" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000894" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0.0s)
+-> done: MinimalSteps.ThenPassingStep() (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1043" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.003003" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1047" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.002803" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Inconclusive" />
               </properties>
-              <test-case id="0-1045" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="980176457" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002119" asserts="0">
+              <test-case id="0-1049" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="320302720" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001780" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Inconclusive Scenario" />
                 </properties>
@@ -403,54 +403,54 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1044" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="105033491" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000352" asserts="0">
+              <test-case id="0-1048" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000341" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0.0s)
+-> done: MinimalSteps.ThenPassingStep() (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1046" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001373" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1050" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001204" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Passing" />
               </properties>
-              <test-case id="0-1047" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000731" asserts="0">
+              <test-case id="0-1051" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="1487151050" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000639" asserts="0">
                 <properties>
                   <property name="Description" value="Passing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0.0s)
+-> done: MinimalSteps.ThenPassingStep() (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002403" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.003254" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="NotAutomatedAtAll" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001886" asserts="0">
+            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.002688" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="mytag" />
               </properties>
               <failure>
-                <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object.]]></message>
-                <stack-trace><![CDATA[   at AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 31
-   at lambda_method(Closure , IContextManager , Decimal )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature:line 11]]></stack-trace>
+                <message><![CDATA[System.NullReferenceException : Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.]]></message>
+                <stack-trace><![CDATA[   bei AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 31.
+   bei lambda_method(Closure , IContextManager , Decimal )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\nunit3\NotAutomatedAtAll.feature:Zeile 11.]]></stack-trace>
               </failure>
               <output><![CDATA[Given I have entered 50 into the calculator
--> error: Object reference not set to an instance of an object.
+-> error: Der Objektverweis wurde nicht auf eine Objektinstanz festgelegt.
 And I have entered 70 into the calculator
 -> skipped because of previous errors
 When I press add
@@ -460,31 +460,31 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="17" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.020337" total="17" passed="11" failed="3" inconclusive="3" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="17" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.019696" total="17" passed="11" failed="3" inconclusive="3" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Scenario Outlines" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.013137" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.008329" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="And we can go totally bonkers with multiple example sections." />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001450" asserts="0">
+              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.002243" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000112" asserts="0">
+              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000188" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001235" asserts="0">
+              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001770" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -493,7 +493,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 ]]></output>
               </test-case>
-              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.007418" asserts="0">
+              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001043" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
@@ -502,7 +502,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 ]]></output>
               </test-case>
-              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001478" asserts="0">
+              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001148" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -510,15 +510,15 @@ Then the result should be 120 on the screen
     False
         but was
     True]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -529,7 +529,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000984" asserts="0">
+              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001020" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -537,15 +537,15 @@ Then the result should be 120 on the screen
     False
         but was
     True]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_2'
 -> error: 
@@ -557,64 +557,64 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001171" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001172" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with backslashes in the examples" />
               </properties>
-              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001053" asserts="0">
+              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001052" asserts="0">
                 <output><![CDATA[When I have backslashes in the value, for example a 'c:\Temp\'
--> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
+-> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000893" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001347" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with parenthesis in the examples" />
               </properties>
-              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000747" asserts="0">
+              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001227" asserts="0">
                 <output><![CDATA[When I have parenthesis in the value, for example an 'This is a description (and more)'
--> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+-> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000673" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001621" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where all scenarios pass" />
               </properties>
-              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000287" asserts="0">
+              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000575" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000088" asserts="0">
+              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000208" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000079" asserts="0">
+              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000205" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_3'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.002219" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.003466" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario fails" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000320" asserts="0">
+              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000551" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000099" asserts="0">
+              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000223" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001599" asserts="0">
+              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.002055" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -622,15 +622,15 @@ Then the result should be 120 on the screen
     False
         but was
     True]]></message>
-                  <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:line 34]]></stack-trace>
+                  <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\nunit3\ScenarioOutlines.feature:Zeile 34.]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -642,21 +642,21 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001707" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.002876" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario is inconclusive" />
               </properties>
-              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000344" asserts="0">
+              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000643" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.000093" asserts="0">
+              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000248" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-02-29 18:31:02Z" end-time="2016-02-29 18:31:02Z" duration="0.001035" asserts="0">
+              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001581" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -666,6 +666,39 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
+          </test-suite>
+          <test-suite type="TestFixture" id="0-1039" name="ScenariosWithSpecialCharactersFeature" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.004105" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <properties>
+              <property name="Description" value="Scenarios With Special Characters" />
+            </properties>
+            <test-suite type="ParameterizedMethod" id="0-1042" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001245" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+              <properties>
+                <property name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
+              </properties>
+              <test-case id="0-1041" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="657009205" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.001113" asserts="0">
+                <output><![CDATA[Given the calculator has clean memory
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Then the scenario will 'pass_1'
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+]]></output>
+              </test-case>
+            </test-suite>
+            <test-case id="0-1040" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" methodname="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="129833087" result="Passed" start-time="2016-04-25 22:40:33Z" end-time="2016-04-25 22:40:33Z" duration="0.000639" asserts="0">
+              <properties>
+                <property name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
+              </properties>
+              <output><![CDATA[Given the calculator has clean memory
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 50 into the calculator
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+And I have entered 70 into the calculator
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+When I press add
+-> done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 120 on the screen
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)
+]]></output>
+            </test-case>
           </test-suite>
         </test-suite>
       </test-suite>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/WhenParsingSpecRunTestResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/WhenParsingSpecRunTestResultsFile.cs
@@ -111,5 +111,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.SpecRun
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/results-example-specrun.html
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/SpecRun/results-example-specrun.html
@@ -184,6 +184,19 @@
             &lt;/scenario&gt;
         &lt;/scenarios&gt;
     &lt;/feature&gt;
+    &lt;feature&gt;
+        &lt;title&gt;Scenarios With Special Characters&lt;/title&gt;
+        &lt;scenarios&gt;
+            &lt;scenario&gt;
+                &lt;title&gt;This is a scenario with parentheses, hyphen and comma (10-20, 30-40)&lt;/title&gt;
+                &lt;result&gt;Passed&lt;/result&gt;
+            &lt;/scenario&gt;
+            &lt;scenario&gt;
+                &lt;title&gt;This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40), pass_1&lt;/title&gt;
+                &lt;result&gt;Passed&lt;/result&gt;
+            &lt;/scenario&gt;
+        &lt;/scenarios&gt;
+    &lt;/feature&gt;
 &lt;/features&gt;
 Pickles End -->
     </body>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
@@ -245,6 +245,31 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests
             Check.That(actualResult).IsEqualTo(TestResult.Failed);
         }
 
+        public void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            var results = ParseResultsFile();
+
+            var feature = new Feature { Name = "Scenarios With Special Characters" };
+
+            var scenario = new Scenario{ Name = "This is a scenario with parentheses, hyphen and comma (10-20, 30-40)", Feature = feature };
+
+            var actualResult = results.GetScenarioResult(scenario);
+            Check.That(actualResult).IsEqualTo(TestResult.Passed);
+        }
+
+        public void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            var results = ParseResultsFile();
+
+            var feature = new Feature { Name = "Scenarios With Special Characters" };
+
+            var scenarioOutline = new ScenarioOutline { Name = "This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)", Feature = feature };
+            
+            var actualResult = results.GetExampleResult(scenarioOutline, new string[] { "pass_1" });
+
+            Check.That(actualResult).IsEqualTo(TestResult.Passed);
+        }
+
         private Feature AdditionFeature()
         {
             return new Feature { Name = "Addition" };

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingVsTestResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingVsTestResultsFile.cs
@@ -141,5 +141,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.VsTest
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
@@ -1,102 +1,102 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="82d39159-69f3-4cbd-a00d-d2d7649f2837" name="ocsur@DESKTOP-AIFNJPI 2016-02-29 13:31:23" runUser="DESKTOP-AIFNJPI\ocsur" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-  <Times creation="2016-02-29T13:31:23.0292278-05:00" queuing="2016-02-29T13:31:23.0292278-05:00" start="2016-02-29T13:31:23.0332416-05:00" finish="2016-02-29T13:31:24.0664977-05:00" />
-  <TestSettings name="default" id="fcc68539-05dd-4cc8-adb1-8bc418f40125">
+<TestRun id="b7fff6ff-cbc3-4ec0-85f2-cc94b94a7218" name="Daniel@DANIEL-NOTEBOOK 2016-04-26 00:41:19" runUser="DANIEL-NOTEBOOK\Daniel" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2016-04-26T00:41:19.3671910+02:00" queuing="2016-04-26T00:41:19.3671910+02:00" start="2016-04-26T00:41:19.3731969+02:00" finish="2016-04-26T00:41:20.2651649+02:00" />
+  <TestSettings name="default" id="2beb5777-a21b-4ee8-9633-10b94eec90de">
     <Execution>
       <TestTypeSpecific />
     </Execution>
-    <Deployment runDeploymentRoot="ocsur_DESKTOP-AIFNJPI 2016-02-29 13_31_23" />
+    <Deployment runDeploymentRoot="Daniel_DANIEL-NOTEBOOK 2016-04-26 00_41_19" />
     <Properties />
   </TestSettings>
   <Results>
-    <UnitTestResult executionId="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.1018713" startTime="2016-02-29T13:31:22.1700049-05:00" endTime="2016-02-29T13:31:22.5811287-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39">
+    <UnitTestResult executionId="0faaf7c1-74d8-4c5d-94fb-b3ae709347e1" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="DANIEL-NOTEBOOK" duration="00:00:00.1352464" startTime="2016-04-26T00:41:18.0075631+02:00" endTime="2016-04-26T00:41:18.4969364+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0faaf7c1-74d8-4c5d-94fb-b3ae709347e1">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="65361449-881c-4f34-8f1c-b3aec990f15e" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002712" startTime="2016-02-29T13:31:22.5881310-05:00" endTime="2016-02-29T13:31:22.5891262-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65361449-881c-4f34-8f1c-b3aec990f15e">
+    <UnitTestResult executionId="7f60248b-8a69-427e-a645-7f56ddddd56a" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0003750" startTime="2016-04-26T00:41:18.5064425+02:00" endTime="2016-04-26T00:41:18.5069426+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7f60248b-8a69-427e-a645-7f56ddddd56a">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002148" startTime="2016-02-29T13:31:22.5891262-05:00" endTime="2016-02-29T13:31:22.5891262-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f5d459f6-fcd4-460c-af5a-20bcf57ead8f">
+    <UnitTestResult executionId="ec67dcee-bd41-4fbe-8791-591f7858f5cc" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0003018" startTime="2016-04-26T00:41:18.5069426+02:00" endTime="2016-04-26T00:41:18.5074432+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ec67dcee-bd41-4fbe-8791-591f7858f5cc">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0160539" startTime="2016-02-29T13:31:22.5891262-05:00" endTime="2016-02-29T13:31:22.6051301-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30">
+    <UnitTestResult executionId="6d6a7285-c7da-47b5-b43e-c18575512517" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0309353" startTime="2016-04-26T00:41:18.5079433+02:00" endTime="2016-04-26T00:41:18.5389640+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6d6a7285-c7da-47b5-b43e-c18575512517">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3.2 on the screen
--&gt; error: Input string was not in a correct format.</StdOut>
+-&gt; error: Die Eingabezeichenfolge hat das falsche Format.</StdOut>
         <ErrorInfo>
           <Message>Test method Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers threw exception: 
-System.FormatException: Input string was not in a correct format.</Message>
-          <StackTrace>    at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(Type typeToConvertTo, Object value, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(IBindingType typeToConvertTo, Object value, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.Convert(Object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ConvertArg(Object value, IBindingType typeToConvertTo)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.&lt;&gt;c__DisplayClass5.&lt;GetExecuteArguments&gt;b__4(Object arg, Int32 argIndex)
-   at System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 34
+System.FormatException: Die Eingabezeichenfolge hat das falsche Format.</Message>
+          <StackTrace>    bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
+   bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(Type typeToConvertTo, Object value, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.ConvertSimple(IBindingType typeToConvertTo, Object value, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Bindings.StepArgumentTypeConverter.Convert(Object value, IBindingType typeToConvertTo, CultureInfo cultureInfo)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ConvertArg(Object value, IBindingType typeToConvertTo)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.&lt;&gt;c__DisplayClass5.&lt;GetExecuteArguments&gt;b__4(Object arg, Int32 argIndex)
+   bei System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
+   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature:Zeile 34.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="8d70d6f0-76c2-43ea-9476-93b10f73bfed" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" startTime="2016-02-29T13:31:22.6061188-05:00" endTime="2016-02-29T13:31:22.6061188-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8d70d6f0-76c2-43ea-9476-93b10f73bfed" />
-    <UnitTestResult executionId="29a76e0f-6591-45fa-96de-7719fe7b4a9c" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0548584" startTime="2016-02-29T13:31:22.6061188-05:00" endTime="2016-02-29T13:31:22.6611449-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="29a76e0f-6591-45fa-96de-7719fe7b4a9c">
+    <UnitTestResult executionId="a7ccb454-eb47-450c-bbdd-39fea7f680dc" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="DANIEL-NOTEBOOK" startTime="2016-04-26T00:41:18.5394645+02:00" endTime="2016-04-26T00:41:18.5394645+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a7ccb454-eb47-450c-bbdd-39fea7f680dc" />
+    <UnitTestResult executionId="1f3ad742-cef0-4bf4-a803-a28b1602527a" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0770271" startTime="2016-04-26T00:41:18.5394645+02:00" endTime="2016-04-26T00:41:18.6165160+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1f3ad742-cef0-4bf4-a803-a28b1602527a">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -150,19 +150,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\Addition.feature:line 46
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\Addition.feature:Zeile 46.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0096875" startTime="2016-02-29T13:31:22.6611449-05:00" endTime="2016-02-29T13:31:22.6721522-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b">
+    <UnitTestResult executionId="13d9b0f1-12b4-4365-bc26-93ac2fb0d745" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0878894" startTime="2016-04-26T00:41:18.6170161+02:00" endTime="2016-04-26T00:41:18.7062202+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="13d9b0f1-12b4-4365-bc26-93ac2fb0d745">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -189,22 +189,22 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 12
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 12.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="cea33f60-e243-4965-b63e-597c8a88d2f9" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013760" startTime="2016-02-29T13:31:22.6721522-05:00" endTime="2016-02-29T13:31:22.6741527-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cea33f60-e243-4965-b63e-597c8a88d2f9">
+    <UnitTestResult executionId="37d7c0a6-d24f-44aa-9a61-fdd2996b68cf" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0041165" startTime="2016-04-26T00:41:18.7067207+02:00" endTime="2016-04-26T00:41:18.7112230+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="37d7c0a6-d24f-44aa-9a61-fdd2996b68cf">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -233,23 +233,23 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 19.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9388824a-0969-41ed-a65f-944972aea091" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010644" startTime="2016-02-29T13:31:22.6741527-05:00" endTime="2016-02-29T13:31:22.6751534-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9388824a-0969-41ed-a65f-944972aea091">
+    <UnitTestResult executionId="21ffc846-f35a-4e0c-a371-7ae651f4aa8f" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0031998" startTime="2016-04-26T00:41:18.7117236+02:00" endTime="2016-04-26T00:41:18.7152262+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="21ffc846-f35a-4e0c-a371-7ae651f4aa8f">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -278,23 +278,23 @@ Shouldly.ChuckedAWobbly:
     2
         but was
     1</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\src\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature:Zeile 19.
+   bei Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in D:\Work\pickles-testresults\TestHarness\MsTest\FailingBackground.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a5b25781-7d96-483c-8ea8-95e20603919f" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0040357" startTime="2016-02-29T13:31:22.6751534-05:00" endTime="2016-02-29T13:31:22.6801372-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a5b25781-7d96-483c-8ea8-95e20603919f">
+    <UnitTestResult executionId="65f182b5-b4f5-4a64-ad71-d6a25fdcda7f" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0125501" startTime="2016-04-26T00:41:18.7157263+02:00" endTime="2016-04-26T00:41:18.7292519+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65f182b5-b4f5-4a64-ad71-d6a25fdcda7f">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -357,19 +357,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 9
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 9.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="03240585-ad45-4dac-b760-9754938af626" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0033919" startTime="2016-02-29T13:31:22.6801372-05:00" endTime="2016-02-29T13:31:22.6831509-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="03240585-ad45-4dac-b760-9754938af626">
+    <UnitTestResult executionId="4844e042-ef59-4828-aa5f-96a111cca811" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0056293" startTime="2016-04-26T00:41:18.7302525+02:00" endTime="2016-04-26T00:41:18.7362551+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4844e042-ef59-4828-aa5f-96a111cca811">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -432,19 +432,19 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 14
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 14.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0032946" startTime="2016-02-29T13:31:22.6841507-05:00" endTime="2016-02-29T13:31:22.6871519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5">
+    <UnitTestResult executionId="b9f84e1d-ebb4-4c9b-9538-ff2085f939b1" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0079638" startTime="2016-04-26T00:41:18.7362551+02:00" endTime="2016-04-26T00:41:18.7442609+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b9f84e1d-ebb4-4c9b-9538-ff2085f939b1">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -507,81 +507,81 @@ namespace MyNamespace
     }
 }
 </Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:line 19
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in D:\Work\pickles-testresults\TestHarness\MsTest\NotAutomatedAtAll.feature:Zeile 19.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5c954959-f9e2-4f11-a707-3391ee0382ad" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0009594" startTime="2016-02-29T13:31:22.6871519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5c954959-f9e2-4f11-a707-3391ee0382ad">
+    <UnitTestResult executionId="d9768042-79f4-4c16-a34c-87469b5c5818" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0012418" startTime="2016-04-26T00:41:18.7447615+02:00" endTime="2016-04-26T00:41:18.7462623+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d9768042-79f4-4c16-a34c-87469b5c5818">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="091433bf-fed1-470e-b06c-cb4b7b972e6e" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000942" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="091433bf-fed1-470e-b06c-cb4b7b972e6e">
+    <UnitTestResult executionId="5ea8df5a-da16-4fd0-9532-02f345ed4f07" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001175" startTime="2016-04-26T00:41:18.7462623+02:00" endTime="2016-04-26T00:41:18.7472653+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5ea8df5a-da16-4fd0-9532-02f345ed4f07">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000936" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6891519-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="23ff0c73-6cc8-4e6f-b179-964f6547f7d1">
+    <UnitTestResult executionId="0f2ae577-83ce-4598-9f5d-b8c410027dfd" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001189" startTime="2016-04-26T00:41:18.7472653+02:00" endTime="2016-04-26T00:41:18.7477672+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0f2ae577-83ce-4598-9f5d-b8c410027dfd">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e8b916c9-e2cd-4024-b8db-066ec4c977db" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001832" startTime="2016-02-29T13:31:22.6891519-05:00" endTime="2016-02-29T13:31:22.6901412-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e8b916c9-e2cd-4024-b8db-066ec4c977db">
+    <UnitTestResult executionId="e034dcba-b4be-4630-b0cb-e0a22bc121ce" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002304" startTime="2016-04-26T00:41:18.7477672+02:00" endTime="2016-04-26T00:41:18.7482678+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e034dcba-b4be-4630-b0cb-e0a22bc121ce">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d40e68a2-8718-4471-ab2a-8edda2509a11" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000916" startTime="2016-02-29T13:31:22.6901412-05:00" endTime="2016-02-29T13:31:22.6901412-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d40e68a2-8718-4471-ab2a-8edda2509a11">
+    <UnitTestResult executionId="9727de58-2d38-4205-8d8b-9ebd13659d29" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001142" startTime="2016-04-26T00:41:18.7482678+02:00" endTime="2016-04-26T00:41:18.7487679+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9727de58-2d38-4205-8d8b-9ebd13659d29">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3f2955ce-7301-4d16-8632-62450d7586c0" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0028238" startTime="2016-02-29T13:31:22.6901412-05:00" endTime="2016-02-29T13:31:22.6931532-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3f2955ce-7301-4d16-8632-62450d7586c0">
+    <UnitTestResult executionId="47a72276-c2fd-4c3e-9c70-08ad45c16295" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0033878" startTime="2016-04-26T00:41:18.7487679+02:00" endTime="2016-04-26T00:41:18.7522705+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="47a72276-c2fd-4c3e-9c70-08ad45c16295">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 21.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="18072b05-d227-43a5-a03b-e7b5b137f8b0" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002433" startTime="2016-02-29T13:31:22.6931532-05:00" endTime="2016-02-29T13:31:22.6941533-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="18072b05-d227-43a5-a03b-e7b5b137f8b0">
+    <UnitTestResult executionId="8a6cea0b-efae-41c8-9341-e6ff6a0f1e6c" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002239" startTime="2016-04-26T00:41:18.7527706+02:00" endTime="2016-04-26T00:41:18.7532711+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8a6cea0b-efae-41c8-9341-e6ff6a0f1e6c">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="419f70e2-5e6a-48a8-930a-d55488701243" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0001018" startTime="2016-02-29T13:31:22.6941533-05:00" endTime="2016-02-29T13:31:22.6941533-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="419f70e2-5e6a-48a8-930a-d55488701243">
+    <UnitTestResult executionId="5f71559a-ec53-4fea-9af8-ae5a984eead6" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001058" startTime="2016-04-26T00:41:18.7532711+02:00" endTime="2016-04-26T00:41:18.7532711+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5f71559a-ec53-4fea-9af8-ae5a984eead6">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="58745bc6-950b-44fa-a5fe-478985e2ed78" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0058740" startTime="2016-02-29T13:31:22.6941533-05:00" endTime="2016-02-29T13:31:22.7001463-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="58745bc6-950b-44fa-a5fe-478985e2ed78">
+    <UnitTestResult executionId="a709acb5-59c0-402e-8dcd-7ae701e2b263" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0034423" startTime="2016-04-26T00:41:18.7537713+02:00" endTime="2016-04-26T00:41:18.7572757+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a709acb5-59c0-402e-8dcd-7ae701e2b263">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -598,75 +598,75 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 34.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f25d9785-df62-4803-9145-764d6ef67308" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004149" startTime="2016-02-29T13:31:22.7011470-05:00" endTime="2016-02-29T13:31:22.7011470-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f25d9785-df62-4803-9145-764d6ef67308">
+    <UnitTestResult executionId="77ddc88a-06ae-427d-9ce3-3220c7aba998" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002528" startTime="2016-04-26T00:41:18.7576400+02:00" endTime="2016-04-26T00:41:18.7581434+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="77ddc88a-06ae-427d-9ce3-3220c7aba998">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="760b0de1-dc3a-4559-a94c-c8cd867189f5" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0002097" startTime="2016-02-29T13:31:22.7021471-05:00" endTime="2016-02-29T13:31:22.7021471-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="760b0de1-dc3a-4559-a94c-c8cd867189f5">
+    <UnitTestResult executionId="8c392f9f-7620-403f-8aec-87c70c92ff62" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0001142" startTime="2016-04-26T00:41:18.7581434+02:00" endTime="2016-04-26T00:41:18.7586430+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8c392f9f-7620-403f-8aec-87c70c92ff62">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="00c36296-d9c2-4947-9035-214f41a64332" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0022020" startTime="2016-02-29T13:31:22.7031438-05:00" endTime="2016-02-29T13:31:22.7051444-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="00c36296-d9c2-4947-9035-214f41a64332">
+    <UnitTestResult executionId="3f44cb29-1dfe-4bb4-a54b-422d53719308" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0012735" startTime="2016-04-26T00:41:18.7586430+02:00" endTime="2016-04-26T00:41:18.7601443+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3f44cb29-1dfe-4bb4-a54b-422d53719308">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4f98e324-0a04-4175-afd5-5d704bc20564" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0020819" startTime="2016-02-29T13:31:22.7051444-05:00" endTime="2016-02-29T13:31:22.7081450-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4f98e324-0a04-4175-afd5-5d704bc20564">
+    <UnitTestResult executionId="09ca9d8a-c3c9-44c9-8502-3b0646849487" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0012469" startTime="2016-04-26T00:41:18.7601443+02:00" endTime="2016-04-26T00:41:18.7616450+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="09ca9d8a-c3c9-44c9-8502-3b0646849487">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0356259c-3cf9-4dbf-8fd3-baffefeb0883" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0021986" startTime="2016-02-29T13:31:22.7081450-05:00" endTime="2016-02-29T13:31:22.7101455-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0356259c-3cf9-4dbf-8fd3-baffefeb0883">
+    <UnitTestResult executionId="f9699f38-e96d-4375-a580-55d313d66d52" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0012217" startTime="2016-04-26T00:41:18.7616450+02:00" endTime="2016-04-26T00:41:18.7631458+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f9699f38-e96d-4375-a580-55d313d66d52">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -683,23 +683,23 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="47cca6d3-de44-47a4-806d-526a742a8099" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0070082" startTime="2016-02-29T13:31:22.7111459-05:00" endTime="2016-02-29T13:31:22.7181476-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="47cca6d3-de44-47a4-806d-526a742a8099">
+    <UnitTestResult executionId="a36a0fad-43c8-4236-a910-54967801b670" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0012829" startTime="2016-04-26T00:41:18.7636464+02:00" endTime="2016-04-26T00:41:18.7651476+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a36a0fad-43c8-4236-a910-54967801b670">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -716,61 +716,83 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at lambda_method(Closure , IContextManager , String )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\src\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:line 0
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei lambda_method(Closure , IContextManager , String )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature:Zeile 45.
+   bei Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in D:\Work\pickles-testresults\TestHarness\MsTest\ScenarioOutlines.feature.cs:Zeile 0.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0010482" startTime="2016-02-29T13:31:22.7181476-05:00" endTime="2016-02-29T13:31:22.7201481-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc">
+    <UnitTestResult executionId="58fc9b63-57fa-4af9-afcc-a2ba963c56ae" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0005630" startTime="2016-04-26T00:41:18.7651476+02:00" endTime="2016-04-26T00:41:18.7656477+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="58fc9b63-57fa-4af9-afcc-a2ba963c56ae">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="879519fd-a94d-4ae5-9173-20591899e52b" testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0008580" startTime="2016-02-29T13:31:22.7201481-05:00" endTime="2016-02-29T13:31:22.7211482-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="879519fd-a94d-4ae5-9173-20591899e52b">
+    <UnitTestResult executionId="f55e30be-6806-484c-abbb-694245120daf" testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0005112" startTime="2016-04-26T00:41:18.7661478+02:00" endTime="2016-04-26T00:41:18.7666484+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f55e30be-6806-484c-abbb-694245120daf">
       <Output>
         <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="12c93c51-68b3-4578-bd2e-14b15f688d77" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0000879" startTime="2016-02-29T13:31:22.7221486-05:00" endTime="2016-02-29T13:31:22.7221486-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12c93c51-68b3-4578-bd2e-14b15f688d77" />
-    <UnitTestResult executionId="31091b52-79e0-488f-a271-f704c0430d89" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0013479" startTime="2016-02-29T13:31:22.7231670-05:00" endTime="2016-02-29T13:31:22.7241671-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31091b52-79e0-488f-a271-f704c0430d89">
+    <UnitTestResult executionId="e0d446d2-5ab3-446c-8d6e-46226ba1b788" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0000396" startTime="2016-04-26T00:41:18.7671485+02:00" endTime="2016-04-26T00:41:18.7671485+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e0d446d2-5ab3-446c-8d6e-46226ba1b788" />
+    <UnitTestResult executionId="e2e1a545-25b8-4c1f-97dc-cd09b1f92bef" testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0006451" startTime="2016-04-26T00:41:18.7671485+02:00" endTime="2016-04-26T00:41:18.7686534+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e2e1a545-25b8-4c1f-97dc-cd09b1f92bef">
+      <Output>
+        <StdOut>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 120 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="90a9ecc5-9772-4068-ad21-46db3035a278" testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0002467" startTime="2016-04-26T00:41:18.7686534+02:00" endTime="2016-04-26T00:41:18.7691535+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="90a9ecc5-9772-4068-ad21-46db3035a278">
+      <Output>
+        <StdOut>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+      </Output>
+    </UnitTestResult>
+    <UnitTestResult executionId="2f2191a4-839a-45b7-a1b5-4b03d0c4a50f" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0007356" startTime="2016-04-26T00:41:18.7691535+02:00" endTime="2016-04-26T00:41:18.7701542+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2f2191a4-839a-45b7-a1b5-4b03d0c4a50f">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0017201" startTime="2016-02-29T13:31:22.7251672-05:00" endTime="2016-02-29T13:31:22.7271629-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b">
+    <UnitTestResult executionId="f64aa2ad-9dbc-44bd-be26-33fb70ab4ed0" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0017223" startTime="2016-04-26T00:41:18.7706548+02:00" endTime="2016-04-26T00:41:18.7726561+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f64aa2ad-9dbc-44bd-be26-33fb70ab4ed0">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 7
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:Zeile 7.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f33041be-df5f-457c-8e78-b671ef333130" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0015784" startTime="2016-02-29T13:31:22.7271629-05:00" endTime="2016-02-29T13:31:22.7281630-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f33041be-df5f-457c-8e78-b671ef333130">
+    <UnitTestResult executionId="7c23e7d5-86b0-4569-9544-94c56e6ee911" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0015474" startTime="2016-04-26T00:41:18.7726561+02:00" endTime="2016-04-26T00:41:18.7741569+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7c23e7d5-86b0-4569-9544-94c56e6ee911">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -787,243 +809,253 @@ Shouldly.ChuckedAWobbly:
     False
         but was
     True</Message>
-          <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at lambda_method(Closure , IContextManager )
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:line 10
+          <StackTrace>    bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+   bei lambda_method(Closure , IContextManager )
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Failing.feature:Zeile 10.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004155" startTime="2016-02-29T13:31:22.7291506-05:00" endTime="2016-02-29T13:31:22.7291506-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e44a7b2-d4ab-4669-9675-5a72eaff53c7">
+    <UnitTestResult executionId="f70d4383-48f2-43ec-9a02-0d78f76f6292" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0003942" startTime="2016-04-26T00:41:18.7746570+02:00" endTime="2016-04-26T00:41:18.7751580+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f70d4383-48f2-43ec-9a02-0d78f76f6292">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="765922f5-5658-4a15-96de-d06a70063d76" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0012249" startTime="2016-02-29T13:31:22.7301507-05:00" endTime="2016-02-29T13:31:22.7311508-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="765922f5-5658-4a15-96de-d06a70063d76">
+    <UnitTestResult executionId="06cb4fe8-8c93-4929-bd5f-b2d9da5590ae" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0013295" startTime="2016-04-26T00:41:18.7756581+02:00" endTime="2016-04-26T00:41:18.7771594+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="06cb4fe8-8c93-4929-bd5f-b2d9da5590ae">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
         <ErrorInfo>
           <Message>Assert.Inconclusive failed. One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</Message>
-          <StackTrace>   at lambda_method(Closure , String , Object[] )
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
-   at TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:line 7
+          <StackTrace>   bei lambda_method(Closure , String , Object[] )
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestInconclusive(String message)
+   bei TechTalk.SpecFlow.UnitTestProvider.MsTestRuntimeProvider.TestPending(String message)
+   bei TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\MsTest\Minimal Features\Inconclusive.feature:Zeile 7.
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ea8121e6-4daa-4421-b440-d02288bef8ef" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="DESKTOP-AIFNJPI" duration="00:00:00.0004038" startTime="2016-02-29T13:31:22.7311508-05:00" endTime="2016-02-29T13:31:22.7321515-05:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ea8121e6-4daa-4421-b440-d02288bef8ef">
+    <UnitTestResult executionId="17811f90-5fc5-4207-a9dc-01d0a4e664a2" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="DANIEL-NOTEBOOK" duration="00:00:00.0004254" startTime="2016-04-26T00:41:18.7771594+02:00" endTime="2016-04-26T00:41:18.7781619+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="17811f90-5fc5-4207-a9dc-01d0a4e664a2">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>
   <TestDefinitions>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
-      <Execution id="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
+      <Execution id="0faaf7c1-74d8-4c5d-94fb-b3ae709347e1" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
-      <Execution id="65361449-881c-4f34-8f1c-b3aec990f15e" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
+      <Execution id="7f60248b-8a69-427e-a645-7f56ddddd56a" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
-      <Execution id="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
+      <Execution id="ec67dcee-bd41-4fbe-8791-591f7858f5cc" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
-      <Execution id="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
+    <UnitTest name="FailToAddTwoNumbers" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
+      <Execution id="6d6a7285-c7da-47b5-b43e-c18575512517" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="IgnoredAddingTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
-      <Execution id="8d70d6f0-76c2-43ea-9476-93b10f73bfed" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
+    <UnitTest name="IgnoredAddingTwoNumbers" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
+      <Execution id="a7ccb454-eb47-450c-bbdd-39fea7f680dc" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
-      <Execution id="29a76e0f-6591-45fa-96de-7719fe7b4a9c" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
+      <Execution id="1f3ad742-cef0-4bf4-a803-a28b1602527a" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
-      <Execution id="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
+      <Execution id="13d9b0f1-12b4-4365-bc26-93ac2fb0d745" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
-      <Execution id="cea33f60-e243-4965-b63e-597c8a88d2f9" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
+      <Execution id="37d7c0a6-d24f-44aa-9a61-fdd2996b68cf" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
-      <Execution id="9388824a-0969-41ed-a65f-944972aea091" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
+      <Execution id="21ffc846-f35a-4e0c-a371-7ae651f4aa8f" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
-      <Execution id="a5b25781-7d96-483c-8ea8-95e20603919f" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
+    <UnitTest name="NotAutomatedScenario1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
+      <Execution id="65f182b5-b4f5-4a64-ad71-d6a25fdcda7f" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
-      <Execution id="03240585-ad45-4dac-b760-9754938af626" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
+    <UnitTest name="NotAutomatedScenario2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
+      <Execution id="4844e042-ef59-4828-aa5f-96a111cca811" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
-      <Execution id="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
+    <UnitTest name="NotAutomatedScenario3" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
+      <Execution id="b9f84e1d-ebb4-4c9b-9538-ff2085f939b1" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
-      <Execution id="5c954959-f9e2-4f11-a707-3391ee0382ad" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
+      <Execution id="d9768042-79f4-4c16-a34c-87469b5c5818" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
-      <Execution id="091433bf-fed1-470e-b06c-cb4b7b972e6e" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
+      <Execution id="5ea8df5a-da16-4fd0-9532-02f345ed4f07" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
-      <Execution id="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
+      <Execution id="0f2ae577-83ce-4598-9f5d-b8c410027dfd" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
-      <Execution id="e8b916c9-e2cd-4024-b8db-066ec4c977db" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
+      <Execution id="e034dcba-b4be-4630-b0cb-e0a22bc121ce" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
-      <Execution id="d40e68a2-8718-4471-ab2a-8edda2509a11" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
+      <Execution id="9727de58-2d38-4205-8d8b-9ebd13659d29" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
-      <Execution id="3f2955ce-7301-4d16-8632-62450d7586c0" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
+      <Execution id="47a72276-c2fd-4c3e-9c70-08ad45c16295" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
-      <Execution id="18072b05-d227-43a5-a03b-e7b5b137f8b0" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
+      <Execution id="8a6cea0b-efae-41c8-9341-e6ff6a0f1e6c" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
-      <Execution id="419f70e2-5e6a-48a8-930a-d55488701243" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
+      <Execution id="5f71559a-ec53-4fea-9af8-ae5a984eead6" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
-      <Execution id="58745bc6-950b-44fa-a5fe-478985e2ed78" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
+      <Execution id="a709acb5-59c0-402e-8dcd-7ae701e2b263" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
-      <Execution id="f25d9785-df62-4803-9145-764d6ef67308" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
+      <Execution id="77ddc88a-06ae-427d-9ce3-3220c7aba998" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
-      <Execution id="760b0de1-dc3a-4559-a94c-c8cd867189f5" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
+      <Execution id="8c392f9f-7620-403f-8aec-87c70c92ff62" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
-      <Execution id="00c36296-d9c2-4947-9035-214f41a64332" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
+      <Execution id="3f44cb29-1dfe-4bb4-a54b-422d53719308" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
-      <Execution id="4f98e324-0a04-4175-afd5-5d704bc20564" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
+      <Execution id="09ca9d8a-c3c9-44c9-8502-3b0646849487" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
-      <Execution id="0356259c-3cf9-4dbf-8fd3-baffefeb0883" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
+      <Execution id="f9699f38-e96d-4375-a580-55d313d66d52" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
-      <Execution id="47cca6d3-de44-47a4-806d-526a742a8099" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
+      <Execution id="a36a0fad-43c8-4236-a910-54967801b670" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
-      <Execution id="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
+      <Execution id="58fc9b63-57fa-4af9-afcc-a2ba963c56ae" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91">
-      <Execution id="879519fd-a94d-4ae5-9173-20591899e52b" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91">
+      <Execution id="f55e30be-6806-484c-abbb-694245120daf" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
-      <Execution id="12c93c51-68b3-4578-bd2e-14b15f688d77" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
+    <UnitTest name="TestMethod" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
+      <Execution id="e0d446d2-5ab3-446c-8d6e-46226ba1b788" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
-      <Execution id="31091b52-79e0-488f-a271-f704c0430d89" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
+    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f">
+      <Execution id="e2e1a545-25b8-4c1f-97dc-cd09b1f92bef" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
-      <Execution id="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
+    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="efcbe7cc-31a8-2063-2ba3-daddc29b814d">
+      <Execution id="90a9ecc5-9772-4068-ad21-46db3035a278" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
-      <Execution id="f33041be-df5f-457c-8e78-b671ef333130" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
+    <UnitTest name="FailingFeaturePassingScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
+      <Execution id="2f2191a4-839a-45b7-a1b5-4b03d0c4a50f" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
-      <Execution id="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
+      <Execution id="f64aa2ad-9dbc-44bd-be26-33fb70ab4ed0" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
-      <Execution id="765922f5-5658-4a15-96de-d06a70063d76" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
+    <UnitTest name="FailingFeatureFailingScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
+      <Execution id="7c23e7d5-86b0-4569-9544-94c56e6ee911" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\src\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
-      <Execution id="ea8121e6-4daa-4421-b440-d02288bef8ef" />
-      <TestMethod codeBase="C:\src\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
+      <Execution id="f70d4383-48f2-43ec-9a02-0d78f76f6292" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
+    </UnitTest>
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
+      <Execution id="06cb4fe8-8c93-4929-bd5f-b2d9da5590ae" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
+    </UnitTest>
+    <UnitTest name="PassingFeaturePassingScenario" storage="d:\work\pickles-testresults\testharness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
+      <Execution id="17811f90-5fc5-4207-a9dc-01d0a4e664a2" />
+      <TestMethod codeBase="D:\Work\pickles-testresults\TestHarness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>
-    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="60c1b5fd-b6fa-49b1-ad0d-807ae252fe39" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="65361449-881c-4f34-8f1c-b3aec990f15e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="f5d459f6-fcd4-460c-af5a-20bcf57ead8f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="b2157d35-1a6c-4a5a-ad22-d63fc2b92a30" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="8d70d6f0-76c2-43ea-9476-93b10f73bfed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="29a76e0f-6591-45fa-96de-7719fe7b4a9c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="6ea2f4b5-3a2e-468d-a1f3-cf1040a4ff9b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="cea33f60-e243-4965-b63e-597c8a88d2f9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="9388824a-0969-41ed-a65f-944972aea091" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="a5b25781-7d96-483c-8ea8-95e20603919f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="03240585-ad45-4dac-b760-9754938af626" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="fa70f3ab-b35c-49b6-b035-75e5e3c9d8d5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="5c954959-f9e2-4f11-a707-3391ee0382ad" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="091433bf-fed1-470e-b06c-cb4b7b972e6e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="23ff0c73-6cc8-4e6f-b179-964f6547f7d1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="e8b916c9-e2cd-4024-b8db-066ec4c977db" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="d40e68a2-8718-4471-ab2a-8edda2509a11" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="3f2955ce-7301-4d16-8632-62450d7586c0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="18072b05-d227-43a5-a03b-e7b5b137f8b0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="419f70e2-5e6a-48a8-930a-d55488701243" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="58745bc6-950b-44fa-a5fe-478985e2ed78" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="f25d9785-df62-4803-9145-764d6ef67308" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="760b0de1-dc3a-4559-a94c-c8cd867189f5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="00c36296-d9c2-4947-9035-214f41a64332" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="4f98e324-0a04-4175-afd5-5d704bc20564" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="0356259c-3cf9-4dbf-8fd3-baffefeb0883" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="47cca6d3-de44-47a4-806d-526a742a8099" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="d4466368-b8ab-4bfc-b17b-a32e54d6e7fc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" executionId="879519fd-a94d-4ae5-9173-20591899e52b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="12c93c51-68b3-4578-bd2e-14b15f688d77" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="31091b52-79e0-488f-a271-f704c0430d89" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="d0e2c2b1-ebd9-47fa-98a0-eb11b9f52d2b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="f33041be-df5f-457c-8e78-b671ef333130" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="1e44a7b2-d4ab-4669-9675-5a72eaff53c7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="765922f5-5658-4a15-96de-d06a70063d76" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="ea8121e6-4daa-4421-b440-d02288bef8ef" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="0faaf7c1-74d8-4c5d-94fb-b3ae709347e1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="7f60248b-8a69-427e-a645-7f56ddddd56a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="ec67dcee-bd41-4fbe-8791-591f7858f5cc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="6d6a7285-c7da-47b5-b43e-c18575512517" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="a7ccb454-eb47-450c-bbdd-39fea7f680dc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="1f3ad742-cef0-4bf4-a803-a28b1602527a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="13d9b0f1-12b4-4365-bc26-93ac2fb0d745" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="37d7c0a6-d24f-44aa-9a61-fdd2996b68cf" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="21ffc846-f35a-4e0c-a371-7ae651f4aa8f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="65f182b5-b4f5-4a64-ad71-d6a25fdcda7f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="4844e042-ef59-4828-aa5f-96a111cca811" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="b9f84e1d-ebb4-4c9b-9538-ff2085f939b1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="d9768042-79f4-4c16-a34c-87469b5c5818" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="5ea8df5a-da16-4fd0-9532-02f345ed4f07" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="0f2ae577-83ce-4598-9f5d-b8c410027dfd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="e034dcba-b4be-4630-b0cb-e0a22bc121ce" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="9727de58-2d38-4205-8d8b-9ebd13659d29" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="47a72276-c2fd-4c3e-9c70-08ad45c16295" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="8a6cea0b-efae-41c8-9341-e6ff6a0f1e6c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="5f71559a-ec53-4fea-9af8-ae5a984eead6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="a709acb5-59c0-402e-8dcd-7ae701e2b263" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="77ddc88a-06ae-427d-9ce3-3220c7aba998" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="8c392f9f-7620-403f-8aec-87c70c92ff62" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="3f44cb29-1dfe-4bb4-a54b-422d53719308" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="09ca9d8a-c3c9-44c9-8502-3b0646849487" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="f9699f38-e96d-4375-a580-55d313d66d52" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="a36a0fad-43c8-4236-a910-54967801b670" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="58fc9b63-57fa-4af9-afcc-a2ba963c56ae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" executionId="f55e30be-6806-484c-abbb-694245120daf" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="e0d446d2-5ab3-446c-8d6e-46226ba1b788" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" executionId="e2e1a545-25b8-4c1f-97dc-cd09b1f92bef" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" executionId="90a9ecc5-9772-4068-ad21-46db3035a278" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="2f2191a4-839a-45b7-a1b5-4b03d0c4a50f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="f64aa2ad-9dbc-44bd-be26-33fb70ab4ed0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="7c23e7d5-86b0-4569-9544-94c56e6ee911" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="f70d4383-48f2-43ec-9a02-0d78f76f6292" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="06cb4fe8-8c93-4929-bd5f-b2d9da5590ae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="17811f90-5fc5-4207-a9dc-01d0a4e664a2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <TestLists>
     <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <ResultSummary outcome="Failed">
-    <Counters total="36" executed="26" passed="18" failed="8" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
+    <Counters total="38" executed="28" passed="20" failed="8" error="0" timeout="0" aborted="0" inconclusive="0" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
     <Output>
       <StdOut>Test 'IgnoredAddingTwoNumbers' was skipped in the test run.Test 'NotAutomatedAddingTwoNumbers' was skipped in the test run.Test 'NotAutomatedScenario1' was skipped in the test run.Test 'NotAutomatedScenario2' was skipped in the test run.Test 'NotAutomatedScenario3' was skipped in the test run.Test 'ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1' was skipped in the test run.Test 'AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1' was skipped in the test run.Test 'AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2' was skipped in the test run.Test 'FailingFeatureInconclusiveScenario' was skipped in the test run.Test 'InconclusiveFeatureInconclusiveScenario' was skipped in the test run.</StdOut>
     </Output>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/WhenParsingxUnitResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/WhenParsingxUnitResultsFile.cs
@@ -111,5 +111,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.XUnit.XUnit1
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
@@ -1,36 +1,60 @@
-<assembly name="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-02-29" run-time="13:31:14" configFile="C:\src\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.334" total="35" passed="17" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.278" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.182"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+<assembly name="D:\Work\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-04-26" run-time="00:40:49" configFile="D:\Work\pickles-testresults\TestHarness\xunit\bin\Debug\xunitHarness.dll.config" time="0.746" total="37" passed="19" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.593" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.306"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3.2 on the screen
--&gt; error: Input string was not in a correct format.
-</output><failure exception-type="System.FormatException"><message>System.FormatException : Input string was not in a correct format.</message><stack-trace>   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.014"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; error: Die Eingabezeichenfolge hat das falsche Format.
+</output><failure exception-type="System.FormatException"><message>System.FormatException : Die Eingabezeichenfolge hat das falsche Format.</message><stack-trace>   bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
+   bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   bei System.Linq.Enumerable.&lt;SelectIterator&gt;d__5`2.MoveNext()
+   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit\Addition.feature:Zeile 34.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.168"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.081"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,2s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.003"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 60 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+And I have entered 130 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 260 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 40 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+And I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+And I have entered 90 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 180 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.116"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -83,97 +107,9 @@ namespace MyNamespace
         }
     }
 }
-</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\Addition.feature:line 46</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
-Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
-And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
-And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
-Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
-Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
-And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
-And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
-Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
-</output></test></class><class time="0.020" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.017"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
--&gt; error: 
-    1
-        should be
-    2
-        but was
-    1
-And the calculator has clean memory
--&gt; skipped because of previous errors
-Given I have entered 60 into the calculator
--&gt; skipped because of previous errors
-And I have entered 70 into the calculator
--&gt; skipped because of previous errors
-And I have entered 130 into the calculator
--&gt; skipped because of previous errors
-When I press add
--&gt; skipped because of previous errors
-Then the result should be 260 on the screen
--&gt; skipped because of previous errors
-</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    1
-        should be
-    2
-        but was
-    1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
--&gt; error: 
-    1
-        should be
-    2
-        but was
-    1
-And the calculator has clean memory
--&gt; skipped because of previous errors
-Given I have entered 40 into the calculator
--&gt; skipped because of previous errors
-And I have entered 50 into the calculator
--&gt; skipped because of previous errors
-And I have entered 90 into the calculator
--&gt; skipped because of previous errors
-When I press add
--&gt; skipped because of previous errors
-Then the result should be 180 on the screen
--&gt; skipped because of previous errors
-</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    1
-        should be
-    2
-        but was
-    1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
+</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit\Addition.feature:Zeile 46.</stack-trace></failure></test></class><class time="0.110" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.105"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -195,250 +131,281 @@ Then the result should be 120 on the screen
         should be
     2
         but was
-    1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.015" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-When unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Then unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
-using System;
-using TechTalk.SpecFlow;
-
-namespace MyNamespace
-{
-    [Binding]
-    public class StepDefinitions
-    {
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-    }
-}
-</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-When unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Then unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
-using System;
-using TechTalk.SpecFlow;
-
-namespace MyNamespace
-{
-    [Binding]
-    public class StepDefinitions
-    {
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-    }
-}
-</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-When unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Then unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
-using System;
-using TechTalk.SpecFlow;
-
-namespace MyNamespace
-{
-    [Binding]
-    public class StepDefinitions
-    {
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-    }
-}
-</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test></class><class time="0.014" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="17" passed="11" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
+    1</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature:Zeile 12.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
-    true
+    1
         should be
-    False
+    2
         but was
-    True
+    1
+And the calculator has clean memory
+-&gt; skipped because of previous errors
+Given I have entered 60 into the calculator
+-&gt; skipped because of previous errors
+And I have entered 70 into the calculator
+-&gt; skipped because of previous errors
+And I have entered 130 into the calculator
+-&gt; skipped because of previous errors
+When I press add
+-&gt; skipped because of previous errors
+Then the result should be 260 on the screen
+-&gt; skipped because of previous errors
 </output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    true
+    1
         should be
-    False
+    2
         but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
--&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+    1</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature:Zeile 19.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+-&gt; error: 
+    1
+        should be
+    2
+        but was
+    1
+And the calculator has clean memory
+-&gt; skipped because of previous errors
+Given I have entered 40 into the calculator
+-&gt; skipped because of previous errors
+And I have entered 50 into the calculator
+-&gt; skipped because of previous errors
+And I have entered 90 into the calculator
+-&gt; skipped because of previous errors
+When I press add
+-&gt; skipped because of previous errors
+Then the result should be 180 on the screen
+-&gt; skipped because of previous errors
+</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
+    1
+        should be
+    2
+        but was
+    1</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\FailingBackground.feature:Zeile 19.</stack-trace></failure></test></class><class time="0.019" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+When unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Then unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
+using System;
+using TechTalk.SpecFlow;
+
+namespace MyNamespace
+{
+    [Binding]
+    public class StepDefinitions
+    {
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+    }
+}
+</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:Zeile 9.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.008"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+When unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Then unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
+using System;
+using TechTalk.SpecFlow;
+
+namespace MyNamespace
+{
+    [Binding]
+    public class StepDefinitions
+    {
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+    }
+}
+</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:Zeile 14.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+When unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Then unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
+using System;
+using TechTalk.SpecFlow;
+
+namespace MyNamespace
+{
+    [Binding]
+    public class StepDefinitions
+    {
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+    }
+}
+</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in D:\Work\pickles-testresults\TestHarness\xunit\NotAutomatedAtAll.feature:Zeile 19.</stack-trace></failure></test></class><class time="0.016" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="17" passed="11" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
+  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 45.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
+  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 45.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -450,15 +417,15 @@ namespace MyNamespace
         should be
     False
         but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
+    True</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 45.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
 -&gt; error: 
     true
         should be
@@ -470,23 +437,36 @@ namespace MyNamespace
         should be
     False
         but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+    True</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 45.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example an 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
-</output></test></class><class time="0.005" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
+-&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
+  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 21.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -498,28 +478,62 @@ namespace MyNamespace
         should be
     False
         but was
-    True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
-</output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
+    True</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit\ScenarioOutlines.feature:Zeile 34.</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" total="2" passed="2" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+Given I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+Then the result should be 120 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)
+</output></test></class><class time="0.006" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+-&gt; error: 
+    true
+        should be
+    False
+        but was
+    True
+</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
+    true
+        should be
+    False
+        but was
+    True</message><stack-trace>   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:Zeile 10.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
+  MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Failing.feature:Zeile 7.</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
+</output></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
 </output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
+  MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\xunit\Minimal Features\Inconclusive.feature:Zeile 7.</stack-trace></failure></test></class><class time="0.000" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
 </output></test></class></assembly>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/WhenParsingxUnit2ResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/WhenParsingxUnit2ResultsFile.cs
@@ -111,5 +111,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.XUnit.XUnit2
         {
             base.ThenCanReadResultOfScenarioOutlineExampleWithFailingBackground();
         }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioWithSpecialCharacters();
+        }
+
+        [Test]
+        public new void ThenCanReadResultOfScenarioOutlineWithSpecialCharacters()
+        {
+            base.ThenCanReadResultOfScenarioOutlineWithSpecialCharacters();
+        }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
@@ -1,89 +1,365 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assemblies>
-  <assembly name="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-02-29" run-time="13:31:15" config-file="C:\src\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="35" passed="17" failed="17" skipped="1" time="0.922" errors="0">
+  <assembly name="D:\Work\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-04-26" run-time="00:40:53" config-file="D:\Work\pickles-testresults\TestHarness\xunit2\bin\Debug\xunit2Harness.dll.config" total="37" passed="19" failed="17" skipped="1" time="1.726" errors="0">
     <errors />
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.097">
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0858221" result="Fail">
+    <collection total="17" passed="11" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.062">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0033965" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0020777" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0020306" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0023487" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0032682" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0067292" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario fails" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 34.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0088421" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0021397" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0033886" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 21.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0024545" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0020786" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0035733" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.003347" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0031581" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0031432" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in D:\Work\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:Zeile 21.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:Zeile 45.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0057108" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with parenthesis in the examples" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0043118" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenario Outlines" />
+          <trait name="Description" value="Deal correctly with backslashes in the examples" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.156">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0024076" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.1505908" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Failing Scenario" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:Zeile 24.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:Zeile 10.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0027648" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing" />
+          <trait name="Description" value="Failing Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:Zeile 7.]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="2" passed="2" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" time="0.067">
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" time="0.0253361" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" time="0.0413514" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.039">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0153532" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
         <failure exception-type="Shouldly.ChuckedAWobbly">
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:Zeile 19.]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0067753" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0130668" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
         <failure exception-type="Shouldly.ChuckedAWobbly">
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:Zeile 19.]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0048399" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0107427" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing Background" />
           <trait name="Description" value="Add two numbers" />
         </traits>
         <failure exception-type="Shouldly.ChuckedAWobbly">
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\src\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:line 12]]></stack-trace>
+          <stack-trace><![CDATA[   bei Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:Zeile 18.
+   bei Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:Zeile 17.
+   bei AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in D:\Work\pickles-testresults\TestHarness\AutomationLayer\AdditionSteps.cs:Zeile 25.
+   bei TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit2\FailingBackground.feature:Zeile 12.]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.021">
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.006154" result="Pass">
+    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.221">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.165995" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0551102" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in D:\Work\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:Zeile 7.]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.169">
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.115866" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 2" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:Zeile 14.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0266974" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 3" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:Zeile 19.]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0261464" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 1" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in D:\Work\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:Zeile 9.]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.002">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0021794" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Passing" />
+          <trait name="Description" value="Passing Feature Passing Scenario" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.075">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0152651" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0019932" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0135082" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0066196" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0201924" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Not automated adding two numbers" />
         </traits>
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature:line 46]]></stack-trace>
+          <stack-trace><![CDATA[   bei TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   bei Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit2\Addition.feature:Zeile 46.]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0020522" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0117144" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Add two numbers" />
@@ -96,288 +372,26 @@
         </traits>
         <reason><![CDATA[Ignored]]></reason>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0038321" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0140861" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Fail to add two numbers" />
         </traits>
         <failure exception-type="System.FormatException">
-          <message><![CDATA[System.FormatException : Input string was not in a correct format.]]></message>
-          <stack-trace><![CDATA[   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
-   at System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
-   at System.String.System.IConvertible.ToInt32(IFormatProvider provider)
-   at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
-   at System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
-   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
-   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in C:\src\pickles-testresults\TestHarness\xunit2\Addition.feature:line 34]]></stack-trace>
+          <message><![CDATA[System.FormatException : Die Eingabezeichenfolge hat das falsche Format.]]></message>
+          <stack-trace><![CDATA[   bei System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer& number, NumberFormatInfo info, Boolean parseDecimal)
+   bei System.Number.ParseInt32(String s, NumberStyles style, NumberFormatInfo info)
+   bei System.String.System.IConvertible.ToInt32(IFormatProvider provider)
+   bei System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
+   bei System.Linq.Enumerable.<SelectIterator>d__5`2.MoveNext()
+   bei System.Linq.Buffer`1..ctor(IEnumerable`1 source)
+   bei System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   bei TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   bei Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in D:\Work\pickles-testresults\TestHarness\xunit2\Addition.feature.cs:Zeile 0.
+   bei Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in D:\Work\pickles-testresults\TestHarness\xunit2\Addition.feature:Zeile 34.]]></stack-trace>
         </failure>
-      </test>
-    </collection>
-    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.004">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0012419" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0025451" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="17" passed="11" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.033">
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0038048" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0004233" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0005659" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where all scenarios pass" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0005764" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003229" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0070835" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario fails" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0006553" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0003766" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0073032" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0007401" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0005" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0015254" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0016901" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0026199" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0026273" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\src\pickles-testresults\TestHarness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\src\pickles-testresults\TestHarness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0014107" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="Deal correctly with parenthesis in the examples" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0009254" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenario Outlines" />
-          <trait name="Description" value="Deal correctly with backslashes in the examples" />
-        </traits>
-      </test>
-    </collection>
-    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.006">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.001077" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0031601" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Failing Scenario" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\src\pickles-testresults\TestHarness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0019713" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing" />
-          <trait name="Description" value="Failing Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\src\pickles-testresults\TestHarness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.102">
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.0862641" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 2" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.007645" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 3" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0080992" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 1" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature.cs:line 0
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\src\pickles-testresults\TestHarness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.124">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.1237773" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Passing" />
-          <trait name="Description" value="Passing Feature Passing Scenario" />
-        </traits>
       </test>
     </collection>
   </assembly>

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitExampleSignatureBuilder.cs
@@ -34,9 +34,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit
         {
             var stringBuilder = new StringBuilder();
 
-            var name = scenarioOutline.Name.ToLowerInvariant();
-            name = PunctuationCharactersRegex.Replace(name, "_");
-            name = NonIdentifierCharacterRegex.Replace(name, string.Empty);
+            var name = SpecFlowNameMapping.Build(scenarioOutline.Name.ToLowerInvariant());
             stringBuilder.Append(name).Append("\\(");
 
             foreach (string value in row)

--- a/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
+++ b/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
@@ -56,6 +56,7 @@
     <Compile Include="CucumberJson\CucumberJsonSingleResultLoader.cs" />
     <Compile Include="IScenarioOutlineExampleMatcher.cs" />
     <Compile Include="ISingleResultLoader.cs" />
+    <Compile Include="SpecFlowNameMapping.cs" />
     <Compile Include="VsTest\VsTestElementExtensions.cs" />
     <Compile Include="VsTest\VsTestExampleSignatureBuilder.cs" />
     <Compile Include="VsTest\VsTestResults.cs" />

--- a/src/Pickles/Pickles.TestFrameworks/SpecFlowNameMapping.cs
+++ b/src/Pickles/Pickles.TestFrameworks/SpecFlowNameMapping.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.RegularExpressions;
+
+namespace PicklesDoc.Pickles.TestFrameworks
+{
+	internal static class SpecFlowNameMapping
+	{
+		private static readonly Regex PunctuationCharactersRegex = new Regex(@"[\n\.-]+", RegexOptions.Compiled);
+		private static readonly Regex NonIdentifierCharacterRegex = new Regex(@"[^\p{Ll}\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}\p{Pc}]", RegexOptions.Compiled);
+
+		public static string Build(string name)
+		{
+			name = PunctuationCharactersRegex.Replace(name, "_");
+			name = NonIdentifierCharacterRegex.Replace(name, string.Empty);
+			return name;
+		}
+	}
+}

--- a/src/Pickles/Pickles.TestFrameworks/SpecRun/SpecRunExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/SpecRun/SpecRunExampleSignatureBuilder.cs
@@ -31,7 +31,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.SpecRun
         public Regex Build(ScenarioOutline scenarioOutline, string[] row)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(scenarioOutline.Name);
+            stringBuilder.Append(Regex.Escape(scenarioOutline.Name));
             stringBuilder.Append("(, Examples (\\d*))?");
             stringBuilder.Append(", " + row[0]);
 

--- a/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
+++ b/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
@@ -143,7 +143,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.VsTest
 
         private static string TransformName(string name)
         {
-            return name.Replace(" ", "").Replace(".", "_").ToUpperInvariant();
+            return SpecFlowNameMapping.Build(name).ToUpperInvariant();
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
@@ -18,7 +18,6 @@
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
-using System;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -31,7 +30,9 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit
         public Regex Build(ScenarioOutline scenarioOutline, string[] row)
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(scenarioOutline.Name.ToLowerInvariant().Replace(" ", string.Empty) + "\\(");
+
+            var name = SpecFlowNameMapping.Build(scenarioOutline.Name.ToLowerInvariant());
+            stringBuilder.Append(name).Append("\\(");
 
             foreach (string value in row)
             {


### PR DESCRIPTION
Adresses issue #326

Updated test data by scenario and scenario outline with special characters (hyphen, comma, parantheses) and added tests for parsing the result data.

Refactored out name mapping logic from issue #315 and use for nunit, xunit and vstest. Fix name handling for SpecRun (regex escaping).