### PR TITLE
Enhancement to support Unix path!

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/heirarchyBuilder.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/heirarchyBuilder.js
@@ -68,7 +68,7 @@ function getElementInDirectoryList(list, dirName) {
 };
 
 function splitDirectoryPathIntoArrayOfFormattedFolders(path) {
-    var paths = $.map(path.split('\\'), function (directory) {
+    var paths = $.map(path.split(/[\\/]+/), function (directory) {
         return directory;
     });
 
@@ -88,7 +88,7 @@ function getFoldersWithASubdirectory(folderList) {
 }
 
 function folderHasSubdirectory(folder) {
-    return folder.indexOf('\\') > -1;
+    return folder.indexOf('\\') > -1 || folder.indexOf('/') > -1;
 }
 
 


### PR DESCRIPTION
I'm not sure you already got a try or a feedback about it but actually pickles run relatively well under Linux with mono which is interesting when like me you can't get a windows machine.

However without this little change we can't get the folder structure display correctly.

Could you integrate this modification?

Thanks