### PR TITLE
Enable xUnit Test Result Provider to Deal with more than 255 Scenarios in a File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 - Enable Pickles to deal with ignored scenario examples in VsTest Result Provider ([340](https://github.com/picklesdoc/pickles/pull/340)) (by [@dirkrombauts](https://github.com/dirkrombauts))
 
+- Enable xUnit Test Result Provider to Deal with more than 255 Scenarios in a File ([405](https://github.com/picklesdoc/pickles/pull/405)) (by [@dirkrombauts](https://github.com/dirkrombauts))
+
+  ​
+
 ## [2.11.0] - 2016-12-05
 
 ### Changed

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/results-example-xunit2.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/results-example-xunit2.cs
@@ -62,17 +62,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         private string configfileField;
 
-        private byte totalField;
+        private int totalField;
 
-        private byte passedField;
+        private int passedField;
 
-        private byte failedField;
+        private int failedField;
 
-        private byte skippedField;
+        private int skippedField;
 
         private decimal timeField;
 
-        private byte errors1Field;
+        private int errors1Field;
 
         /// <remarks/>
         public object errors {
@@ -163,7 +163,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte total {
+        public int total {
             get {
                 return this.totalField;
             }
@@ -174,7 +174,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte passed {
+        public int passed {
             get {
                 return this.passedField;
             }
@@ -185,7 +185,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte failed {
+        public int failed {
             get {
                 return this.failedField;
             }
@@ -196,7 +196,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte skipped {
+        public int skipped {
             get {
                 return this.skippedField;
             }
@@ -218,7 +218,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute("errors")]
-        public byte errors1 {
+        public int errors1 {
             get {
                 return this.errors1Field;
             }
@@ -238,13 +238,13 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         private assembliesAssemblyCollectionTest[] testField;
 
-        private byte totalField;
+        private int totalField;
 
-        private byte passedField;
+        private int passedField;
 
-        private byte failedField;
+        private int failedField;
 
-        private byte skippedField;
+        private int skippedField;
 
         private string nameField;
 
@@ -263,7 +263,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte total {
+        public int total {
             get {
                 return this.totalField;
             }
@@ -274,7 +274,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte passed {
+        public int passed {
             get {
                 return this.passedField;
             }
@@ -285,7 +285,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte failed {
+        public int failed {
             get {
                 return this.failedField;
             }
@@ -296,7 +296,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2 {
 
         /// <remarks/>
         [XmlAttribute()]
-        public byte skipped {
+        public int skipped {
             get {
                 return this.skippedField;
             }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/results-example-xunit2.xsd
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/results-example-xunit2.xsd
@@ -44,10 +44,10 @@
                                             </xs:complexType>
                                         </xs:element>
                                     </xs:sequence>
-                                    <xs:attribute name="total" type="xs:unsignedByte" use="required" />
-                                    <xs:attribute name="passed" type="xs:unsignedByte" use="required" />
-                                    <xs:attribute name="failed" type="xs:unsignedByte" use="required" />
-                                    <xs:attribute name="skipped" type="xs:unsignedByte" use="required" />
+                                    <xs:attribute name="total" type="xs:int" use="required" />
+                                    <xs:attribute name="passed" type="xs:int" use="required" />
+                                    <xs:attribute name="failed" type="xs:int" use="required" />
+                                    <xs:attribute name="skipped" type="xs:int" use="required" />
                                     <xs:attribute name="name" type="xs:string" use="required" />
                                     <xs:attribute name="time" type="xs:decimal" use="required" />
                                 </xs:complexType>
@@ -59,12 +59,12 @@
                         <xs:attribute name="run-date" type="xs:date" use="required" />
                         <xs:attribute name="run-time" type="xs:time" use="required" />
                         <xs:attribute name="config-file" type="xs:string" use="required" />
-                        <xs:attribute name="total" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="passed" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="failed" type="xs:unsignedByte" use="required" />
-                        <xs:attribute name="skipped" type="xs:unsignedByte" use="required" />
+                        <xs:attribute name="total" type="xs:int" use="required" />
+                        <xs:attribute name="passed" type="xs:int" use="required" />
+                        <xs:attribute name="failed" type="xs:int" use="required" />
+                        <xs:attribute name="skipped" type="xs:int" use="required" />
                         <xs:attribute name="time" type="xs:decimal" use="required" />
-                        <xs:attribute name="errors" type="xs:unsignedByte" use="required" />
+                        <xs:attribute name="errors" type="xs:int" use="required" />
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>


### PR DESCRIPTION
Originally fixed in #397 but merged wrongly.