### PR TITLE
WIP - Move DHTML files out of resources - use file copy instead of ResourceStreamReader

### DIFF
--- a/src/Pickles/.vs/config/applicationhost.config
+++ b/src/Pickles/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Pickles.BaseDhtmlFiles" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\DevProjects\Tools\pickles\src\Pickles\Pickles.BaseDhtmlFiles" />
+                    <virtualDirectory path="/" physicalPath="C:\src\pickles\src\Pickles\Pickles.BaseDhtmlFiles" />
                 </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:52000:localhost" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
@@ -62,132 +62,154 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\css\bootstrap.min.css">
-      <Link>Resources\css\bootstrap.min.css</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\css\bootstrap.min.css">
+      <Link>basedhtmlfiles\css\bootstrap.min.css</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\css\print.css">
-      <Link>Resources\css\print.css</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\css\print.css">
+      <Link>basedhtmlfiles\css\print.css</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\css\styles.css">
-      <Link>Resources\css\styles.css</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\css\styles.css">
+      <Link>basedhtmlfiles\css\styles.css</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\img\glyphicons-halflings-white.png">
-      <Link>Resources\img\glyphicons-halflings-white.png</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\img\glyphicons-halflings-white.png">
+      <Link>basedhtmlfiles\img\glyphicons-halflings-white.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\img\glyphicons-halflings.png">
-      <Link>Resources\img\glyphicons-halflings.png</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\img\glyphicons-halflings.png">
+      <Link>basedhtmlfiles\img\glyphicons-halflings.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\img\link.png">
-      <Link>Resources\img\link.png</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\img\link.png">
+      <Link>basedhtmlfiles\img\link.png</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\bootstrap.min.js">
-      <Link>Resources\js\bootstrap.min.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\bootstrap.min.js">
+      <Link>basedhtmlfiles\js\bootstrap.min.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\Chart.min.js">
-      <Link>Resources\js\Chart.min.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\Chart.min.js">
+      <Link>basedhtmlfiles\js\Chart.min.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\Chart.StackedBar.js">
-      <Link>Resources\js\Chart.StackedBar.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\Chart.StackedBar.js">
+      <Link>basedhtmlfiles\js\Chart.StackedBar.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\featureSearch.js">
-      <Link>Resources\js\featureSearch.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\featureSearch.js">
+      <Link>basedhtmlfiles\js\featureSearch.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\featuresModel.js">
-      <Link>Resources\js\featuresModel.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\featuresModel.js">
+      <Link>basedhtmlfiles\js\featuresModel.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\heirarchyBuilder.js">
-      <Link>Resources\js\heirarchyBuilder.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\heirarchyBuilder.js">
+      <Link>basedhtmlfiles\js\heirarchyBuilder.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\html5.js">
-      <Link>Resources\js\html5.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\html5.js">
+      <Link>basedhtmlfiles\js\html5.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\jquery-1.8.3.min.js">
-      <Link>Resources\js\jquery-1.8.3.min.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\jquery-1.8.3.min.js">
+      <Link>basedhtmlfiles\js\jquery-1.8.3.min.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\jquery.highlight-4.closure.js">
-      <Link>Resources\js\jquery.highlight-4.closure.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\jquery.highlight-4.closure.js">
+      <Link>basedhtmlfiles\js\jquery.highlight-4.closure.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\knockout-3.4.0.js">
-      <Link>Resources\js\knockout-3.4.0.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\knockout-3.4.0.js">
+      <Link>basedhtmlfiles\js\knockout-3.4.0.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\knockout.mapping-latest.js">
-      <Link>Resources\js\knockout.mapping-latest.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\knockout.mapping-latest.js">
+      <Link>basedhtmlfiles\js\knockout.mapping-latest.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\logger.js">
-      <Link>Resources\js\logger.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\logger.js">
+      <Link>basedhtmlfiles\js\logger.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\Markdown.Converter.js">
-      <Link>Resources\js\Markdown.Converter.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\Markdown.Converter.js">
+      <Link>basedhtmlfiles\js\Markdown.Converter.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\Markdown.Extra.js">
-      <Link>Resources\js\Markdown.Extra.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\Markdown.Extra.js">
+      <Link>basedhtmlfiles\js\Markdown.Extra.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\picklesOverview.js">
-      <Link>Resources\js\picklesOverview.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\picklesOverview.js">
+      <Link>basedhtmlfiles\js\picklesOverview.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\stringFormatting.js">
-      <Link>Resources\js\stringFormatting.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\stringFormatting.js">
+      <Link>basedhtmlfiles\js\stringFormatting.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\typeaheadList.js">
-      <Link>Resources\js\typeaheadList.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\typeaheadList.js">
+      <Link>basedhtmlfiles\js\typeaheadList.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\pickles.basedhtmlfiles\js\underscore-min.js">
-      <Link>Resources\js\underscore-min.js</Link>
-    </EmbeddedResource>
+    <None Include="..\pickles.basedhtmlfiles\js\underscore-min.js">
+      <Link>basedhtmlfiles\js\underscore-min.js</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="..\Pickles.BaseDhtmlFiles\Index.html">
-      <Link>Resources\Index.html</Link>
-    </EmbeddedResource>
-    <EmbeddedResource Include="..\Pickles.BaseDhtmlFiles\pickledFeatures.js">
-      <Link>Resources\pickledFeatures.js</Link>
-    </EmbeddedResource>
+    <None Include="..\Pickles.BaseDhtmlFiles\Index.html">
+      <Link>basedhtmlfiles\Index.html</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Pickles.DocumentationBuilders.Html\Pickles.DocumentationBuilders.Html.csproj">

--- a/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj.DotSettings
+++ b/src/Pickles/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=basedhtmlfiles/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Hey @dirkrombauts , wanted to run this by you.  We have started using the Pickles command line with mono for non-Windows environments.  Its working great, except that the `System.Drawing` namespace does not seem to have a mono implementation, so the site generates but its missing the images.  In order to simplify the building of the DHTML website, this PR moves the static site files from resources to the file system.  That way we can just use the `System.IO` libraries to copy them over to the target.

If you are okay with this approach, I'll flush out the rest of this PR with unit tests and apply the same logic to the HTML builder (which shares `ResourceWriter` with the DHTML builder).  Let me know, thanks!

CC: @bliles, @pbredenberg