### PR TITLE
Handle Encoding or Opposite Slash in Feature Paths

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
@@ -29,6 +29,7 @@
 
         var queryVars = query.split('&');
 
+        // find feature query param
         for (var i=0;i<queryVars.length;i++) {
             var pair = queryVars[i].split('=');
             if (pair[0] == 'feature') {
@@ -84,6 +85,10 @@ function getFeaturesMatching(searchString, features) {
 }
 
 function findFeatureByRelativeFolder(path, features) {
+    // make sure path is not url encoded, and replace forward-slashes with back-slashes to match JSON
+    path = decodeURIComponent(path);
+    path = path.replace(/\//g, '\\');
+
     var feature = _.find(features, function(featureTesting) {
         return featureTesting.RelativeFolder == path;
     });


### PR DESCRIPTION
With the DHTML site, we found that if the `?feature=....` portion was URL encoded, the `\` characters are replaced with `%5C`, which breaks the deep-linking feature.  This simple change decodes the url and changes any `/` characters in the feature path to `\` to match what is in the `pickledFeatures.js` file and `RelativeFolder` property used to locate the feature.