### PR TITLE
Added test for sorting when generating word docs

### DIFF
--- a/src/Pickles/Pickles.Test/BaseFixture.cs
+++ b/src/Pickles/Pickles.Test/BaseFixture.cs
@@ -92,6 +92,10 @@ namespace PicklesDoc.Pickles.Test
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne", new[] { "ignorethisfile.ignore", "LevelOneSublevelOne.feature", "LevelOneSublevelTwo.feature" });
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne\SubLevelTwo", new[] { "LevelOneSublevelOneSubLevelTwo.feature" });
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne\SubLevelTwo\IgnoreThisDirectory", new[] { "IgnoreThisFile.ignore" });
+
+            this.AddFakeFolderAndFiles(@"OrderingTests", new string[0]);
+            this.AddFakeFolderAndFiles(@"OrderingTests\A", new [] {"a-a.feature", "a-b.feature"});
+            this.AddFakeFolderAndFiles(@"OrderingTests\B", new [] {"b-a.feature", "b-b.feature"});
         }
 
         protected void AddFakeFolderAndFiles(string directoryName, IEnumerable<string> fileNames)

--- a/src/Pickles/Pickles.Test/DocumentationBuilders/Word/WhenBuildingWordDocuments.cs
+++ b/src/Pickles/Pickles.Test/DocumentationBuilders/Word/WhenBuildingWordDocuments.cs
@@ -1,0 +1,79 @@
+﻿using System.IO;
+using System.Linq;
+using Autofac;
+using DocumentFormat.OpenXml;
+using DocumentFormat.OpenXml.Packaging;
+using DocumentFormat.OpenXml.Wordprocessing;
+using NUnit.Framework;
+using PicklesDoc.Pickles.DataStructures;
+using PicklesDoc.Pickles.DirectoryCrawler;
+using PicklesDoc.Pickles.DocumentationBuilders.Word;
+
+namespace PicklesDoc.Pickles.Test.DocumentationBuilders.Word
+{
+    [TestFixture]
+    public class WhenBuildingWordDocuments : BaseFixture
+    {
+        private WordDocumentationBuilder builder;
+        private Tree features;
+        private const string RootPath = FileSystemPrefix + @"OrderingTests";
+
+        [SetUp]
+        public void Setup()
+        {
+            AddFakeFolderStructures();
+
+            Configuration.OutputFolder = this.FileSystem.DirectoryInfo.FromDirectoryName(FileSystemPrefix);
+            features = Container.Resolve<DirectoryTreeCrawler>().Crawl(RootPath);
+            builder = Container.Resolve<WordDocumentationBuilder>();
+        }
+
+        [Test]
+        public void ShouldOutputFeaturesInParsedOrder()
+        {
+            string[] expectedSequence = {
+                "a-a",
+                "a-a-a",
+                "a-a-b",
+                "a-b",
+                "a-b-a",
+                "a-b-b",
+                "b-a",
+                "b-a-a",
+                "b-a-b",
+                "b-b",
+                "b-b-a",
+                "b-b-b",
+            };
+
+            builder.Build(features);
+
+            var doc = WordprocessingDocument.Open(Path.Combine(Configuration.OutputFolder.FullName, "features.docx"), false);
+            var body = doc.MainDocumentPart.Document.Body;
+            var headings = body.Where(IsHeading).Select(InnerText);
+
+            Assert.That(headings, Is.EquivalentTo(expectedSequence));
+
+        }
+
+        private static string InnerText(OpenXmlElement part)
+        {
+            return part.InnerText;
+        }
+
+        private static bool IsHeading(OpenXmlElement part)
+        {
+            return part.OfType<ParagraphProperties>().Any(IsHeading);
+        }
+
+        private static bool IsHeading(ParagraphProperties property)
+        {
+            return property.OfType<ParagraphStyleId>().Any(IsHeading);
+        }
+
+        private static bool IsHeading(ParagraphStyleId styleId)
+        {
+            return styleId.Val.HasValue && styleId.Val.Value.StartsWith("Heading");
+        }
+    }
+}

--- a/src/Pickles/Pickles.Test/DocumentationBuilders/Word/WhenBuildingWordDocuments.cs
+++ b/src/Pickles/Pickles.Test/DocumentationBuilders/Word/WhenBuildingWordDocuments.cs
@@ -48,11 +48,16 @@ namespace PicklesDoc.Pickles.Test.DocumentationBuilders.Word
 
             builder.Build(features);
 
-            var doc = WordprocessingDocument.Open(Path.Combine(Configuration.OutputFolder.FullName, "features.docx"), false);
-            var body = doc.MainDocumentPart.Document.Body;
-            var headings = body.Where(IsHeading).Select(InnerText);
+            var outputPath = Path.Combine(Configuration.OutputFolder.FullName, "features.docx");
 
-            Assert.That(headings, Is.EquivalentTo(expectedSequence));
+            using (var stream = this.FileSystem.File.OpenRead(outputPath))
+            {
+                var doc = WordprocessingDocument.Open(stream, false);
+                var body = doc.MainDocumentPart.Document.Body;
+                var headings = body.Where(IsHeading).Select(InnerText);
+
+                Assert.That(headings, Is.EquivalentTo(expectedSequence));
+            }
 
         }
 

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/A/a-a.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/A/a-a.feature
@@ -1,0 +1,13 @@
+﻿Feature: a-a
+	In order to generate nice docs
+	As a generator
+	I want to output this feature first
+
+@mytag
+Scenario: a-a-a
+	Given I am first
+	Then All is well
+
+Scenario: a-a-b
+	Given I am second
+	Then All is well

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/A/a-b.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/A/a-b.feature
@@ -1,0 +1,13 @@
+﻿Feature: a-b
+	In order to generate nice docs
+	As a generator
+	I want to output this feature first
+
+@mytag
+Scenario: a-b-a
+	Given I am first
+	Then All is well
+
+Scenario: a-b-b
+	Given I am second
+	Then All is well

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/B/b-a.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/B/b-a.feature
@@ -1,0 +1,13 @@
+﻿Feature: b-a
+	In order to generate nice docs
+	As a generator
+	I want to output this feature first
+
+@mytag
+Scenario: b-a-a
+	Given I am first
+	Then All is well
+
+Scenario: b-a-b
+	Given I am second
+	Then All is well

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/B/b-b.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/OrderingTests/B/b-b.feature
@@ -1,0 +1,13 @@
+﻿Feature: b-b
+	In order to generate nice docs
+	As a generator
+	I want to output this feature first
+
+@mytag
+Scenario: b-b-a
+	Given I am first
+	Then All is well
+
+Scenario: b-b-b
+	Given I am second
+	Then All is well

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -86,6 +86,7 @@
       <HintPath>..\packages\SpecFlow.2.0.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\VersionInfo.cs">
@@ -108,6 +109,7 @@
       <DependentUpon>FormattingAFeature.feature</DependentUpon>
     </Compile>
     <Compile Include="DocumentationBuilders\Word\WordDescriptionFormatterTests.cs" />
+    <Compile Include="DocumentationBuilders\Word\WhenBuildingWordDocuments.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ObjectModel\Factory.cs" />
     <Compile Include="ObjectModel\Json\CommentToJsonCommentMapperTests.cs" />
@@ -226,6 +228,18 @@
       <LastGenOutput>FormattingAFeature.feature.cs</LastGenOutput>
     </None>
     <EmbeddedResource Include="HtmlFormatterTestFiles\Comment.feature" />
+    <EmbeddedResource Include="FakeFolderStructures\OrderingTests\A\a-b.feature">
+      <LastGenOutput>a-b.feature.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\OrderingTests\A\a-a.feature">
+      <LastGenOutput>a-a.feature.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\OrderingTests\B\b-a.feature">
+      <LastGenOutput>a-a.feature.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\OrderingTests\B\b-b.feature">
+      <LastGenOutput>a-b.feature.cs</LastGenOutput>
+    </EmbeddedResource>
     <None Include="Resources\test.jpg" />
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Pickles/Pickles/DocumentationBuilders/Word/WordDocumentationBuilder.cs
+++ b/src/Pickles/Pickles/DocumentationBuilders/Word/WordDocumentationBuilder.cs
@@ -81,9 +81,10 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
                 }
             }
 
+            using (var stream = this.fileSystem.File.Create(documentFileName))
             using (
                 WordprocessingDocument wordProcessingDocument = WordprocessingDocument.Create(
-                    documentFileName,
+                    stream,
                     WordprocessingDocumentType.Document))
             {
                 MainDocumentPart mainDocumentPart = wordProcessingDocument.AddMainDocumentPart();
@@ -113,7 +114,8 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Word
             }
 
             // HACK - Add the table of contents
-            using (WordprocessingDocument wordProcessingDocument = WordprocessingDocument.Open(documentFileName, true))
+            using (var stream = this.fileSystem.File.Open(documentFileName, System.IO.FileMode.Open))
+            using (WordprocessingDocument wordProcessingDocument = WordprocessingDocument.Open(stream, true))
             {
                 XElement firstPara = wordProcessingDocument
                     .MainDocumentPart


### PR DESCRIPTION
It actually seems like getting rid of NGenerics magically fixed the sorting problem with Word files. I think you can close #368 (and #357 ?).
I'll give the current develop branch a go with my real world stuff tomorrow and let you know conclusively.
In any case, here's a test I wrote to prove the problem, and it actually passes without modifying the code. :)

I didn't research enough to find whether you had something stubbed for written files, so I made a dependency on disk in this test. Can fix if I know your preference. Add Stream overrides on the builder?