### PR TITLE
Fixes hiding topnav when printing

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/css/print.css
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/css/print.css
@@ -1,1 +1,1 @@
-#FolderNav, #TopNav { display: none; }
+#FolderNav, #TopNav { display: none !important; }


### PR DESCRIPTION
Currently, the hide and show of the topnav while loading breaks hiding the topnav when printing. This is because jQuery.show() puts a style="display: block;" on the topnav element. 