### PR TITLE
Wildcard support for test result files

### DIFF
--- a/src/Pickles/Pickles.MSBuild/Pickles.cs
+++ b/src/Pickles/Pickles.MSBuild/Pickles.cs
@@ -98,8 +98,8 @@ namespace PicklesDoc.Pickles.MSBuild
 
             if (!string.IsNullOrEmpty(this.ResultsFile))
             {
-                configuration.AddTestResultFiles(
-                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.ResultsFile, fileSystem));
+                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.ResultsFile, fileSystem);
+                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f)));
             }
 
             if (!string.IsNullOrEmpty(this.SystemUnderTestName))

--- a/src/Pickles/Pickles.MSBuild/Pickles.cs
+++ b/src/Pickles/Pickles.MSBuild/Pickles.cs
@@ -98,8 +98,8 @@ namespace PicklesDoc.Pickles.MSBuild
 
             if (!string.IsNullOrEmpty(this.ResultsFile))
             {
-                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.ResultsFile, fileSystem);
-                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f)));
+                configuration.AddTestResultFiles(
+                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.ResultsFile, fileSystem));
             }
 
             if (!string.IsNullOrEmpty(this.SystemUnderTestName))

--- a/src/Pickles/Pickles.MSBuild/Pickles.cs
+++ b/src/Pickles/Pickles.MSBuild/Pickles.cs
@@ -24,6 +24,8 @@ using System.Reflection;
 using Autofac;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using PicklesDoc.Pickles.Extensions;
+using System.Linq;
 
 namespace PicklesDoc.Pickles.MSBuild
 {
@@ -96,7 +98,8 @@ namespace PicklesDoc.Pickles.MSBuild
 
             if (!string.IsNullOrEmpty(this.ResultsFile))
             {
-                configuration.AddTestResultFile(fileSystem.FileInfo.FromFileName(this.ResultsFile));
+                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.ResultsFile, fileSystem);
+                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f)));
             }
 
             if (!string.IsNullOrEmpty(this.SystemUnderTestName))

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -97,8 +97,8 @@ namespace PicklesDoc.Pickles.PowerShell
 
             if (!string.IsNullOrEmpty(this.TestResultsFile))
             {
-                configuration.AddTestResultFiles(
-                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.TestResultsFile, fileSystem));
+                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.TestResultsFile, fileSystem);
+                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f))); 
             }
 
             configuration.SystemUnderTestName = this.SystemUnderTestName;

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -25,6 +25,8 @@ using System.IO.Abstractions;
 using System.Management.Automation;
 using System.Reflection;
 using Autofac;
+using PicklesDoc.Pickles.Extensions;
+using System.Linq;
 
 namespace PicklesDoc.Pickles.PowerShell
 {
@@ -95,7 +97,8 @@ namespace PicklesDoc.Pickles.PowerShell
 
             if (!string.IsNullOrEmpty(this.TestResultsFile))
             {
-                configuration.AddTestResultFile(fileSystem.FileInfo.FromFileName(this.TestResultsFile));
+                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.TestResultsFile, fileSystem);
+                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f))); 
             }
 
             configuration.SystemUnderTestName = this.SystemUnderTestName;

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -97,8 +97,8 @@ namespace PicklesDoc.Pickles.PowerShell
 
             if (!string.IsNullOrEmpty(this.TestResultsFile))
             {
-                var files = PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(this.TestResultsFile, fileSystem);
-                configuration.AddTestResultFiles(files.Select(f => fileSystem.FileInfo.FromFileName(f))); 
+                configuration.AddTestResultFiles(
+                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.TestResultsFile, fileSystem));
             }
 
             configuration.SystemUnderTestName = this.SystemUnderTestName;

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -232,6 +232,63 @@ namespace PicklesDoc.Pickles.Test
         }
 
         [Test]
+        public void ThenCanParseMultipleResultsFilesWithWildCard()
+        {
+            FileSystem.AddFile(@"c:\results1.xml", "<xml />");
+            FileSystem.AddFile(@"c:\results2.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\results*.xml" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(2);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results1.xml").Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results2.xml").Count()).IsEqualTo(1);
+        }
+
+        [Test]
+        public void ThenCanParseMultipleResultsFilesWithWildCardWhereNoMatchIsExcluded()
+        {
+            FileSystem.AddFile(@"c:\results1.xml", "<xml />");
+            FileSystem.AddFile(@"c:\results2.xml", "<xml />");
+            FileSystem.AddFile(@"c:\nomatch_results3.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\results*.xml" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(2);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results1.xml").Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results2.xml").Count()).IsEqualTo(1);
+        }
+
+        [Test]
+        public void ThenCanParseMultipleResultsFilesWithWildCardAndSemicolon()
+        {
+            FileSystem.AddFile(@"c:\results_foo1.xml", "<xml />");
+            FileSystem.AddFile(@"c:\results_foo2.xml", "<xml />");
+            FileSystem.AddFile(@"c:\results_bar.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\results_foo*.xml;c:\results_bar.xml" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(3);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo1.xml").Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo2.xml").Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_bar.xml").Count()).IsEqualTo(1);
+        }
+
+        [Test]
         public void ThenCanParseResultsFileWithShortFormSuccessfully()
         {
             FileSystem.AddFile(@"c:\results.xml", "<xml />");
@@ -465,6 +522,7 @@ namespace PicklesDoc.Pickles.Test
         [Test]
         public void ThenCanFilterOutNonExistingTestResultFiles()
         {
+            FileSystem.AddFile(@"c:\results1.xml", "<xml />");
             var args = new[] { @"-link-results-file=c:\DoesNotExist.xml;" };
 
             var configuration = new Configuration();

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -289,6 +289,55 @@ namespace PicklesDoc.Pickles.Test
         }
 
         [Test]
+        public void ThenCanParseMultipleResultsFilesWithWildCardsAndSemicolonWhenSomeHaveNoMatch()
+        {
+            FileSystem.AddFile(@"c:\results_foo1.xml", "<xml />");
+            FileSystem.AddFile(@"c:\results_foo2.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\results_foo*.xml;c:\results_bar*.xml" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(2);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo1.xml").Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo2.xml").Count()).IsEqualTo(1);
+        }
+
+        [Test]
+        public void ThenNoExceptionIsThrownWhenResultsFileIsDir()
+        {
+            FileSystem.AddFile(@"c:\temp\results_foo1.xml", "<xml />");
+            FileSystem.AddFile(@"c:\temp\results_foo2.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\temp\" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsFalse();
+        }
+
+        [Test]
+        public void ThenCanParseResultsFilesWithMultipleMatchesResolvingInSingleMatch()
+        {
+            FileSystem.AddFile(@"c:\results_foo.xml", "<xml />");
+            var args = new[] { @"-link-results-file=c:\results*.xml;c:\*foo.xml" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(1);
+            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo.xml").Count()).IsEqualTo(1);
+        }
+
+        [Test]
         public void ThenCanParseResultsFileWithShortFormSuccessfully()
         {
             FileSystem.AddFile(@"c:\results.xml", "<xml />");

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -289,55 +289,6 @@ namespace PicklesDoc.Pickles.Test
         }
 
         [Test]
-        public void ThenCanParseMultipleResultsFilesWithWildCardsAndSemicolonWhenSomeHaveNoMatch()
-        {
-            FileSystem.AddFile(@"c:\results_foo1.xml", "<xml />");
-            FileSystem.AddFile(@"c:\results_foo2.xml", "<xml />");
-            var args = new[] { @"-link-results-file=c:\results_foo*.xml;c:\results_bar*.xml" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.HasTestResults).IsTrue();
-            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(2);
-            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo1.xml").Count()).IsEqualTo(1);
-            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo2.xml").Count()).IsEqualTo(1);
-        }
-
-        [Test]
-        public void ThenNoExceptionIsThrownWhenResultsFileIsDir()
-        {
-            FileSystem.AddFile(@"c:\temp\results_foo1.xml", "<xml />");
-            FileSystem.AddFile(@"c:\temp\results_foo2.xml", "<xml />");
-            var args = new[] { @"-link-results-file=c:\temp\" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.HasTestResults).IsFalse();
-        }
-
-        [Test]
-        public void ThenCanParseResultsFilesWithMultipleMatchesResolvingInSingleMatch()
-        {
-            FileSystem.AddFile(@"c:\results_foo.xml", "<xml />");
-            var args = new[] { @"-link-results-file=c:\results*.xml;c:\*foo.xml" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.HasTestResults).IsTrue();
-            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(1);
-            Check.That(configuration.TestResultsFiles.Where(trf => trf.FullName == @"c:\results_foo.xml").Count()).IsEqualTo(1);
-        }
-
-        [Test]
         public void ThenCanParseResultsFileWithShortFormSuccessfully()
         {
             FileSystem.AddFile(@"c:\results.xml", "<xml />");

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/MsTest/results-example-mstest.trx
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="8b92f3df-38df-4ef7-bf11-219c12f59f95" name="HKR@AS0283 2016-09-28 09:33:43" runUser="OEVERMANN\HKR" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+<TestRun id="c21ee009-2c8b-416d-9329-b9c4df3ac26b" name="Bas@LENOVOWERK 2017-02-02 21:43:40" runUser="LENOVOWERK\Bas" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
   <TestSettings name="TestSettings" id="3d90c4f8-ccdc-4663-bad3-9f4c55f42318">
     <Description>These are default test settings for a local test run.</Description>
-    <Deployment userDeploymentRoot="C:\DevProjects\Tools\pickles" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="HKR_AS0283 2016-09-28 09_33_43" />
+    <Deployment userDeploymentRoot="C:\Users\Bas\Source\Repos\pickles" useDefaultDeploymentRoot="false" enabled="false" runDeploymentRoot="Bas_LENOVOWERK 2017-02-02 21_43_40" />
     <Execution>
       <TestTypeSpecific />
       <AgentRule name="Execution Agents">
@@ -10,14 +10,14 @@
     </Execution>
     <Properties />
   </TestSettings>
-  <Times creation="2016-09-28T09:33:43.1911705+02:00" queuing="2016-09-28T09:33:43.7031465+02:00" start="2016-09-28T09:33:43.7971511+02:00" finish="2016-09-28T09:33:44.4531422+02:00" />
+  <Times creation="2017-02-02T21:43:40.0476177+01:00" queuing="2017-02-02T21:43:40.6347317+01:00" start="2017-02-02T21:43:40.8799259+01:00" finish="2017-02-02T21:43:42.2034759+01:00" />
   <ResultSummary outcome="Failed">
     <Counters total="47" executed="47" passed="30" error="0" failed="8" timeout="0" aborted="0" inconclusive="9" passedButRunAborted="0" notRunnable="0" notExecuted="0" disconnected="0" warning="0" completed="0" inProgress="0" pending="0" />
   </ResultSummary>
   <TestDefinitions>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="7699da71-b819-eb00-3894-2f0be7eec39c">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="7699da71-b819-eb00-3894-2f0be7eec39c">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="fe022d9c-e496-4d25-8ee2-cecdfd7d7cbd" />
+      <Execution id="39a4465d-26ed-45e0-ad5a-91b8da4b0fe7" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -32,25 +32,25 @@
           <Value>[]</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
+    <UnitTest name="NotAutomatedScenario1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="0e090158-43a1-1be8-47c2-13e1b2c9f8c7">
       <Description>Not automated scenario 1</Description>
-      <Execution id="0289f165-b539-472e-97da-60133c9753c3" />
+      <Execution id="4f8ee6a1-3d3b-4b24-9a56-dd37da2c02a4" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="4d0f7327-ed22-9a43-969a-ac2ea8102d66">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="6b7ae4ce-36d5-4d33-b8f0-1bd2c47ce15e" />
+      <Execution id="636379ec-8480-4ae3-9532-0e13d0147638" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -77,11 +77,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="40304968-0dee-8e41-4f42-20809899a9d0">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="dc477dc5-8081-4326-a1a3-7f691ef07670" />
+      <Execution id="0f480644-c25e-441b-a30a-c1e9b9ca2f61" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -96,22 +96,22 @@
           <Value>fail_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
+    <UnitTest name="NotAutomatedScenario3" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="64813bea-d79b-d74b-adb5-1302eaf5641f">
       <Description>Not automated scenario 3</Description>
-      <Execution id="08a69590-d4ac-4a25-b0bf-00702dee00bd" />
+      <Execution id="379de59b-de9d-4799-b665-f00be26f656a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="a3bd6f67-daac-1ebc-5894-1d73dbe8d707">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="a3bd6f67-daac-1ebc-5894-1d73dbe8d707">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="f2df90c9-7a83-4804-8286-7e68abdb6acc" />
+      <Execution id="71c519c6-928c-4c78-a4f2-5f6650a40625" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -126,22 +126,22 @@
           <Value>.*</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="3fe8806f-fabb-1deb-7e27-c59578f16da3">
+    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="3fe8806f-fabb-1deb-7e27-c59578f16da3">
       <Description>This is a scenario with parentheses, hyphen and comma (10-20, 30-40)</Description>
-      <Execution id="d6156b13-8dea-4855-a0d6-c17e57bc0bf1" />
+      <Execution id="45704043-909e-4213-9939-73003e03a08d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Scenarios With Special Characters</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="fb3ec8b2-a410-ecc8-265b-29bfd3772553">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="fb3ec8b2-a410-ecc8-265b-29bfd3772553">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="1aa8cc43-19e6-440f-9d36-87f525d47f1b" />
+      <Execution id="3b5efa31-0ffb-48d2-9846-b239b87188d1" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -156,33 +156,33 @@
           <Value>++</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
+    <UnitTest name="AddTwoNumbers" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ca63316a-39e5-9545-3bca-f1839c7b4664">
       <Description>Add two numbers</Description>
-      <Execution id="e88d9922-5a81-4f06-a73d-fe2ec0f0055b" />
+      <Execution id="4ed2d641-2d8c-4de9-a2a9-91a159a77383" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="7e6c75c9-5365-7582-f701-20d37d3ff511">
       <Description>Failing Feature Inconclusive Scenario</Description>
-      <Execution id="a05975bf-21e1-475a-8743-11ad25a86434" />
+      <Execution id="7b3bf790-7524-4675-bd79-8e4b87441beb" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="f8369e2e-c5ec-dade-ad85-e2c56909c853">
+    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="f8369e2e-c5ec-dade-ad85-e2c56909c853">
       <Description>This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)</Description>
-      <Execution id="8b1c3c84-7a92-4086-a0b6-570d83a0369b" />
+      <Execution id="92723242-e59b-4426-af79-f7bcffaf140d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -197,33 +197,33 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="add44896-9236-510f-750d-eb49b89a7a65">
       <Description>Inconclusive Feature Inconclusive Scenario</Description>
-      <Execution id="e624cfd3-c524-4fa1-98d3-9eefc8ed4be0" />
+      <Execution id="38c2b714-9773-4601-b41d-69770f8e8819" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
+    <UnitTest name="FailingFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="fa1e54c9-cdb0-8bb1-6764-9179c3b61825">
       <Description>Failing Feature Passing Scenario</Description>
-      <Execution id="f5f65ec2-fb08-42b7-af73-9396576ce7c2" />
+      <Execution id="837c84ee-e678-4a77-8021-6bc1221395db" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="72d470fa-c19a-1302-1fcf-eb104ea36048">
       <Description>Deal correctly with backslashes in the examples</Description>
-      <Execution id="0db42487-c1e4-4189-a35f-e93bd02705bb" />
+      <Execution id="8bb11ce6-7794-4998-b148-562f39c0f2f1" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -238,11 +238,11 @@
           <Value>c:\Temp\</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b04f3200-80ca-d47f-0c01-8a37e5c952e6">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="6d018bfc-866c-4963-9cf2-fea88195981b" />
+      <Execution id="521ca88d-475f-41f5-93f1-203791eea1df" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -257,11 +257,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="763d7e52-45c9-3e45-478d-dd6659bc69ba">
+    <UnitTest name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="763d7e52-45c9-3e45-478d-dd6659bc69ba">
       <Description>This is a scenario outline with german umlauts äöüß ÄÖÜ</Description>
-      <Execution id="aa138266-ab3e-4002-a38e-c8e05c31c8e6" />
+      <Execution id="723a3a61-5240-4228-8f03-2c258bab3d49" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -276,11 +276,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="ab1d7239-4539-458b-a7f9-dfab7f9bc5da" />
+      <Execution id="4a46c15b-d51c-4090-942a-628cdadc844f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -295,11 +295,11 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="22ccdb90-02c8-97c1-e2a1-6bec4f044d99">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="22ccdb90-02c8-97c1-e2a1-6bec4f044d99">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="8861d3d8-946d-4d98-a506-6f0abfeb7d86" />
+      <Execution id="d8d0c0d2-27cb-4881-a391-7ca4164855d9" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -314,11 +314,11 @@
           <Value>^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="cca2404a-911a-a50e-9898-327264f0ea76">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="cca2404a-911a-a50e-9898-327264f0ea76">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="7fa9f127-15ff-45a9-90a0-69b0359e0f64" />
+      <Execution id="b4fcf215-b3b4-4fad-bc4b-fab6c66eb579" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -333,14 +333,14 @@
           <Value>()</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="f4b45c2f-fc98-d23c-6179-62d5b5a59825">
       <Description>Adding several numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag2" />
       </TestCategory>
-      <Execution id="80a37d44-11e7-4e5f-a101-252de0b2c2b3" />
+      <Execution id="71b07acc-0cf4-46cf-8d19-4d8ffa86d961" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -367,11 +367,11 @@
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ee74d71f-f824-19d9-866e-a408a95ffa99">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="e3ae304c-2dae-4ced-8f1e-a967c4dbacd0" />
+      <Execution id="08cf7da8-ed5e-4929-9b59-f4dc84297d02" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -386,22 +386,22 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
+    <UnitTest name="FailingFeatureFailingScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0">
       <Description>Failing Feature Failing Scenario</Description>
-      <Execution id="5c44dfb5-71bb-431e-9e76-26c2e6475b11" />
+      <Execution id="7d4dde75-2912-4580-bcac-b905668c4ad3" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Failing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="d09c033d-0065-cbeb-bd7c-ee8b6460688f">
       <Description>Deal correctly with parenthesis in the examples</Description>
-      <Execution id="cb798ff2-ffd4-4096-88aa-ac2565e53858" />
+      <Execution id="80bed3bb-cf6c-4498-ad65-fc058726aea2" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -416,11 +416,11 @@
           <Value>This is a description (and more)</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="6e54c207-a3b1-f181-06be-066795ac26e1">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="37420234-8748-4b85-94dd-c262b1d4acae" />
+      <Execution id="31e76ec9-aeed-44cf-aa4f-618b0fe6d48b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -435,11 +435,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="9efc5df4-5f77-a670-8622-976418721b8f">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="807f7b27-c6eb-417f-8733-2d48ea7263c9" />
+      <Execution id="90852d30-e5ef-4b9e-9340-f27b827f8c51" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -454,22 +454,22 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="41cb0c4f-1c07-4937-29e8-dcc987caf94e">
       <Description>Inconclusive Feature Passing Scenario</Description>
-      <Execution id="404c51e5-0866-4a9f-8135-e10148b23cab" />
+      <Execution id="45745e7e-83c4-44da-85c8-bd4717d02da5" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Inconclusive</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="InconclusiveFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="8c97c958-0c5d-1594-2cc5-02c96df8fc9b">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="64386890-55a5-4b95-a423-b7712a39b8bf" />
+      <Execution id="d015761e-47dd-4fe8-8c95-152dd4cbe2e3" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -484,21 +484,21 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
-      <Execution id="cc24508e-638a-4091-b113-e0ef1509435e" />
+    <UnitTest name="TestMethod" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21">
+      <Execution id="9163e985-bacc-4d1f-8cbb-f34759532824" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="73c03e74-0c0b-5c1d-2193-91dd98f1f95e">
+    <UnitTest name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="73c03e74-0c0b-5c1d-2193-91dd98f1f95e">
       <Description>This is a scenario outline with ampersand &amp;</Description>
-      <Execution id="7e500918-0760-421a-83be-4ad63c51d858" />
+      <Execution id="02218523-4b0d-47d7-b7dd-55d6db0e9daa" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -513,25 +513,25 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
+    <UnitTest name="AddTwoNumbers" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="6b8581c3-611e-6116-4232-a31382677735">
       <Description>Add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="556edf09-34cc-473f-9b70-5d231853b07e" />
+      <Execution id="2a193c2a-d0a2-4bfe-b50e-fc3253b622e3" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="8f2bb160-fa82-a566-570e-51eeb5237e95">
       <Description>This is a scenario outline where one scenario is inconclusive</Description>
-      <Execution id="2caaf730-6060-459c-a263-4b80a7f424e4" />
+      <Execution id="3d378506-8c2e-4d77-812b-1c9299d7a26b" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -546,11 +546,11 @@
           <Value>pass_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="05c22c90-eaaa-d3c2-bd2d-36c2df85528e">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="943c71de-e0fb-4491-bee5-a88a58ce5d6f" />
+      <Execution id="5fa55760-e921-40f0-8246-dbbd3838a88a" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -565,11 +565,11 @@
           <Value>fail_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="4d5f7893-139c-db00-8823-de561780758d">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="b88e3fe2-7142-4844-82fb-c028962cf58c" />
+      <Execution id="1fe3f0a7-f7a6-466c-93eb-8c68289fbdb8" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -584,11 +584,11 @@
           <Value>inconclusive_2</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="17bb28b8-a770-72be-af08-5a4b0847e4ea">
       <Description>Adding several numbers</Description>
-      <Execution id="4e036648-6c72-4565-b4e8-4952c46022e2" />
+      <Execution id="ff20609f-60df-49eb-a108-83c60f2c97b5" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -615,22 +615,22 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
+    <UnitTest name="NotAutomatedScenario2" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="067e1c92-2860-531b-28dc-c2863e91b7f5">
       <Description>Not automated scenario 2</Description>
-      <Execution id="991a416f-6dc9-43ca-8fd8-49defbb57f07" />
+      <Execution id="60d71832-95b3-4c8b-b905-c0b7f668444d" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Not Automated At All</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="2c8f1abb-446c-6683-6327-8ec4ccd46e1a">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="12e9883b-8b0c-4deb-a841-759574515567" />
+      <Execution id="655e07dd-9759-4675-abe3-e97974342beb" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -645,11 +645,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296">
+    <UnitTest name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296">
       <Description>Deal correctly with overlong example values</Description>
-      <Execution id="5f84a30c-d6be-43b0-8e3e-9539f2944ba2" />
+      <Execution id="85ed41c3-fdd6-4bb1-a950-75aaf50015e6" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -668,11 +668,11 @@
           <Value>This is just a very very very veery long error message!</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="78aeddd0-4ae5-6103-b7dd-e62b71148721">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="df0fdf42-4c14-4bde-ba6a-2b06e801f895" />
+      <Execution id="487e6d0f-ed7b-47a8-ad09-e79b1539044c" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -687,22 +687,22 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
+    <UnitTest name="PassingFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="3af599bd-a8de-95a2-1ecc-194c7f8aceeb">
       <Description>Passing Feature Passing Scenario</Description>
-      <Execution id="7c0571c5-7649-47e7-b5a3-d78ccf512327" />
+      <Execution id="b69ad1e7-ff02-4ecf-a51e-89147be57c29" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Passing</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="PassingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b891bd24-e5b1-222b-8d70-96a2ba7b0807">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b891bd24-e5b1-222b-8d70-96a2ba7b0807">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="98c888d3-b7f7-4085-8aef-ce81ee21100d" />
+      <Execution id="c00eb885-753d-4d0a-a99e-dee30d523362" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -717,11 +717,11 @@
           <Value>**</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="9bb2410c-d8c6-90b8-75cd-5c93dc903745">
       <Description>This is a scenario outline where all scenarios pass</Description>
-      <Execution id="5afafeb3-4f9f-4761-aa1c-25437fb913db" />
+      <Execution id="6f75d59f-71d7-4bb1-a312-de629dcc0f35" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -736,11 +736,11 @@
           <Value>pass_3</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="e64af447-d4dc-7221-865a-703128db7b90">
       <Description>This is a scenario outline where one scenario fails</Description>
-      <Execution id="f48a7003-60ee-4a81-980d-93aa28dcdf4a" />
+      <Execution id="a41914cf-7ed9-4737-9515-85d23e57e158" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -755,11 +755,11 @@
           <Value>pass_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="d253522e-be41-9b3a-247a-ca440d4ac588">
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="d253522e-be41-9b3a-247a-ca440d4ac588">
       <Description>This scenario contains examples with Regex-special characters</Description>
-      <Execution id="41ec70d9-da3e-4c83-928e-51a61b9d48c3" />
+      <Execution id="a2216e3d-4a60-4f17-9398-5cc5767d919f" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -774,11 +774,11 @@
           <Value>{}</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b4815779-aba4-cf1b-8df3-4a745af70720">
       <Description>Adding several numbers</Description>
-      <Execution id="fe37892d-8ca6-4fea-a2c9-030ff029b388" />
+      <Execution id="e3224b22-ad2f-4d31-9e09-784b2c9fec09" />
       <Properties>
         <Property>
           <Key>Parameter:first number</Key>
@@ -805,36 +805,36 @@
           <Value>Failing Background</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
+    <UnitTest name="FailToAddTwoNumbers" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="b13a186e-33df-348e-f9e2-a18b445d0d6e">
       <Description>Fail to add two numbers</Description>
       <TestCategory>
         <TestCategoryItem TestCategory="tag1" />
       </TestCategory>
-      <Execution id="d67a21cd-9867-4f32-9358-2433e6159a0e" />
+      <Execution id="d30a1fa3-a584-4272-bf66-ad0c5c521842" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="2124dd33-7aaa-d4fb-c72f-98ad434251c0">
       <Description>Not automated adding two numbers</Description>
-      <Execution id="b6698137-01dc-42cc-9f5e-ae0e310d7af5" />
+      <Execution id="1a5af968-f14e-4056-9af5-48062a955305" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
           <Value>Addition</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.AdditionFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\devprojects\tools\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\users\bas\source\repos\pickles\\test-harness\mstest\bin\debug\mstestharness.dll" id="e30ef794-1ea7-a76a-356b-1668bca94630">
       <Description>And we can go totally bonkers with multiple example sections.</Description>
-      <Execution id="c2c64da2-f4d5-4797-a119-ff5b2470b978" />
+      <Execution id="69f3c322-1c37-49d2-a381-0402c332eadb" />
       <Properties>
         <Property>
           <Key>FeatureTitle</Key>
@@ -849,7 +849,7 @@
           <Value>inconclusive_1</Value>
         </Property>
       </Properties>
-      <TestMethod codeBase="C:/DevProjects/Tools/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+      <TestMethod codeBase="C:/Users/Bas/Source/Repos/pickles/test-harness/mstest/bin/Debug/MsTestHarness.DLL" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter, Microsoft.VisualStudio.QualityTools.Tips.UnitTest.Adapter, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature, MsTestHarness, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
   </TestDefinitions>
   <TestLists>
@@ -857,111 +857,111 @@
     <TestList name="All Loaded Results" id="19431567-8539-422a-85d7-44ee4e166bda" />
   </TestLists>
   <TestEntries>
-    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="6b7ae4ce-36d5-4d33-b8f0-1bd2c47ce15e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="80a37d44-11e7-4e5f-a101-252de0b2c2b3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="556edf09-34cc-473f-9b70-5d231853b07e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="d67a21cd-9867-4f32-9358-2433e6159a0e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="b6698137-01dc-42cc-9f5e-ae0e310d7af5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="fe37892d-8ca6-4fea-a2c9-030ff029b388" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="4e036648-6c72-4565-b4e8-4952c46022e2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="e88d9922-5a81-4f06-a73d-fe2ec0f0055b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="5c44dfb5-71bb-431e-9e76-26c2e6475b11" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="a05975bf-21e1-475a-8743-11ad25a86434" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="f5f65ec2-fb08-42b7-af73-9396576ce7c2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="e624cfd3-c524-4fa1-98d3-9eefc8ed4be0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="404c51e5-0866-4a9f-8135-e10148b23cab" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="7c0571c5-7649-47e7-b5a3-d78ccf512327" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="0289f165-b539-472e-97da-60133c9753c3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="991a416f-6dc9-43ca-8fd8-49defbb57f07" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="08a69590-d4ac-4a25-b0bf-00702dee00bd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="cc24508e-638a-4091-b113-e0ef1509435e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="df0fdf42-4c14-4bde-ba6a-2b06e801f895" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="e3ae304c-2dae-4ced-8f1e-a967c4dbacd0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="c2c64da2-f4d5-4797-a119-ff5b2470b978" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="b88e3fe2-7142-4844-82fb-c028962cf58c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="ab1d7239-4539-458b-a7f9-dfab7f9bc5da" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="dc477dc5-8081-4326-a1a3-7f691ef07670" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="0db42487-c1e4-4189-a35f-e93bd02705bb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296" executionId="5f84a30c-d6be-43b0-8e3e-9539f2944ba2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="cb798ff2-ffd4-4096-88aa-ac2565e53858" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="12e9883b-8b0c-4deb-a841-759574515567" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="807f7b27-c6eb-417f-8733-2d48ea7263c9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="5afafeb3-4f9f-4761-aa1c-25437fb913db" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="943c71de-e0fb-4491-bee5-a88a58ce5d6f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="f48a7003-60ee-4a81-980d-93aa28dcdf4a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="6d018bfc-866c-4963-9cf2-fea88195981b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="64386890-55a5-4b95-a423-b7712a39b8bf" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="37420234-8748-4b85-94dd-c262b1d4acae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="2caaf730-6060-459c-a263-4b80a7f424e4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="73c03e74-0c0b-5c1d-2193-91dd98f1f95e" executionId="7e500918-0760-421a-83be-4ad63c51d858" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="763d7e52-45c9-3e45-478d-dd6659bc69ba" executionId="aa138266-ab3e-4002-a38e-c8e05c31c8e6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" executionId="8b1c3c84-7a92-4086-a0b6-570d83a0369b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" executionId="d6156b13-8dea-4855-a0d6-c17e57bc0bf1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b891bd24-e5b1-222b-8d70-96a2ba7b0807" executionId="98c888d3-b7f7-4085-8aef-ce81ee21100d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="fb3ec8b2-a410-ecc8-265b-29bfd3772553" executionId="1aa8cc43-19e6-440f-9d36-87f525d47f1b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="a3bd6f67-daac-1ebc-5894-1d73dbe8d707" executionId="f2df90c9-7a83-4804-8286-7e68abdb6acc" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7699da71-b819-eb00-3894-2f0be7eec39c" executionId="fe022d9c-e496-4d25-8ee2-cecdfd7d7cbd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d253522e-be41-9b3a-247a-ca440d4ac588" executionId="41ec70d9-da3e-4c83-928e-51a61b9d48c3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="cca2404a-911a-a50e-9898-327264f0ea76" executionId="7fa9f127-15ff-45a9-90a0-69b0359e0f64" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="22ccdb90-02c8-97c1-e2a1-6bec4f044d99" executionId="8861d3d8-946d-4d98-a506-6f0abfeb7d86" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" executionId="636379ec-8480-4ae3-9532-0e13d0147638" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" executionId="71b07acc-0cf4-46cf-8d19-4d8ffa86d961" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6b8581c3-611e-6116-4232-a31382677735" executionId="2a193c2a-d0a2-4bfe-b50e-fc3253b622e3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" executionId="d30a1fa3-a584-4272-bf66-ad0c5c521842" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" executionId="1a5af968-f14e-4056-9af5-48062a955305" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4815779-aba4-cf1b-8df3-4a745af70720" executionId="e3224b22-ad2f-4d31-9e09-784b2c9fec09" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" executionId="ff20609f-60df-49eb-a108-83c60f2c97b5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ca63316a-39e5-9545-3bca-f1839c7b4664" executionId="4ed2d641-2d8c-4de9-a2a9-91a159a77383" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" executionId="7d4dde75-2912-4580-bcac-b905668c4ad3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e6c75c9-5365-7582-f701-20d37d3ff511" executionId="7b3bf790-7524-4675-bd79-8e4b87441beb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" executionId="837c84ee-e678-4a77-8021-6bc1221395db" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="add44896-9236-510f-750d-eb49b89a7a65" executionId="38c2b714-9773-4601-b41d-69770f8e8819" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" executionId="45745e7e-83c4-44da-85c8-bd4717d02da5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" executionId="b69ad1e7-ff02-4ecf-a51e-89147be57c29" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" executionId="4f8ee6a1-3d3b-4b24-9a56-dd37da2c02a4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="067e1c92-2860-531b-28dc-c2863e91b7f5" executionId="60d71832-95b3-4c8b-b905-c0b7f668444d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="64813bea-d79b-d74b-adb5-1302eaf5641f" executionId="379de59b-de9d-4799-b665-f00be26f656a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" executionId="9163e985-bacc-4d1f-8cbb-f34759532824" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" executionId="487e6d0f-ed7b-47a8-ad09-e79b1539044c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee74d71f-f824-19d9-866e-a408a95ffa99" executionId="08cf7da8-ed5e-4929-9b59-f4dc84297d02" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e30ef794-1ea7-a76a-356b-1668bca94630" executionId="69f3c322-1c37-49d2-a381-0402c332eadb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4d5f7893-139c-db00-8823-de561780758d" executionId="1fe3f0a7-f7a6-466c-93eb-8c68289fbdb8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" executionId="4a46c15b-d51c-4090-942a-628cdadc844f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="40304968-0dee-8e41-4f42-20809899a9d0" executionId="0f480644-c25e-441b-a30a-c1e9b9ca2f61" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="72d470fa-c19a-1302-1fcf-eb104ea36048" executionId="8bb11ce6-7794-4998-b148-562f39c0f2f1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296" executionId="85ed41c3-fdd6-4bb1-a950-75aaf50015e6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" executionId="80bed3bb-cf6c-4498-ad65-fc058726aea2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" executionId="655e07dd-9759-4675-abe3-e97974342beb" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9efc5df4-5f77-a670-8622-976418721b8f" executionId="90852d30-e5ef-4b9e-9340-f27b827f8c51" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" executionId="6f75d59f-71d7-4bb1-a312-de629dcc0f35" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" executionId="5fa55760-e921-40f0-8246-dbbd3838a88a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e64af447-d4dc-7221-865a-703128db7b90" executionId="a41914cf-7ed9-4737-9515-85d23e57e158" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" executionId="521ca88d-475f-41f5-93f1-203791eea1df" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" executionId="d015761e-47dd-4fe8-8c95-152dd4cbe2e3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6e54c207-a3b1-f181-06be-066795ac26e1" executionId="31e76ec9-aeed-44cf-aa4f-618b0fe6d48b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8f2bb160-fa82-a566-570e-51eeb5237e95" executionId="3d378506-8c2e-4d77-812b-1c9299d7a26b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="73c03e74-0c0b-5c1d-2193-91dd98f1f95e" executionId="02218523-4b0d-47d7-b7dd-55d6db0e9daa" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="763d7e52-45c9-3e45-478d-dd6659bc69ba" executionId="723a3a61-5240-4228-8f03-2c258bab3d49" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" executionId="92723242-e59b-4426-af79-f7bcffaf140d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" executionId="45704043-909e-4213-9939-73003e03a08d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b891bd24-e5b1-222b-8d70-96a2ba7b0807" executionId="c00eb885-753d-4d0a-a99e-dee30d523362" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="fb3ec8b2-a410-ecc8-265b-29bfd3772553" executionId="3b5efa31-0ffb-48d2-9846-b239b87188d1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a3bd6f67-daac-1ebc-5894-1d73dbe8d707" executionId="71c519c6-928c-4c78-a4f2-5f6650a40625" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7699da71-b819-eb00-3894-2f0be7eec39c" executionId="39a4465d-26ed-45e0-ad5a-91b8da4b0fe7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d253522e-be41-9b3a-247a-ca440d4ac588" executionId="a2216e3d-4a60-4f17-9398-5cc5767d919f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="cca2404a-911a-a50e-9898-327264f0ea76" executionId="b4fcf215-b3b4-4fad-bc4b-fab6c66eb579" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="22ccdb90-02c8-97c1-e2a1-6bec4f044d99" executionId="d8d0c0d2-27cb-4881-a391-7ca4164855d9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <Results>
-    <UnitTestResult executionId="6b7ae4ce-36d5-4d33-b8f0-1bd2c47ce15e" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="AS0283" duration="00:00:00.0473846" startTime="2016-09-28T09:33:43.8291468+02:00" endTime="2016-09-28T09:33:44.1701469+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6b7ae4ce-36d5-4d33-b8f0-1bd2c47ce15e">
+    <UnitTestResult executionId="636379ec-8480-4ae3-9532-0e13d0147638" testId="4d0f7327-ed22-9a43-969a-ac2ea8102d66" testName="AddingSeveralNumbers_40" computerName="LENOVOWERK" duration="00:00:00.0929641" startTime="2017-02-02T21:43:40.9639923+01:00" endTime="2017-02-02T21:43:41.5722379+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="636379ec-8480-4ae3-9532-0e13d0147638">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="80a37d44-11e7-4e5f-a101-252de0b2c2b3" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="AS0283" duration="00:00:00.0003016" startTime="2016-09-28T09:33:44.1711479+02:00" endTime="2016-09-28T09:33:44.1731476+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="80a37d44-11e7-4e5f-a101-252de0b2c2b3">
+    <UnitTestResult executionId="71b07acc-0cf4-46cf-8d19-4d8ffa86d961" testId="f4b45c2f-fc98-d23c-6179-62d5b5a59825" testName="AddingSeveralNumbers_60" computerName="LENOVOWERK" duration="00:00:00.0036739" startTime="2017-02-02T21:43:41.5782422+01:00" endTime="2017-02-02T21:43:41.5852476+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="71b07acc-0cf4-46cf-8d19-4d8ffa86d961">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="556edf09-34cc-473f-9b70-5d231853b07e" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="AS0283" duration="00:00:00.0002879" startTime="2016-09-28T09:33:44.1731476+02:00" endTime="2016-09-28T09:33:44.1751479+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="556edf09-34cc-473f-9b70-5d231853b07e">
+    <UnitTestResult executionId="2a193c2a-d0a2-4bfe-b50e-fc3253b622e3" testId="6b8581c3-611e-6116-4232-a31382677735" testName="AddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0004178" startTime="2017-02-02T21:43:41.5892495+01:00" endTime="2017-02-02T21:43:41.5932549+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2a193c2a-d0a2-4bfe-b50e-fc3253b622e3">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d67a21cd-9867-4f32-9358-2433e6159a0e" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="AS0283" duration="00:00:00.0245749" startTime="2016-09-28T09:33:44.1761455+02:00" endTime="2016-09-28T09:33:44.2021441+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d67a21cd-9867-4f32-9358-2433e6159a0e">
+    <UnitTestResult executionId="d30a1fa3-a584-4272-bf66-ad0c5c521842" testId="b13a186e-33df-348e-f9e2-a18b445d0d6e" testName="FailToAddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0392162" startTime="2017-02-02T21:43:41.5982760+01:00" endTime="2017-02-02T21:43:41.6403678+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d30a1fa3-a584-4272-bf66-ad0c5c521842">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -&gt; error: Input string was not in a correct format.</StdOut>
         <ErrorInfo>
@@ -983,16 +983,16 @@ System.FormatException: Input string was not in a correct format.</Message>
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Addition.feature:line 34
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature:line 34
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b6698137-01dc-42cc-9f5e-ae0e310d7af5" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="AS0283" duration="00:00:00.0276110" startTime="2016-09-28T09:33:44.2031442+02:00" endTime="2016-09-28T09:33:44.2341461+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b6698137-01dc-42cc-9f5e-ae0e310d7af5">
+    <UnitTestResult executionId="1a5af968-f14e-4056-9af5-48062a955305" testId="2124dd33-7aaa-d4fb-c72f-98ad434251c0" testName="NotAutomatedAddingTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0768180" startTime="2017-02-02T21:43:41.6473736+01:00" endTime="2017-02-02T21:43:41.7262140+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1a5af968-f14e-4056-9af5-48062a955305">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -1052,13 +1052,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Addition.feature:line 46
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature:line 46
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fe37892d-8ca6-4fea-a2c9-030ff029b388" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="AS0283" duration="00:00:00.0117864" startTime="2016-09-28T09:33:44.2351442+02:00" endTime="2016-09-28T09:33:44.2501582+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fe37892d-8ca6-4fea-a2c9-030ff029b388">
+    <UnitTestResult executionId="e3224b22-ad2f-4d31-9e09-784b2c9fec09" testId="b4815779-aba4-cf1b-8df3-4a745af70720" testName="AddingSeveralNumbers_40" computerName="LENOVOWERK" duration="00:00:00.0194424" startTime="2017-02-02T21:43:41.7312026+01:00" endTime="2017-02-02T21:43:41.7542215+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e3224b22-ad2f-4d31-9e09-784b2c9fec09">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -1089,21 +1089,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40()
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4e036648-6c72-4565-b4e8-4952c46022e2" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="AS0283" duration="00:00:00.0030294" startTime="2016-09-28T09:33:44.2511469+02:00" endTime="2016-09-28T09:33:44.2561650+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4e036648-6c72-4565-b4e8-4952c46022e2">
+    <UnitTestResult executionId="ff20609f-60df-49eb-a108-83c60f2c97b5" testId="17bb28b8-a770-72be-af08-5a4b0847e4ea" testName="AddingSeveralNumbers_60" computerName="LENOVOWERK" duration="00:00:00.0027681" startTime="2017-02-02T21:43:41.7592225+01:00" endTime="2017-02-02T21:43:41.7642457+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ff20609f-60df-49eb-a108-83c60f2c97b5">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -1134,21 +1134,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60()
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e88d9922-5a81-4f06-a73d-fe2ec0f0055b" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="AS0283" duration="00:00:00.0026212" startTime="2016-09-28T09:33:44.2581447+02:00" endTime="2016-09-28T09:33:44.2621444+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e88d9922-5a81-4f06-a73d-fe2ec0f0055b">
+    <UnitTestResult executionId="4ed2d641-2d8c-4de9-a2a9-91a159a77383" testId="ca63316a-39e5-9545-3bca-f1839c7b4664" testName="AddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0025693" startTime="2017-02-02T21:43:41.7692526+01:00" endTime="2017-02-02T21:43:41.7742549+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4ed2d641-2d8c-4de9-a2a9-91a159a77383">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -1177,20 +1177,20 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 12
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 12
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5c44dfb5-71bb-431e-9e76-26c2e6475b11" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="AS0283" duration="00:00:00.0050990" startTime="2016-09-28T09:33:44.2631448+02:00" endTime="2016-09-28T09:33:44.2701466+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5c44dfb5-71bb-431e-9e76-26c2e6475b11">
+    <UnitTestResult executionId="7d4dde75-2912-4580-bcac-b905668c4ad3" testId="18582dd5-09c7-ce67-9cb7-8e15a9cdffd0" testName="FailingFeatureFailingScenario" computerName="LENOVOWERK" duration="00:00:00.0061013" startTime="2017-02-02T21:43:41.7802373+01:00" endTime="2017-02-02T21:43:41.7892642+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7d4dde75-2912-4580-bcac-b905668c4ad3">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -1209,20 +1209,20 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 10
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 10
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a05975bf-21e1-475a-8743-11ad25a86434" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="AS0283" duration="00:00:00.0024849" startTime="2016-09-28T09:33:44.2711453+02:00" endTime="2016-09-28T09:33:44.2751461+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a05975bf-21e1-475a-8743-11ad25a86434">
+    <UnitTestResult executionId="7b3bf790-7524-4675-bd79-8e4b87441beb" testId="7e6c75c9-5365-7582-f701-20d37d3ff511" testName="FailingFeatureInconclusiveScenario" computerName="LENOVOWERK" duration="00:00:00.0028870" startTime="2017-02-02T21:43:41.7942485+01:00" endTime="2017-02-02T21:43:41.7992705+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7b3bf790-7524-4675-bd79-8e4b87441beb">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -1235,19 +1235,19 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f5f65ec2-fb08-42b7-af73-9396576ce7c2" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0004045" startTime="2016-09-28T09:33:44.2771441+02:00" endTime="2016-09-28T09:33:44.2781440+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f5f65ec2-fb08-42b7-af73-9396576ce7c2">
+    <UnitTestResult executionId="837c84ee-e678-4a77-8021-6bc1221395db" testId="fa1e54c9-cdb0-8bb1-6764-9179c3b61825" testName="FailingFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0005123" startTime="2017-02-02T21:43:41.8032729+01:00" endTime="2017-02-02T21:43:41.8052747+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="837c84ee-e678-4a77-8021-6bc1221395db">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e624cfd3-c524-4fa1-98d3-9eefc8ed4be0" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="AS0283" duration="00:00:00.0021981" startTime="2016-09-28T09:33:44.2801439+02:00" endTime="2016-09-28T09:33:44.2841567+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e624cfd3-c524-4fa1-98d3-9eefc8ed4be0">
+    <UnitTestResult executionId="38c2b714-9773-4601-b41d-69770f8e8819" testId="add44896-9236-510f-750d-eb49b89a7a65" testName="InconclusiveFeatureInconclusiveScenario" computerName="LENOVOWERK" duration="00:00:00.0024136" startTime="2017-02-02T21:43:41.8122600+01:00" endTime="2017-02-02T21:43:41.8177883+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="38c2b714-9773-4601-b41d-69770f8e8819">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -1260,25 +1260,25 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="404c51e5-0866-4a9f-8135-e10148b23cab" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0003558" startTime="2016-09-28T09:33:44.2851437+02:00" endTime="2016-09-28T09:33:44.2871540+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="404c51e5-0866-4a9f-8135-e10148b23cab">
+    <UnitTestResult executionId="45745e7e-83c4-44da-85c8-bd4717d02da5" testId="41cb0c4f-1c07-4937-29e8-dcc987caf94e" testName="InconclusiveFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0002715" startTime="2017-02-02T21:43:41.8217702+01:00" endTime="2017-02-02T21:43:41.8242925+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="45745e7e-83c4-44da-85c8-bd4717d02da5">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="7c0571c5-7649-47e7-b5a3-d78ccf512327" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0004627" startTime="2016-09-28T09:33:44.2881496+02:00" endTime="2016-09-28T09:33:44.2911451+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7c0571c5-7649-47e7-b5a3-d78ccf512327">
+    <UnitTestResult executionId="b69ad1e7-ff02-4ecf-a51e-89147be57c29" testId="3af599bd-a8de-95a2-1ecc-194c7f8aceeb" testName="PassingFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0004956" startTime="2017-02-02T21:43:41.8299969+01:00" endTime="2017-02-02T21:43:41.8339998+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b69ad1e7-ff02-4ecf-a51e-89147be57c29">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0289f165-b539-472e-97da-60133c9753c3" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="AS0283" duration="00:00:00.0042078" startTime="2016-09-28T09:33:44.2931556+02:00" endTime="2016-09-28T09:33:44.2991430+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0289f165-b539-472e-97da-60133c9753c3">
+    <UnitTestResult executionId="4f8ee6a1-3d3b-4b24-9a56-dd37da2c02a4" testId="0e090158-43a1-1be8-47c2-13e1b2c9f8c7" testName="NotAutomatedScenario1" computerName="LENOVOWERK" duration="00:00:00.0064075" startTime="2017-02-02T21:43:41.8389841+01:00" endTime="2017-02-02T21:43:41.8480097+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4f8ee6a1-3d3b-4b24-9a56-dd37da2c02a4">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1347,13 +1347,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 9
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 9
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="991a416f-6dc9-43ca-8fd8-49defbb57f07" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="AS0283" duration="00:00:00.0046255" startTime="2016-09-28T09:33:44.3001457+02:00" endTime="2016-09-28T09:33:44.3071441+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="991a416f-6dc9-43ca-8fd8-49defbb57f07">
+    <UnitTestResult executionId="60d71832-95b3-4c8b-b905-c0b7f668444d" testId="067e1c92-2860-531b-28dc-c2863e91b7f5" testName="NotAutomatedScenario2" computerName="LENOVOWERK" duration="00:00:00.0055877" startTime="2017-02-02T21:43:41.8520117+01:00" endTime="2017-02-02T21:43:41.8599981+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="60d71832-95b3-4c8b-b905-c0b7f668444d">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1422,13 +1422,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 14
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 14
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="08a69590-d4ac-4a25-b0bf-00702dee00bd" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="AS0283" duration="00:00:00.0035657" startTime="2016-09-28T09:33:44.3081437+02:00" endTime="2016-09-28T09:33:44.3131435+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="08a69590-d4ac-4a25-b0bf-00702dee00bd">
+    <UnitTestResult executionId="379de59b-de9d-4799-b665-f00be26f656a" testId="64813bea-d79b-d74b-adb5-1302eaf5641f" testName="NotAutomatedScenario3" computerName="LENOVOWERK" duration="00:00:00.0059931" startTime="2017-02-02T21:43:41.8650021+01:00" endTime="2017-02-02T21:43:41.8730278+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="379de59b-de9d-4799-b665-f00be26f656a">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -1497,27 +1497,27 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 19
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 19
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="cc24508e-638a-4091-b113-e0ef1509435e" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="AS0283" duration="00:00:00.0001146" startTime="2016-09-28T09:33:44.3141439+02:00" endTime="2016-09-28T09:33:44.3161433+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cc24508e-638a-4091-b113-e0ef1509435e">
+    <UnitTestResult executionId="9163e985-bacc-4d1f-8cbb-f34759532824" testId="aa71fe8a-e5aa-f23d-c632-cfb3c587ca21" testName="TestMethod" computerName="LENOVOWERK" duration="00:00:00.0001445" startTime="2017-02-02T21:43:41.8790128+01:00" endTime="2017-02-02T21:43:41.8810331+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9163e985-bacc-4d1f-8cbb-f34759532824">
     </UnitTestResult>
-    <UnitTestResult executionId="df0fdf42-4c14-4bde-ba6a-2b06e801f895" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="AS0283" duration="00:00:00.0009066" startTime="2016-09-28T09:33:44.3171466+02:00" endTime="2016-09-28T09:33:44.3201570+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="df0fdf42-4c14-4bde-ba6a-2b06e801f895">
+    <UnitTestResult executionId="487e6d0f-ed7b-47a8-ad09-e79b1539044c" testId="78aeddd0-4ae5-6103-b7dd-e62b71148721" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0019017" startTime="2017-02-02T21:43:41.8850355+01:00" endTime="2017-02-02T21:43:41.8900232+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="487e6d0f-ed7b-47a8-ad09-e79b1539044c">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e3ae304c-2dae-4ced-8f1e-a967c4dbacd0" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="AS0283" duration="00:00:00.0002620" startTime="2016-09-28T09:33:44.3211463+02:00" endTime="2016-09-28T09:33:44.3221570+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e3ae304c-2dae-4ced-8f1e-a967c4dbacd0">
+    <UnitTestResult executionId="08cf7da8-ed5e-4929-9b59-f4dc84297d02" testId="ee74d71f-f824-19d9-866e-a408a95ffa99" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0002044" startTime="2017-02-02T21:43:41.8960240+01:00" endTime="2017-02-02T21:43:41.8980451+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="08cf7da8-ed5e-4929-9b59-f4dc84297d02">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c2c64da2-f4d5-4797-a119-ff5b2470b978" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="AS0283" duration="00:00:00.0016034" startTime="2016-09-28T09:33:44.3241575+02:00" endTime="2016-09-28T09:33:44.3271459+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c2c64da2-f4d5-4797-a119-ff5b2470b978">
+    <UnitTestResult executionId="69f3c322-1c37-49d2-a381-0402c332eadb" testId="e30ef794-1ea7-a76a-356b-1668bca94630" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="LENOVOWERK" duration="00:00:00.0018731" startTime="2017-02-02T21:43:41.9030290+01:00" endTime="2017-02-02T21:43:41.9070310+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="69f3c322-1c37-49d2-a381-0402c332eadb">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1530,14 +1530,14 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="b88e3fe2-7142-4844-82fb-c028962cf58c" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="AS0283" duration="00:00:00.0011649" startTime="2016-09-28T09:33:44.3281435+02:00" endTime="2016-09-28T09:33:44.3311579+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b88e3fe2-7142-4844-82fb-c028962cf58c">
+    <UnitTestResult executionId="1fe3f0a7-f7a6-466c-93eb-8c68289fbdb8" testId="4d5f7893-139c-db00-8823-de561780758d" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="LENOVOWERK" duration="00:00:00.0015964" startTime="2017-02-02T21:43:41.9130391+01:00" endTime="2017-02-02T21:43:41.9165612+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1fe3f0a7-f7a6-466c-93eb-8c68289fbdb8">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
@@ -1550,14 +1550,14 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ab1d7239-4539-458b-a7f9-dfab7f9bc5da" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="AS0283" duration="00:00:00.0027723" startTime="2016-09-28T09:33:44.3321466+02:00" endTime="2016-09-28T09:33:44.3361571+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ab1d7239-4539-458b-a7f9-dfab7f9bc5da">
+    <UnitTestResult executionId="4a46c15b-d51c-4090-942a-628cdadc844f" testId="78a6b3a3-679e-ee71-7ff5-c9338e3be6c2" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="LENOVOWERK" duration="00:00:00.0034524" startTime="2017-02-02T21:43:41.9215571+01:00" endTime="2017-02-02T21:43:41.9270691+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4a46c15b-d51c-4090-942a-628cdadc844f">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1576,21 +1576,21 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="dc477dc5-8081-4326-a1a3-7f691ef07670" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="AS0283" duration="00:00:00.0025975" startTime="2016-09-28T09:33:44.3371438+02:00" endTime="2016-09-28T09:33:44.3411472+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dc477dc5-8081-4326-a1a3-7f691ef07670">
+    <UnitTestResult executionId="0f480644-c25e-441b-a30a-c1e9b9ca2f61" testId="40304968-0dee-8e41-4f42-20809899a9d0" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="LENOVOWERK" duration="00:00:00.0027395" startTime="2017-02-02T21:43:41.9325734+01:00" endTime="2017-02-02T21:43:41.9365758+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0f480644-c25e-441b-a30a-c1e9b9ca2f61">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -1609,61 +1609,61 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0db42487-c1e4-4189-a35f-e93bd02705bb" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="AS0283" duration="00:00:00.0006420" startTime="2016-09-28T09:33:44.3421442+02:00" endTime="2016-09-28T09:33:44.3441462+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0db42487-c1e4-4189-a35f-e93bd02705bb">
+    <UnitTestResult executionId="8bb11ce6-7794-4998-b148-562f39c0f2f1" testId="72d470fa-c19a-1302-1fcf-eb104ea36048" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="LENOVOWERK" duration="00:00:00.0006500" startTime="2017-02-02T21:43:41.9425788+01:00" endTime="2017-02-02T21:43:41.9455997+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8bb11ce6-7794-4998-b148-562f39c0f2f1">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5f84a30c-d6be-43b0-8e3e-9539f2944ba2" testId="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296" testName="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" computerName="AS0283" duration="00:00:00.0005394" startTime="2016-09-28T09:33:44.3451435+02:00" endTime="2016-09-28T09:33:44.3471463+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5f84a30c-d6be-43b0-8e3e-9539f2944ba2">
+    <UnitTestResult executionId="85ed41c3-fdd6-4bb1-a950-75aaf50015e6" testId="ce4a9bf6-5fc5-0a40-2cbe-242a59cb1296" testName="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" computerName="LENOVOWERK" duration="00:00:00.0007744" startTime="2017-02-02T21:43:41.9505982+01:00" endTime="2017-02-02T21:43:41.9536054+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="85ed41c3-fdd6-4bb1-a950-75aaf50015e6">
       <Output>
         <StdOut>When I have a field with value 'Please enter a valid two letter country code (e.g. DE)!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0.0s)
 And I have a field with value 'This is just a very very very veery long error message!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="cb798ff2-ffd4-4096-88aa-ac2565e53858" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="AS0283" duration="00:00:00.0004382" startTime="2016-09-28T09:33:44.3481433+02:00" endTime="2016-09-28T09:33:44.3501436+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cb798ff2-ffd4-4096-88aa-ac2565e53858">
+    <UnitTestResult executionId="80bed3bb-cf6c-4498-ad65-fc058726aea2" testId="d09c033d-0065-cbeb-bd7c-ee8b6460688f" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="LENOVOWERK" duration="00:00:00.0006821" startTime="2017-02-02T21:43:41.9620477+01:00" endTime="2017-02-02T21:43:41.9650494+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="80bed3bb-cf6c-4498-ad65-fc058726aea2">
       <Output>
         <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="12e9883b-8b0c-4deb-a841-759574515567" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="AS0283" duration="00:00:00.0003110" startTime="2016-09-28T09:33:44.3511434+02:00" endTime="2016-09-28T09:33:44.3531460+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="12e9883b-8b0c-4deb-a841-759574515567">
+    <UnitTestResult executionId="655e07dd-9759-4675-abe3-e97974342beb" testId="2c8f1abb-446c-6683-6327-8ec4ccd46e1a" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0006072" startTime="2017-02-02T21:43:41.9690711+01:00" endTime="2017-02-02T21:43:41.9720557+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="655e07dd-9759-4675-abe3-e97974342beb">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="807f7b27-c6eb-417f-8733-2d48ea7263c9" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="AS0283" duration="00:00:00.0001924" startTime="2016-09-28T09:33:44.3541430+02:00" endTime="2016-09-28T09:33:44.3561438+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="807f7b27-c6eb-417f-8733-2d48ea7263c9">
+    <UnitTestResult executionId="90852d30-e5ef-4b9e-9340-f27b827f8c51" testId="9efc5df4-5f77-a670-8622-976418721b8f" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0002052" startTime="2017-02-02T21:43:41.9770780+01:00" endTime="2017-02-02T21:43:41.9810612+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="90852d30-e5ef-4b9e-9340-f27b827f8c51">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5afafeb3-4f9f-4761-aa1c-25437fb913db" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="AS0283" duration="00:00:00.0001702" startTime="2016-09-28T09:33:44.3571556+02:00" endTime="2016-09-28T09:33:44.3591434+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5afafeb3-4f9f-4761-aa1c-25437fb913db">
+    <UnitTestResult executionId="6f75d59f-71d7-4bb1-a312-de629dcc0f35" testId="9bb2410c-d8c6-90b8-75cd-5c93dc903745" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="LENOVOWERK" duration="00:00:00.0002086" startTime="2017-02-02T21:43:41.9850828+01:00" endTime="2017-02-02T21:43:41.9870851+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6f75d59f-71d7-4bb1-a312-de629dcc0f35">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="943c71de-e0fb-4491-bee5-a88a58ce5d6f" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="AS0283" duration="00:00:00.0034038" startTime="2016-09-28T09:33:44.3601435+02:00" endTime="2016-09-28T09:33:44.3651570+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="943c71de-e0fb-4491-bee5-a88a58ce5d6f">
+    <UnitTestResult executionId="5fa55760-e921-40f0-8246-dbbd3838a88a" testId="05c22c90-eaaa-d3c2-bd2d-36c2df85528e" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="LENOVOWERK" duration="00:00:00.0028896" startTime="2017-02-02T21:43:41.9920690+01:00" endTime="2017-02-02T21:43:41.9980925+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5fa55760-e921-40f0-8246-dbbd3838a88a">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -1682,33 +1682,33 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 34
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f48a7003-60ee-4a81-980d-93aa28dcdf4a" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="AS0283" duration="00:00:00.0001605" startTime="2016-09-28T09:33:44.3661432+02:00" endTime="2016-09-28T09:33:44.3681463+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f48a7003-60ee-4a81-980d-93aa28dcdf4a">
+    <UnitTestResult executionId="a41914cf-7ed9-4737-9515-85d23e57e158" testId="e64af447-d4dc-7221-865a-703128db7b90" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0002189" startTime="2017-02-02T21:43:42.0030780+01:00" endTime="2017-02-02T21:43:42.0050795+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a41914cf-7ed9-4737-9515-85d23e57e158">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="6d018bfc-866c-4963-9cf2-fea88195981b" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="AS0283" duration="00:00:00.0002360" startTime="2016-09-28T09:33:44.3691436+02:00" endTime="2016-09-28T09:33:44.3711438+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6d018bfc-866c-4963-9cf2-fea88195981b">
+    <UnitTestResult executionId="521ca88d-475f-41f5-93f1-203791eea1df" testId="b04f3200-80ca-d47f-0c01-8a37e5c952e6" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0002715" startTime="2017-02-02T21:43:42.0100822+01:00" endTime="2017-02-02T21:43:42.0130843+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="521ca88d-475f-41f5-93f1-203791eea1df">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="64386890-55a5-4b95-a423-b7712a39b8bf" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="AS0283" duration="00:00:00.0016638" startTime="2016-09-28T09:33:44.3721448+02:00" endTime="2016-09-28T09:33:44.3751441+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="64386890-55a5-4b95-a423-b7712a39b8bf">
+    <UnitTestResult executionId="d015761e-47dd-4fe8-8c95-152dd4cbe2e3" testId="8c97c958-0c5d-1594-2cc5-02c96df8fc9b" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="LENOVOWERK" duration="00:00:00.0017136" startTime="2017-02-02T21:43:42.0175922+01:00" endTime="2017-02-02T21:43:42.0211126+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Inconclusive" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d015761e-47dd-4fe8-8c95-152dd4cbe2e3">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -1721,131 +1721,131 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 21
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="37420234-8748-4b85-94dd-c262b1d4acae" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="AS0283" duration="00:00:00.0001576" startTime="2016-09-28T09:33:44.3761459+02:00" endTime="2016-09-28T09:33:44.3781570+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="37420234-8748-4b85-94dd-c262b1d4acae">
+    <UnitTestResult executionId="31e76ec9-aeed-44cf-aa4f-618b0fe6d48b" testId="6e54c207-a3b1-f181-06be-066795ac26e1" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0002347" startTime="2017-02-02T21:43:42.0270972+01:00" endTime="2017-02-02T21:43:42.0292534+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31e76ec9-aeed-44cf-aa4f-618b0fe6d48b">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="2caaf730-6060-459c-a263-4b80a7f424e4" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="AS0283" duration="00:00:00.0001345" startTime="2016-09-28T09:33:44.3791432+02:00" endTime="2016-09-28T09:33:44.3801436+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2caaf730-6060-459c-a263-4b80a7f424e4">
+    <UnitTestResult executionId="3d378506-8c2e-4d77-812b-1c9299d7a26b" testId="8f2bb160-fa82-a566-570e-51eeb5237e95" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0002065" startTime="2017-02-02T21:43:42.0342377+01:00" endTime="2017-02-02T21:43:42.0362413+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3d378506-8c2e-4d77-812b-1c9299d7a26b">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="7e500918-0760-421a-83be-4ad63c51d858" testId="73c03e74-0c0b-5c1d-2193-91dd98f1f95e" testName="ThisIsAScenarioOutlineWithAmpersand_Pass_1" computerName="AS0283" duration="00:00:00.0005328" startTime="2016-09-28T09:33:44.3811625+02:00" endTime="2016-09-28T09:33:44.3841461+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7e500918-0760-421a-83be-4ad63c51d858">
+    <UnitTestResult executionId="02218523-4b0d-47d7-b7dd-55d6db0e9daa" testId="73c03e74-0c0b-5c1d-2193-91dd98f1f95e" testName="ThisIsAScenarioOutlineWithAmpersand_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0006812" startTime="2017-02-02T21:43:42.0402428+01:00" endTime="2017-02-02T21:43:42.0452648+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="02218523-4b0d-47d7-b7dd-55d6db0e9daa">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="aa138266-ab3e-4002-a38e-c8e05c31c8e6" testId="763d7e52-45c9-3e45-478d-dd6659bc69ba" testName="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" computerName="AS0283" duration="00:00:00.0003084" startTime="2016-09-28T09:33:44.3851431+02:00" endTime="2016-09-28T09:33:44.3871434+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="aa138266-ab3e-4002-a38e-c8e05c31c8e6">
+    <UnitTestResult executionId="723a3a61-5240-4228-8f03-2c258bab3d49" testId="763d7e52-45c9-3e45-478d-dd6659bc69ba" testName="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0003579" startTime="2017-02-02T21:43:42.0502503+01:00" endTime="2017-02-02T21:43:42.0522693+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="723a3a61-5240-4228-8f03-2c258bab3d49">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="8b1c3c84-7a92-4086-a0b6-570d83a0369b" testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="AS0283" duration="00:00:00.0003523" startTime="2016-09-28T09:33:44.3881430+02:00" endTime="2016-09-28T09:33:44.3901444+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8b1c3c84-7a92-4086-a0b6-570d83a0369b">
+    <UnitTestResult executionId="92723242-e59b-4426-af79-f7bcffaf140d" testId="f8369e2e-c5ec-dade-ad85-e2c56909c853" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0003754" startTime="2017-02-02T21:43:42.0572536+01:00" endTime="2017-02-02T21:43:42.0592854+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="92723242-e59b-4426-af79-f7bcffaf140d">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d6156b13-8dea-4855-a0d6-c17e57bc0bf1" testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="AS0283" duration="00:00:00.0004102" startTime="2016-09-28T09:33:44.3911431+02:00" endTime="2016-09-28T09:33:44.3931433+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d6156b13-8dea-4855-a0d6-c17e57bc0bf1">
+    <UnitTestResult executionId="45704043-909e-4213-9939-73003e03a08d" testId="3fe8806f-fabb-1deb-7e27-c59578f16da3" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="LENOVOWERK" duration="00:00:00.0004280" startTime="2017-02-02T21:43:42.0652601+01:00" endTime="2017-02-02T21:43:42.0672803+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="45704043-909e-4213-9939-73003e03a08d">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 120 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="98c888d3-b7f7-4085-8aef-ce81ee21100d" testId="b891bd24-e5b1-222b-8d70-96a2ba7b0807" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" computerName="AS0283" duration="00:00:00.0007828" startTime="2016-09-28T09:33:44.3941440+02:00" endTime="2016-09-28T09:33:44.3971430+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="98c888d3-b7f7-4085-8aef-ce81ee21100d">
+    <UnitTestResult executionId="c00eb885-753d-4d0a-a99e-dee30d523362" testId="b891bd24-e5b1-222b-8d70-96a2ba7b0807" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" computerName="LENOVOWERK" duration="00:00:00.0013783" startTime="2017-02-02T21:43:42.0712652+01:00" endTime="2017-02-02T21:43:42.0752689+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c00eb885-753d-4d0a-a99e-dee30d523362">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '**'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="1aa8cc43-19e6-440f-9d36-87f525d47f1b" testId="fb3ec8b2-a410-ecc8-265b-29bfd3772553" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" computerName="AS0283" duration="00:00:00.0003503" startTime="2016-09-28T09:33:44.3981434+02:00" endTime="2016-09-28T09:33:44.4001460+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1aa8cc43-19e6-440f-9d36-87f525d47f1b">
+    <UnitTestResult executionId="3b5efa31-0ffb-48d2-9846-b239b87188d1" testId="fb3ec8b2-a410-ecc8-265b-29bfd3772553" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" computerName="LENOVOWERK" duration="00:00:00.0002625" startTime="2017-02-02T21:43:42.0802720+01:00" endTime="2017-02-02T21:43:42.0822914+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3b5efa31-0ffb-48d2-9846-b239b87188d1">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '++'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f2df90c9-7a83-4804-8286-7e68abdb6acc" testId="a3bd6f67-daac-1ebc-5894-1d73dbe8d707" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" computerName="AS0283" duration="00:00:00.0001918" startTime="2016-09-28T09:33:44.4011441+02:00" endTime="2016-09-28T09:33:44.4031564+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f2df90c9-7a83-4804-8286-7e68abdb6acc">
+    <UnitTestResult executionId="71c519c6-928c-4c78-a4f2-5f6650a40625" testId="a3bd6f67-daac-1ebc-5894-1d73dbe8d707" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" computerName="LENOVOWERK" duration="00:00:00.0002600" startTime="2017-02-02T21:43:42.0872941+01:00" endTime="2017-02-02T21:43:42.0892959+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="71c519c6-928c-4c78-a4f2-5f6650a40625">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '.*'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fe022d9c-e496-4d25-8ee2-cecdfd7d7cbd" testId="7699da71-b819-eb00-3894-2f0be7eec39c" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" computerName="AS0283" duration="00:00:00.0001870" startTime="2016-09-28T09:33:44.4041454+02:00" endTime="2016-09-28T09:33:44.4051566+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fe022d9c-e496-4d25-8ee2-cecdfd7d7cbd">
+    <UnitTestResult executionId="39a4465d-26ed-45e0-ad5a-91b8da4b0fe7" testId="7699da71-b819-eb00-3894-2f0be7eec39c" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" computerName="LENOVOWERK" duration="00:00:00.0002587" startTime="2017-02-02T21:43:42.0952814+01:00" endTime="2017-02-02T21:43:42.0973020+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="39a4465d-26ed-45e0-ad5a-91b8da4b0fe7">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '[]'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="41ec70d9-da3e-4c83-928e-51a61b9d48c3" testId="d253522e-be41-9b3a-247a-ca440d4ac588" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" computerName="AS0283" duration="00:00:00.0002936" startTime="2016-09-28T09:33:44.4061439+02:00" endTime="2016-09-28T09:33:44.4091569+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="41ec70d9-da3e-4c83-928e-51a61b9d48c3">
+    <UnitTestResult executionId="a2216e3d-4a60-4f17-9398-5cc5767d919f" testId="d253522e-be41-9b3a-247a-ca440d4ac588" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" computerName="LENOVOWERK" duration="00:00:00.0002822" startTime="2017-02-02T21:43:42.1022855+01:00" endTime="2017-02-02T21:43:42.1043074+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a2216e3d-4a60-4f17-9398-5cc5767d919f">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '{}'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="7fa9f127-15ff-45a9-90a0-69b0359e0f64" testId="cca2404a-911a-a50e-9898-327264f0ea76" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" computerName="AS0283" duration="00:00:00.0002098" startTime="2016-09-28T09:33:44.4101447+02:00" endTime="2016-09-28T09:33:44.4121427+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7fa9f127-15ff-45a9-90a0-69b0359e0f64">
+    <UnitTestResult executionId="b4fcf215-b3b4-4fad-bc4b-fab6c66eb579" testId="cca2404a-911a-a50e-9898-327264f0ea76" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" computerName="LENOVOWERK" duration="00:00:00.0002583" startTime="2017-02-02T21:43:42.1102911+01:00" endTime="2017-02-02T21:43:42.1123131+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="b4fcf215-b3b4-4fad-bc4b-fab6c66eb579">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '()'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="8861d3d8-946d-4d98-a506-6f0abfeb7d86" testId="22ccdb90-02c8-97c1-e2a1-6bec4f044d99" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" computerName="AS0283" duration="00:00:00.0001895" startTime="2016-09-28T09:33:44.4131440+02:00" endTime="2016-09-28T09:33:44.4141570+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8861d3d8-946d-4d98-a506-6f0abfeb7d86">
+    <UnitTestResult executionId="d8d0c0d2-27cb-4881-a391-7ca4164855d9" testId="22ccdb90-02c8-97c1-e2a1-6bec4f044d99" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" computerName="LENOVOWERK" duration="00:00:00.0002681" startTime="2017-02-02T21:43:42.1177990+01:00" endTime="2017-02-02T21:43:42.1198210+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8d0c0d2-27cb-4881-a391-7ca4164855d9">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/results-example-nunit.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!--This file represents the results of running a test suite-->
-<test-results name="C:\DevProjects\Tools\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" total="46" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2016-09-28" time="09:33:22">
-  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8669" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\DevProjects\Tools\pickles" machine-name="AS0283" user="HKR" user-domain="OEVERMANN" />
-  <culture-info current-culture="de-DE" current-uiculture="en-US" />
-  <test-suite type="Assembly" name="C:\DevProjects\Tools\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="0.818" asserts="0">
+<test-results name="C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" total="46" errors="8" failures="0" not-run="1" inconclusive="9" ignored="1" skipped="0" invalid="0" date="2017-02-02" time="21:43:19">
+  <environment nunit-version="2.6.4.14350" clr-version="2.0.50727.8745" os-version="Microsoft Windows NT 6.2.9200.0" platform="Win32NT" cwd="C:\Users\Bas\Source\Repos\pickles" machine-name="LENOVOWERK" user="Bas" user-domain="LENOVOWERK" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" executed="True" result="Failure" success="False" time="1.031" asserts="0">
     <results>
-      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="0.812" asserts="0">
+      <test-suite type="Namespace" name="Pickles" executed="True" result="Failure" success="False" time="1.023" asserts="0">
         <results>
-          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="0.812" asserts="0">
+          <test-suite type="Namespace" name="TestHarness" executed="True" result="Failure" success="False" time="1.022" asserts="0">
             <results>
-              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="0.812" asserts="0">
+              <test-suite type="Namespace" name="nunit" executed="True" result="Failure" success="False" time="1.022" asserts="0">
                 <results>
-                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.664" asserts="0">
+                  <test-suite type="TestFixture" name="AdditionFeature" description="Addition" executed="True" result="Failure" success="False" time="0.762" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.190" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Success" success="True" time="0.243" asserts="0">
                         <categories>
                           <category name="tag2" />
                         </categories>
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.182" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Success" success="True" time="0.232" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddTwoNumbers" description="Add two numbers" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.AddTwoNumbers" description="Add two numbers" executed="True" result="Success" success="True" time="0.001" asserts="0">
                         <categories>
                           <category name="tag1" />
                         </categories>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.051" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" description="Fail to add two numbers" executed="True" result="Error" success="False" time="0.017" asserts="0">
                         <categories>
                           <category name="tag1" />
                         </categories>
@@ -43,8 +43,8 @@ at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit\Addition.feature:line 34
+at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Addition.feature.cs:line 0
+at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Addition.feature:line 34
 ]]></stack-trace>
                         </failure>
                       </test-case>
@@ -53,7 +53,7 @@ at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\DevProj
                           <message><![CDATA[]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.124" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" description="Not automated adding two numbers" executed="True" result="Inconclusive" success="False" time="0.127" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -88,11 +88,11 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.034" asserts="0">
+                  <test-suite type="TestFixture" name="FailingBackgroundFeature" description="Failing Background" executed="True" result="Failure" success="False" time="0.060" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.024" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AddingSeveralNumbers" description="Adding several numbers" executed="True" result="Failure" success="False" time="0.043" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.017" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" executed="True" result="Error" success="False" time="0.025" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -102,17 +102,17 @@ namespace MyNamespace
     1]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 19
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 19
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" executed="True" result="Error" success="False" time="0.004" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -122,13 +122,13 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     1]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 19
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 19
 ]]></stack-trace>
                             </failure>
                           </test-case>
@@ -144,23 +144,23 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(Strin
     1]]></message>
                           <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 12
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 12
 ]]></stack-trace>
                         </failure>
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.021" asserts="0">
+                  <test-suite type="Namespace" name="MinimalFeatures" executed="True" result="Failure" success="False" time="0.036" asserts="0">
                     <results>
-                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.014" asserts="0">
+                      <test-suite type="TestFixture" name="FailingFeature" description="Failing" executed="True" result="Failure" success="False" time="0.021" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.005" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" description="Failing Feature Failing Scenario" executed="True" result="Error" success="False" time="0.008" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -170,17 +170,17 @@ at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\DevP
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\nunit\Minimal Features\Failing.feature:line 10
+at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Minimal Features\Failing.feature.cs:line 0
+at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Minimal Features\Failing.feature:line 10
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" description="Failing Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.006" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()]]></message>
@@ -189,9 +189,9 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" description="Failing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                      <test-suite type="TestFixture" name="InconclusiveFeature" description="Inconclusive" executed="True" result="Success" success="True" time="0.008" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" description="Inconclusive Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" description="Inconclusive Feature Inconclusive Scenario" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()]]></message>
@@ -200,16 +200,16 @@ at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailin
                           <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" description="Inconclusive Feature Passing Scenario" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="TestFixture" name="PassingFeature" description="Passing" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="TestFixture" name="PassingFeature" description="Passing" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" description="Passing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" description="Passing Feature Passing Scenario" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.019" asserts="0">
+                  <test-suite type="TestFixture" name="NotAutomatedAtAllFeature" description="Not Automated At All" executed="True" result="Inconclusive" success="False" time="0.040" asserts="0">
                     <results>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.008" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" description="Not automated scenario 1" executed="True" result="Inconclusive" success="False" time="0.013" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -242,7 +242,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" description="Not automated scenario 2" executed="True" result="Inconclusive" success="False" time="0.011" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -275,7 +275,7 @@ namespace MyNamespace
 ]]></message>
                         </reason>
                       </test-case>
-                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                      <test-case name="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" description="Not automated scenario 3" executed="True" result="Inconclusive" success="False" time="0.012" asserts="0">
                         <reason>
                           <message><![CDATA[No matching step definition found for one or more steps.
 using System;
@@ -310,13 +310,13 @@ namespace MyNamespace
                       </test-case>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.040" asserts="0">
+                  <test-suite type="TestFixture" name="ScenarioOutlinesFeature" description="Scenario Outlines" executed="True" result="Failure" success="False" time="0.065" asserts="0">
                     <results>
-                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.013" asserts="0">
+                      <test-suite type="ParameterizedTest" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" description="And we can go totally bonkers with multiple example sections." executed="True" result="Failure" success="False" time="0.024" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.003" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.003" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -328,7 +328,7 @@ namespace MyNamespace
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
                             </reason>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.003" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -338,17 +338,17 @@ namespace MyNamespace
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45
 ]]></stack-trace>
                             </failure>
                           </test-case>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" executed="True" result="Error" success="False" time="0.001" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
                               <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -358,26 +358,26 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45
 ]]></stack-trace>
                             </failure>
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithBackslashesInTheExamples" description="Deal correctly with backslashes in the examples" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithBackslashesInTheExamples" description="Deal correctly with backslashes in the examples" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithOverlongExampleValues" description="Deal correctly with overlong example values" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                      <test-suite type="ParameterizedTest" name="DealCorrectlyWithOverlongExampleValues" description="Deal correctly with overlong example values" executed="True" result="Success" success="True" time="0.002" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
                         </results>
                       </test-suite>
                       <test-suite type="ParameterizedTest" name="DealCorrectlyWithParenthesisInTheExamples" description="Deal correctly with parenthesis in the examples" executed="True" result="Success" success="True" time="0.001" asserts="0">
@@ -385,16 +385,16 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereAllScenariosPass" description="This is a scenario outline where all scenarios pass" executed="True" result="Success" success="True" time="0.007" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.005" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioFails" description="This is a scenario outline where one scenario fails" executed="True" result="Failure" success="False" time="0.006" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" executed="True" result="Error" success="False" time="0.002" asserts="0">
                             <failure>
@@ -406,23 +406,23 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWit
     True]]></message>
                               <stack-trace><![CDATA[at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
 at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
 at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
 at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 34
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 34
 ]]></stack-trace>
                             </failure>
                           </test-case>
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" description="This is a scenario outline where one scenario is inconclusive" executed="True" result="Success" success="True" time="0.007" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
                             <reason>
                               <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -432,31 +432,31 @@ at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhere
                       </test-suite>
                     </results>
                   </test-suite>
-                  <test-suite type="TestFixture" name="ScenariosWithSpecialCharactersFeature" description="Scenarios With Special Characters" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                  <test-suite type="TestFixture" name="ScenariosWithSpecialCharactersFeature" description="Scenarios With Special Characters" executed="True" result="Success" success="True" time="0.038" asserts="0">
                     <results>
                       <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWithAmpersand" description="This is a scenario outline with ampersand &amp;" executed="True" result="Success" success="True" time="0.001" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
-                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" description="This is a scenario outline with german umlauts äöüß ÄÖÜ" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" description="This is a scenario outline with german umlauts äöüß ÄÖÜ" executed="True" result="Success" success="True" time="0.001" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                       <test-suite type="ParameterizedTest" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" description="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" executed="True" result="Success" success="True" time="0.001" asserts="0">
                         <results>
-                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                         </results>
                       </test-suite>
                       <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" description="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
-                      <test-suite type="ParameterizedTest" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" description="This scenario contains examples with Regex-special characters" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                      <test-suite type="ParameterizedTest" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" description="This scenario contains examples with Regex-special characters" executed="True" result="Success" success="True" time="0.017" asserts="0">
                         <results>
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
-                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                           <test-case name="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
                         </results>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit2-with-nunit3-runner.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit2-with-nunit3-runner.xml
@@ -1,48 +1,48 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="47" result="Failed" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-09-28 07:33:23Z" end-time="2016-09-28 07:33:24Z" duration="0.920351">
-  <command-line><![CDATA["C:\DevProjects\Tools\pickles\\test-harness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\DevProjects\Tools\pickles\\test-harness\nunit\bin\Debug\nunitHarness.dll" /result="C:\DevProjects\Tools\pickles\\results-example-nunit2-with-nunit3-runner.xml"]]></command-line>
-  <test-suite type="Assembly" id="1-1068" name="C:\DevProjects\Tools\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" fullname="C:\DevProjects\Tools\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" runstate="Runnable" testcasecount="47" result="Failed" duration="0.874353" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+<test-run id="2" testcasecount="47" result="Failed" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2017-02-02 20:43:21Z" end-time="2017-02-02 20:43:22Z" duration="1.359544">
+  <command-line><![CDATA["C:\Users\Bas\Source\Repos\pickles\\test-harness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\Users\Bas\Source\Repos\pickles\\test-harness\nunit\bin\Debug\nunitHarness.dll" /result="C:\Users\Bas\Source\Repos\pickles\\results-example-nunit2-with-nunit3-runner.xml"]]></command-line>
+  <test-suite type="Assembly" id="1-1068" name="C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" fullname="C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\bin\Debug\nunitHarness.dll" runstate="Runnable" testcasecount="47" result="Failed" duration="1.297667" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
     <properties>
-      <property name="_PID" value="13016" />
+      <property name="_PID" value="14860" />
       <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
       <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="Namespace" id="1-1069" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="47" result="Failed" duration="0.867766" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+    <test-suite type="Namespace" id="1-1069" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="47" result="Failed" duration="1.286869" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
       <failure>
         <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="Namespace" id="1-1070" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="47" result="Failed" duration="0.867495" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+      <test-suite type="Namespace" id="1-1070" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="47" result="Failed" duration="1.286567" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
         <failure>
           <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="Namespace" id="1-1071" name="nunit" fullname="Pickles.TestHarness.nunit" runstate="Runnable" testcasecount="47" result="Failed" duration="0.867272" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+        <test-suite type="Namespace" id="1-1071" name="nunit" fullname="Pickles.TestHarness.nunit" runstate="Runnable" testcasecount="47" result="Failed" duration="1.286241" total="47" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
           <failure>
             <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="1-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" duration="0.652075" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="1-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" duration="1.057468" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="_DESCRIPTION" value="Addition" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedTest" id="1-1001" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" duration="0.177382" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1001" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" duration="0.288389" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Adding several numbers" />
                 <property name="_CATEGORIES" value="tag2" />
               </properties>
-              <test-case id="1-1002" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" runstate="Runnable" result="Passed" duration="0.168242" asserts="0" />
-              <test-case id="1-1003" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" runstate="Runnable" result="Passed" duration="0.000551" asserts="0" />
+              <test-case id="1-1002" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" runstate="Runnable" result="Passed" duration="0.276241" asserts="0" />
+              <test-case id="1-1003" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" runstate="Runnable" result="Passed" duration="0.000507" asserts="0" />
             </test-suite>
-            <test-case id="1-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddTwoNumbers" runstate="Runnable" result="Passed" duration="0.000440" asserts="0">
+            <test-case id="1-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.AddTwoNumbers" runstate="Runnable" result="Passed" duration="0.000633" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Add two numbers" />
                 <property name="_CATEGORIES" value="tag1" />
               </properties>
             </test-case>
-            <test-case id="1-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" runstate="Runnable" result="Failed" label="Error" duration="0.009813" asserts="0">
+            <test-case id="1-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers" runstate="Runnable" result="Failed" label="Error" duration="0.009437" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Fail to add two numbers" />
                 <property name="_CATEGORIES" value="tag1" />
@@ -59,11 +59,11 @@
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit\Addition.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Addition.feature.cs:line 0
+   at Pickles.TestHarness.nunit.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Addition.feature:line 34]]></stack-trace>
               </failure>
             </test-case>
-            <test-case id="1-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.IgnoredAddingTwoNumbers" runstate="Ignored" result="Skipped" label="Ignored" duration="0.000359" asserts="0">
+            <test-case id="1-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.IgnoredAddingTwoNumbers" runstate="Ignored" result="Skipped" label="Ignored" duration="0.000504" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Ignored adding two numbers" />
                 <property name="_IGNOREREASON" value="" />
@@ -72,7 +72,7 @@
                 <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="1-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" runstate="Runnable" result="Inconclusive" duration="0.097918" asserts="0">
+            <test-case id="1-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit.AdditionFeature.NotAutomatedAddingTwoNumbers" runstate="Runnable" result="Inconclusive" duration="0.118418" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Not automated adding two numbers" />
               </properties>
@@ -109,21 +109,21 @@ namespace MyNamespace
               </reason>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="1-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" duration="0.027917" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+          <test-suite type="TestFixture" id="1-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" duration="0.031034" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
             <properties>
               <property name="_DESCRIPTION" value="Failing Background" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedTest" id="1-1010" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" duration="0.022354" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1010" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" duration="0.024611" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Adding several numbers" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="1-1011" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.017066" asserts="0">
+              <test-case id="1-1011" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.018285" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -133,16 +133,16 @@ namespace MyNamespace
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
               </test-case>
-              <test-case id="1-1012" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.002533" asserts="0">
+              <test-case id="1-1012" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.002607" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -152,17 +152,17 @@ namespace MyNamespace
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
               </test-case>
             </test-suite>
-            <test-case id="1-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers" runstate="Runnable" result="Failed" label="Error" duration="0.001782" asserts="0">
+            <test-case id="1-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers" runstate="Runnable" result="Failed" label="Error" duration="0.001994" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Add two numbers" />
               </properties>
@@ -175,28 +175,28 @@ namespace MyNamespace
     1]]></message>
                 <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit\FailingBackground.feature:line 12]]></stack-trace>
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\FailingBackground.feature:line 12]]></stack-trace>
               </failure>
             </test-case>
           </test-suite>
-          <test-suite type="Namespace" id="1-1072" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" duration="0.026636" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+          <test-suite type="Namespace" id="1-1072" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" duration="0.040672" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="TestFixture" id="1-1059" name="FailingFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" duration="0.015534" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="1-1059" name="FailingFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" duration="0.023075" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Failing" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="1-1062" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" runstate="Runnable" result="Failed" label="Error" duration="0.006833" asserts="0">
+              <test-case id="1-1062" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" runstate="Runnable" result="Failed" label="Error" duration="0.006599" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Failing Feature Failing Scenario" />
                 </properties>
@@ -209,16 +209,16 @@ namespace MyNamespace
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\nunit\Minimal Features\Failing.feature:line 10]]></stack-trace>
+   at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\Minimal Features\Failing.feature:line 10]]></stack-trace>
                 </failure>
               </test-case>
-              <test-case id="1-1061" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" runstate="Runnable" result="Inconclusive" duration="0.004231" asserts="0">
+              <test-case id="1-1061" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" runstate="Runnable" result="Inconclusive" duration="0.005185" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Failing Feature Inconclusive Scenario" />
                 </properties>
@@ -227,17 +227,17 @@ namespace MyNamespace
   MinimalSteps.ThenInconclusiveStep()]]></message>
                 </reason>
               </test-case>
-              <test-case id="1-1060" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.000710" asserts="0">
+              <test-case id="1-1060" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.000960" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Failing Feature Passing Scenario" />
                 </properties>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="1-1063" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" duration="0.006498" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="1-1063" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" duration="0.010377" total="2" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Inconclusive" />
               </properties>
-              <test-case id="1-1065" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" runstate="Runnable" result="Inconclusive" duration="0.002084" asserts="0">
+              <test-case id="1-1065" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" runstate="Runnable" result="Inconclusive" duration="0.006660" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Inconclusive Feature Inconclusive Scenario" />
                 </properties>
@@ -246,28 +246,28 @@ namespace MyNamespace
   MinimalSteps.ThenInconclusiveStep()]]></message>
                 </reason>
               </test-case>
-              <test-case id="1-1064" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.002095" asserts="0">
+              <test-case id="1-1064" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.000495" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Inconclusive Feature Passing Scenario" />
                 </properties>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="1-1066" name="PassingFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001052" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="1-1066" name="PassingFeature" fullname="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001924" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Passing" />
               </properties>
-              <test-case id="1-1067" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.000398" asserts="0">
+              <test-case id="1-1067" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" runstate="Runnable" result="Passed" duration="0.000940" asserts="0">
                 <properties>
                   <property name="_DESCRIPTION" value="Passing Feature Passing Scenario" />
                 </properties>
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="1-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="3" result="Inconclusive" duration="0.026280" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="1-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="3" result="Inconclusive" duration="0.026128" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="_DESCRIPTION" value="Not Automated At All" />
             </properties>
-            <test-case id="1-1014" name="NotAutomatedScenario1" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" runstate="Runnable" result="Inconclusive" duration="0.004547" asserts="0">
+            <test-case id="1-1014" name="NotAutomatedScenario1" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" runstate="Runnable" result="Inconclusive" duration="0.007026" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Not automated scenario 1" />
               </properties>
@@ -303,7 +303,7 @@ namespace MyNamespace
 ]]></message>
               </reason>
             </test-case>
-            <test-case id="1-1015" name="NotAutomatedScenario2" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" runstate="Runnable" result="Inconclusive" duration="0.004974" asserts="0">
+            <test-case id="1-1015" name="NotAutomatedScenario2" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" runstate="Runnable" result="Inconclusive" duration="0.005831" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Not automated scenario 2" />
               </properties>
@@ -339,7 +339,7 @@ namespace MyNamespace
 ]]></message>
               </reason>
             </test-case>
-            <test-case id="1-1016" name="NotAutomatedScenario3" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" runstate="Runnable" result="Inconclusive" duration="0.010241" asserts="0">
+            <test-case id="1-1016" name="NotAutomatedScenario3" fullname="Pickles.TestHarness.nunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" runstate="Runnable" result="Inconclusive" duration="0.006797" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Not automated scenario 3" />
               </properties>
@@ -376,35 +376,35 @@ namespace MyNamespace
               </reason>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="1-1017" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="18" result="Failed" duration="0.088923" total="18" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
+          <test-suite type="TestFixture" id="1-1017" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="18" result="Failed" duration="0.067097" total="18" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0" site="Child">
             <properties>
               <property name="_DESCRIPTION" value="Scenario Outlines" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedTest" id="1-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" duration="0.016036" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" duration="0.023001" total="6" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="And we can go totally bonkers with multiple example sections." />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="1-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001301" asserts="0" />
-              <test-case id="1-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000133" asserts="0" />
-              <test-case id="1-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.002083" asserts="0">
+              <test-case id="1-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001593" asserts="0" />
+              <test-case id="1-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000169" asserts="0" />
+              <test-case id="1-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.001818" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
                 </reason>
               </test-case>
-              <test-case id="1-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.001747" asserts="0">
+              <test-case id="1-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.001725" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
                 </reason>
               </test-case>
-              <test-case id="1-1035" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.002201" asserts="0">
+              <test-case id="1-1035" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.001694" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -414,16 +414,16 @@ namespace MyNamespace
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
               </test-case>
-              <test-case id="1-1036" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.001282" asserts="0">
+              <test-case id="1-1036" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.001663" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -433,52 +433,52 @@ namespace MyNamespace
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1037" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001286" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1037" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001627" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Deal correctly with backslashes in the examples" />
               </properties>
-              <test-case id="1-1038" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" runstate="Runnable" result="Passed" duration="0.000992" asserts="0" />
+              <test-case id="1-1038" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" runstate="Runnable" result="Passed" duration="0.001307" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1041" name="DealCorrectlyWithOverlongExampleValues" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001242" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1041" name="DealCorrectlyWithOverlongExampleValues" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues" runstate="Runnable" testcasecount="1" result="Passed" duration="0.002119" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Deal correctly with overlong example values" />
               </properties>
-              <test-case id="1-1042" name="DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" runstate="Runnable" result="Passed" duration="0.000988" asserts="0" />
+              <test-case id="1-1042" name="DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter country code (e.g. DE)!&quot;,&quot;This is just a very very very veery long error message!&quot;,null)" runstate="Runnable" result="Passed" duration="0.001631" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1039" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001448" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1039" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" duration="0.002561" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="Deal correctly with parenthesis in the examples" />
               </properties>
-              <test-case id="1-1040" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" runstate="Runnable" result="Passed" duration="0.001126" asserts="0" />
+              <test-case id="1-1040" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" runstate="Runnable" result="Passed" duration="0.002204" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" duration="0.003211" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" duration="0.009026" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline where all scenarios pass" />
               </properties>
-              <test-case id="1-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000526" asserts="0" />
-              <test-case id="1-1020" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000154" asserts="0" />
-              <test-case id="1-1021" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" runstate="Runnable" result="Passed" duration="0.000129" asserts="0" />
+              <test-case id="1-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000547" asserts="0" />
+              <test-case id="1-1020" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000242" asserts="0" />
+              <test-case id="1-1021" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" runstate="Runnable" result="Passed" duration="0.000203" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" duration="0.005645" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" duration="0.006238" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline where one scenario fails" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="1-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000665" asserts="0" />
-              <test-case id="1-1028" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000337" asserts="0" />
-              <test-case id="1-1029" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.002074" asserts="0">
+              <test-case id="1-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000606" asserts="0" />
+              <test-case id="1-1028" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000160" asserts="0" />
+              <test-case id="1-1029" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" runstate="Runnable" result="Failed" label="Error" duration="0.002390" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -488,23 +488,23 @@ namespace MyNamespace
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit\ScenarioOutlines.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit\ScenarioOutlines.feature:line 34]]></stack-trace>
                 </failure>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" duration="0.005562" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" duration="0.006709" total="3" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline where one scenario is inconclusive" />
               </properties>
-              <test-case id="1-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001296" asserts="0" />
-              <test-case id="1-1024" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000144" asserts="0" />
-              <test-case id="1-1025" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.001597" asserts="0">
+              <test-case id="1-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.002137" asserts="0" />
+              <test-case id="1-1024" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" runstate="Runnable" result="Passed" duration="0.000166" asserts="0" />
+              <test-case id="1-1025" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" runstate="Runnable" result="Inconclusive" duration="0.001345" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -512,44 +512,44 @@ namespace MyNamespace
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="1-1043" name="ScenariosWithSpecialCharactersFeature" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature" runstate="Runnable" testcasecount="11" result="Passed" duration="0.025717" total="11" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="1-1043" name="ScenariosWithSpecialCharactersFeature" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature" runstate="Runnable" testcasecount="11" result="Passed" duration="0.037214" total="11" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="_DESCRIPTION" value="Scenarios With Special Characters" />
             </properties>
-            <test-suite type="ParameterizedTest" id="1-1057" name="ThisIsAScenarioOutlineWithAmpersand" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand" runstate="Runnable" testcasecount="1" result="Passed" duration="0.002005" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1057" name="ThisIsAScenarioOutlineWithAmpersand" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001365" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline with ampersand &amp;" />
               </properties>
-              <test-case id="1-1058" name="ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001316" asserts="0" />
+              <test-case id="1-1058" name="ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001046" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1055" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" runstate="Runnable" testcasecount="1" result="Passed" duration="0.000611" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1055" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" runstate="Runnable" testcasecount="1" result="Passed" duration="0.002073" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline with german umlauts äöüß ÄÖÜ" />
               </properties>
-              <test-case id="1-1056" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000396" asserts="0" />
+              <test-case id="1-1056" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.001387" asserts="0" />
             </test-suite>
-            <test-suite type="ParameterizedTest" id="1-1045" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" testcasecount="1" result="Passed" duration="0.000476" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1045" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" testcasecount="1" result="Passed" duration="0.001050" total="1" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
               </properties>
-              <test-case id="1-1046" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000296" asserts="0" />
+              <test-case id="1-1046" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" runstate="Runnable" result="Passed" duration="0.000686" asserts="0" />
             </test-suite>
-            <test-case id="1-1044" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" result="Passed" duration="0.000506" asserts="0">
+            <test-case id="1-1044" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" result="Passed" duration="0.000744" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
               </properties>
             </test-case>
-            <test-suite type="ParameterizedTest" id="1-1047" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters" runstate="Runnable" testcasecount="7" result="Passed" duration="0.013903" total="7" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedTest" id="1-1047" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters" runstate="Runnable" testcasecount="7" result="Passed" duration="0.021059" total="7" passed="0" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="_DESCRIPTION" value="This scenario contains examples with Regex-special characters" />
               </properties>
-              <test-case id="1-1048" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" runstate="Runnable" result="Passed" duration="0.000955" asserts="0" />
-              <test-case id="1-1049" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" runstate="Runnable" result="Passed" duration="0.000253" asserts="0" />
-              <test-case id="1-1050" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" runstate="Runnable" result="Passed" duration="0.000196" asserts="0" />
-              <test-case id="1-1051" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" runstate="Runnable" result="Passed" duration="0.000225" asserts="0" />
-              <test-case id="1-1052" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" runstate="Runnable" result="Passed" duration="0.000258" asserts="0" />
-              <test-case id="1-1053" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" runstate="Runnable" result="Passed" duration="0.000206" asserts="0" />
-              <test-case id="1-1054" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" runstate="Runnable" result="Passed" duration="0.000297" asserts="0" />
+              <test-case id="1-1048" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" runstate="Runnable" result="Passed" duration="0.001448" asserts="0" />
+              <test-case id="1-1049" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" runstate="Runnable" result="Passed" duration="0.000731" asserts="0" />
+              <test-case id="1-1050" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" runstate="Runnable" result="Passed" duration="0.000222" asserts="0" />
+              <test-case id="1-1051" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" runstate="Runnable" result="Passed" duration="0.001448" asserts="0" />
+              <test-case id="1-1052" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" runstate="Runnable" result="Passed" duration="0.000282" asserts="0" />
+              <test-case id="1-1053" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" runstate="Runnable" result="Passed" duration="0.000218" asserts="0" />
+              <test-case id="1-1054" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" fullname="Pickles.TestHarness.nunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" runstate="Runnable" result="Passed" duration="0.000251" asserts="0" />
             </test-suite>
           </test-suite>
         </test-suite>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit3/results-example-nunit3.xml
@@ -1,92 +1,92 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
-<test-run id="2" testcasecount="45" result="Failed" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.770723">
-  <command-line><![CDATA["C:\DevProjects\Tools\pickles\\test-harness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\DevProjects\Tools\pickles\\test-harness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\DevProjects\Tools\pickles\\results-example-nunit3.xml"]]></command-line>
-  <test-suite type="Assembly" id="0-1066" name="nunit3Harness.dll" fullname="C:\DevProjects\Tools\pickles\test-harness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.636880" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
-    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.10240.0" platform="Win32NT" cwd="C:\DevProjects\Tools\pickles" machine-name="AS0283" user="HKR" user-domain="OEVERMANN" culture="de-DE" uiculture="en-US" os-architecture="x64" />
+<test-run id="2" testcasecount="45" result="Failed" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0" engine-version="3.0.5797.27553" clr-version="4.0.30319.42000" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="1.051915">
+  <command-line><![CDATA["C:\Users\Bas\Source\Repos\pickles\\test-harness\packages\NUnit.Console.3.0.0\tools\nunit3-console.exe"  "C:\Users\Bas\Source\Repos\pickles\\test-harness\nunit3\bin\Debug\nunit3Harness.dll" /result="C:\Users\Bas\Source\Repos\pickles\\results-example-nunit3.xml"]]></command-line>
+  <test-suite type="Assembly" id="0-1066" name="nunit3Harness.dll" fullname="C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\bin\Debug\nunit3Harness.dll" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.816578" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <environment framework-version="3.0.5797.27534" clr-version="4.0.30319.42000" os-version="Microsoft Windows NT 10.0.14393.0" platform="Win32NT" cwd="C:\Users\Bas\Source\Repos\pickles" machine-name="LENOVOWERK" user="Bas" user-domain="LENOVOWERK" culture="en-US" uiculture="en-US" os-architecture="x64" />
     <settings>
-      <setting name="WorkDirectory" value="C:\DevProjects\Tools\pickles" />
-      <setting name="NumberOfTestWorkers" value="8" />
+      <setting name="WorkDirectory" value="C:\Users\Bas\Source\Repos\pickles" />
+      <setting name="NumberOfTestWorkers" value="4" />
     </settings>
     <properties>
-      <property name="_PID" value="6272" />
+      <property name="_PID" value="13588" />
       <property name="_APPDOMAIN" value="test-domain-" />
     </properties>
     <failure>
       <message><![CDATA[One or more child tests had errors]]></message>
     </failure>
-    <test-suite type="TestSuite" id="0-1067" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.629982" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
+    <test-suite type="TestSuite" id="0-1067" name="Pickles" fullname="Pickles" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.805820" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
       <failure>
         <message><![CDATA[One or more child tests had errors]]></message>
       </failure>
-      <test-suite type="TestSuite" id="0-1068" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.629910" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
+      <test-suite type="TestSuite" id="0-1068" name="TestHarness" fullname="Pickles.TestHarness" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.805715" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
         <failure>
           <message><![CDATA[One or more child tests had errors]]></message>
         </failure>
-        <test-suite type="TestSuite" id="0-1069" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.629906" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
+        <test-suite type="TestSuite" id="0-1069" name="nunit3" fullname="Pickles.TestHarness.nunit3" runstate="Runnable" testcasecount="45" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.805707" total="45" passed="29" failed="9" inconclusive="6" skipped="1" asserts="0">
           <failure>
             <message><![CDATA[One or more child tests had errors]]></message>
           </failure>
-          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.560098" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
+          <test-suite type="TestFixture" id="0-1000" name="AdditionFeature" fullname="Pickles.TestHarness.nunit3.AdditionFeature" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.707144" total="6" passed="3" failed="1" inconclusive="1" skipped="1" asserts="0">
             <properties>
               <property name="Description" value="Addition" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.149596" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1003" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.204370" total="2" passed="2" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
                 <property name="Category" value="tag2" />
               </properties>
-              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.145978" asserts="0">
+              <test-case id="0-1001" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="798259755" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.195998" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000290" asserts="0">
+              <test-case id="0-1002" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1396928079" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000467" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000356" asserts="0">
+            <test-case id="0-1004" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="575529885" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000949" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="tag1" />
               </properties>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)
 ]]></output>
             </test-case>
-            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.008515" asserts="0">
+            <test-case id="0-1005" name="FailToAddTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers" methodname="FailToAddTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="332551961" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.013472" asserts="0">
               <properties>
                 <property name="Description" value="Fail to add two numbers" />
                 <property name="Category" value="tag1" />
@@ -103,22 +103,22 @@ Then the result should be 3 on the screen
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit3\Addition.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit3.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\Addition.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\Addition.feature:line 34]]></stack-trace>
               </failure>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -> error: Input string was not in a correct format.
 ]]></output>
             </test-case>
-            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000651" asserts="0">
+            <test-case id="0-1006" name="IgnoredAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.IgnoredAddingTwoNumbers" methodname="IgnoredAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Ignored" seed="2113917196" result="Skipped" label="Ignored" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001001" asserts="0">
               <properties>
                 <property name="Description" value="Ignored adding two numbers" />
                 <property name="_SKIPREASON" value="" />
@@ -127,7 +127,7 @@ Then the result should be 3.2 on the screen
                 <message><![CDATA[]]></message>
               </reason>
             </test-case>
-            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.096381" asserts="0">
+            <test-case id="0-1007" name="NotAutomatedAddingTwoNumbers" fullname="Pickles.TestHarness.nunit3.AdditionFeature.NotAutomatedAddingTwoNumbers" methodname="NotAutomatedAddingTwoNumbers" classname="Pickles.TestHarness.nunit3.AdditionFeature" runstate="Runnable" seed="1460656856" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.098167" asserts="0">
               <properties>
                 <property name="Description" value="Not automated adding two numbers" />
               </properties>
@@ -163,7 +163,7 @@ namespace MyNamespace
 ]]></message>
               </reason>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -> No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -191,21 +191,21 @@ Then unimplemented step
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.020294" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1008" name="FailingBackgroundFeature" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.036079" total="3" passed="0" failed="3" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Failing Background" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.017069" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1012" name="AddingSeveralNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers" runstate="Runnable" testcasecount="2" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.032538" total="2" passed="0" failed="2" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Adding several numbers" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.014408" asserts="0">
+              <test-case id="0-1010" name="AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;60&quot;,&quot;70&quot;,&quot;130&quot;,&quot;260&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="1347475421" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.022797" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -215,13 +215,13 @@ Then unimplemented step
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -244,7 +244,7 @@ Then the result should be 260 on the screen
 -> skipped because of previous errors
 ]]></output>
               </test-case>
-              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002525" asserts="0">
+              <test-case id="0-1011" name="AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(&quot;40&quot;,&quot;50&quot;,&quot;90&quot;,&quot;180&quot;,null)" methodname="AddingSeveralNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="211985103" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.009528" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     1
@@ -254,13 +254,13 @@ Then the result should be 260 on the screen
     1]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature:line 19]]></stack-trace>
                 </failure>
                 <output><![CDATA[Given the background step fails
 -> error: 
@@ -284,7 +284,7 @@ Then the result should be 180 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002391" asserts="0">
+            <test-case id="0-1009" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.FailingBackgroundFeature" runstate="Runnable" seed="212386315" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.002280" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
               </properties>
@@ -297,13 +297,13 @@ Then the result should be 180 on the screen
     1]]></message>
                 <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit3\FailingBackground.feature:line 12]]></stack-trace>
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\FailingBackground.feature:line 12]]></stack-trace>
               </failure>
               <output><![CDATA[Given the background step fails
 -> error: 
@@ -325,18 +325,18 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestSuite" id="0-1070" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.601361" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
+          <test-suite type="TestSuite" id="0-1070" name="MinimalFeatures" fullname="Pickles.TestHarness.nunit3.MinimalFeatures" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2017-02-02 20:43:23Z" end-time="2017-02-02 20:43:24Z" duration="0.764975" total="6" passed="3" failed="1" inconclusive="2" skipped="0" asserts="0">
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="TestFixture" id="0-1057" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.016653" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1057" name="FailingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.016289" total="3" passed="1" failed="1" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Failing" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1060" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="451452096" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.008863" asserts="0">
+              <test-case id="0-1060" name="FailingFeatureFailingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" methodname="FailingFeatureFailingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="451452096" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.006790" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Failing Scenario" />
                 </properties>
@@ -349,13 +349,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\nunit3\Minimal Features\Failing.feature:line 10]]></stack-trace>
+   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\Minimal Features\Failing.feature:line 10]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then failing step
 -> error: 
@@ -366,7 +366,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1059" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1868752976" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.006364" asserts="0">
+              <test-case id="0-1059" name="FailingFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" methodname="FailingFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="1868752976" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.007726" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Inconclusive Scenario" />
                 </properties>
@@ -378,20 +378,20 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1058" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="637137152" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000667" asserts="0">
+              <test-case id="0-1058" name="FailingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" methodname="FailingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.FailingFeature" runstate="Runnable" seed="637137152" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000997" asserts="0">
                 <properties>
                   <property name="Description" value="Failing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1061" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.003114" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1061" name="InconclusiveFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" testcasecount="2" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.003519" total="2" passed="1" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Inconclusive" />
               </properties>
-              <test-case id="0-1063" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1362768032" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002350" asserts="0">
+              <test-case id="0-1063" name="InconclusiveFeatureInconclusiveScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" methodname="InconclusiveFeatureInconclusiveScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1362768032" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001933" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Inconclusive Scenario" />
                 </properties>
@@ -403,51 +403,51 @@ Then the result should be 120 on the screen
 -> pending: MinimalSteps.ThenInconclusiveStep()
 ]]></output>
               </test-case>
-              <test-case id="0-1062" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1460000646" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000326" asserts="0">
+              <test-case id="0-1062" name="InconclusiveFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" methodname="InconclusiveFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.InconclusiveFeature" runstate="Runnable" seed="1460000646" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000328" asserts="0">
                 <properties>
                   <property name="Description" value="Inconclusive Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="TestFixture" id="0-1064" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000831" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="TestFixture" id="0-1064" name="PassingFeature" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001383" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Passing" />
               </properties>
-              <test-case id="0-1065" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="529523600" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000423" asserts="0">
+              <test-case id="0-1065" name="PassingFeaturePassingScenario" fullname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" methodname="PassingFeaturePassingScenario" classname="Pickles.TestHarness.nunit3.MinimalFeatures.PassingFeature" runstate="Runnable" seed="529523600" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000680" asserts="0">
                 <properties>
                   <property name="Description" value="Passing Feature Passing Scenario" />
                 </properties>
                 <output><![CDATA[Then passing step
--> done: MinimalSteps.ThenPassingStep() (0,0s)
+-> done: MinimalSteps.ThenPassingStep() (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.003521" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1013" name="NotAutomatedAtAllFeature" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" testcasecount="1" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.004412" total="1" passed="0" failed="1" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="NotAutomatedAtAll" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.003153" asserts="0">
+            <test-case id="0-1014" name="AddTwoNumbers" fullname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers" methodname="AddTwoNumbers" classname="Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature" runstate="Runnable" seed="118089422" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.003535" asserts="0">
               <properties>
                 <property name="Description" value="Add two numbers" />
                 <property name="Category" value="mytag" />
               </properties>
               <failure>
                 <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object.]]></message>
-                <stack-trace><![CDATA[   at AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 31
+                <stack-trace><![CDATA[   at AutomationLayer.AdditionSteps.GivenIHaveEnteredIntoTheCalculator(Decimal p0) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 31
    at lambda_method(Closure , IContextManager , Decimal )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\nunit3\NotAutomatedAtAll.feature:line 11]]></stack-trace>
+   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.NotAutomatedAtAllFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\NotAutomatedAtAll.feature:line 11]]></stack-trace>
               </failure>
               <output><![CDATA[Given I have entered 50 into the calculator
 -> error: Object reference not set to an instance of an object.
@@ -460,31 +460,31 @@ Then the result should be 120 on the screen
 ]]></output>
             </test-case>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="18" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.017604" total="18" passed="12" failed="3" inconclusive="3" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1015" name="ScenarioOutlinesFeature" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" testcasecount="18" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.026580" total="18" passed="12" failed="3" inconclusive="3" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Scenario Outlines" />
             </properties>
             <failure>
               <message><![CDATA[One or more child tests had errors]]></message>
             </failure>
-            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.009258" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1034" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_" runstate="Runnable" testcasecount="6" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.012753" total="6" passed="2" failed="2" inconclusive="2" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="And we can go totally bonkers with multiple example sections." />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001794" asserts="0">
+              <test-case id="0-1028" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="193735939" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.004761" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000150" asserts="0">
+              <test-case id="0-1029" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;pass_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1390597427" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000304" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002448" asserts="0">
+              <test-case id="0-1030" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="875415367" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001990" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -493,7 +493,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 ]]></output>
               </test-case>
-              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001642" asserts="0">
+              <test-case id="0-1031" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;inconclusive_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1231727827" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001972" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
@@ -502,7 +502,7 @@ Then the result should be 120 on the screen
 -> pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 ]]></output>
               </test-case>
-              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001442" asserts="0">
+              <test-case id="0-1032" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_1&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="52758991" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001511" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -512,13 +512,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -529,7 +529,7 @@ Then the result should be 120 on the screen
     True
 ]]></output>
               </test-case>
-              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001108" asserts="0">
+              <test-case id="0-1033" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(&quot;fail_2&quot;,null)" methodname="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1923791459" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001396" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -539,13 +539,13 @@ Then the result should be 120 on the screen
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 45]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_2'
 -> error: 
@@ -557,78 +557,78 @@ Then the result should be 120 on the screen
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000769" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1036" name="DealCorrectlyWithBackslashesInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.002031" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with backslashes in the examples" />
               </properties>
-              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000687" asserts="0">
+              <test-case id="0-1035" name="DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(&quot;c:\\Temp\\&quot;,null)" methodname="DealCorrectlyWithBackslashesInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1069402004" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001904" asserts="0">
                 <output><![CDATA[When I have backslashes in the value, for example a 'c:\Temp\'
--> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1040" name="DealCorrectlyWithOverlongExampleValues" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001577" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1040" name="DealCorrectlyWithOverlongExampleValues" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001339" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with overlong example values" />
               </properties>
-              <test-case id="0-1039" name="DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter count...&quot;,&quot;This is just a very very very veery l...&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter count...&quot;,&quot;This is just a very very very veery l...&quot;,null)" methodname="DealCorrectlyWithOverlongExampleValues" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="392352118" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001443" asserts="0">
+              <test-case id="0-1039" name="DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter count...&quot;,&quot;This is just a very very very veery l...&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(&quot;Please enter a valid two letter count...&quot;,&quot;This is just a very very very veery l...&quot;,null)" methodname="DealCorrectlyWithOverlongExampleValues" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="392352118" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001150" asserts="0">
                 <output><![CDATA[When I have a field with value 'Please enter a valid two letter country code (e.g. DE)!'
--> done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0.0s)
 And I have a field with value 'This is just a very very very veery long error message!'
--> done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0.0s)
 Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000719" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1038" name="DealCorrectlyWithParenthesisInTheExamples" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000993" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="Deal correctly with parenthesis in the examples" />
               </properties>
-              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000608" asserts="0">
+              <test-case id="0-1037" name="DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(&quot;This is a description (and more)&quot;,null)" methodname="DealCorrectlyWithParenthesisInTheExamples" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1448988997" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000872" asserts="0">
                 <output><![CDATA[When I have parenthesis in the value, for example an 'This is a description (and more)'
--> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000618" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1019" name="ThisIsAScenarioOutlineWhereAllScenariosPass" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass" runstate="Runnable" testcasecount="3" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001253" total="3" passed="3" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where all scenarios pass" />
               </properties>
-              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000232" asserts="0">
+              <test-case id="0-1016" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1096460943" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000431" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000076" asserts="0">
+              <test-case id="0-1017" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1554169190" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000144" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000063" asserts="0">
+              <test-case id="0-1018" name="ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(&quot;pass_3&quot;,null)" methodname="ThisIsAScenarioOutlineWhereAllScenariosPass" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="703520303" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000145" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_3'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002080" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1027" name="ThisIsAScenarioOutlineWhereOneScenarioFails" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails" runstate="Runnable" testcasecount="3" result="Failed" site="Child" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.004641" total="3" passed="2" failed="1" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario fails" />
               </properties>
               <failure>
                 <message><![CDATA[One or more child tests had errors]]></message>
               </failure>
-              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000208" asserts="0">
+              <test-case id="0-1024" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1002758134" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001428" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000063" asserts="0">
+              <test-case id="0-1025" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="596653663" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000526" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001604" asserts="0">
+              <test-case id="0-1026" name="ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(&quot;fail_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioFails" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="79304597" result="Failed" label="Error" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001973" asserts="0">
                 <failure>
                   <message><![CDATA[Shouldly.ChuckedAWobbly : 
     true
@@ -638,13 +638,13 @@ Then the scenario will 'pass_1'
     True]]></message>
                   <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\nunit3\ScenarioOutlines.feature:line 34]]></stack-trace>
                 </failure>
                 <output><![CDATA[Then the scenario will 'fail_1'
 -> error: 
@@ -656,21 +656,21 @@ Then the scenario will 'pass_1'
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.002061" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1023" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" runstate="Runnable" testcasecount="3" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.002762" total="3" passed="2" failed="0" inconclusive="1" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline where one scenario is inconclusive" />
               </properties>
-              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000266" asserts="0">
+              <test-case id="0-1020" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1888940438" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000999" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000086" asserts="0">
+              <test-case id="0-1021" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;pass_2&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="1580158007" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000128" asserts="0">
                 <output><![CDATA[Then the scenario will 'pass_2'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001491" asserts="0">
+              <test-case id="0-1022" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(&quot;inconclusive_1&quot;,null)" methodname="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" classname="Pickles.TestHarness.nunit3.ScenarioOutlinesFeature" runstate="Runnable" seed="292299438" result="Inconclusive" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001300" asserts="0">
                 <reason>
                   <message><![CDATA[One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
@@ -681,127 +681,127 @@ Then the scenario will 'pass_1'
               </test-case>
             </test-suite>
           </test-suite>
-          <test-suite type="TestFixture" id="0-1041" name="ScenariosWithSpecialCharactersFeature" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" testcasecount="11" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.006030" total="11" passed="11" failed="0" inconclusive="0" skipped="0" asserts="0">
+          <test-suite type="TestFixture" id="0-1041" name="ScenariosWithSpecialCharactersFeature" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" testcasecount="11" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.008130" total="11" passed="11" failed="0" inconclusive="0" skipped="0" asserts="0">
             <properties>
               <property name="Description" value="Scenarios With Special Characters" />
             </properties>
-            <test-suite type="ParameterizedMethod" id="0-1056" name="ThisIsAScenarioOutlineWithAmpersand" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000754" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1056" name="ThisIsAScenarioOutlineWithAmpersand" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000938" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline with ampersand &amp;" />
               </properties>
-              <test-case id="0-1055" name="ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithAmpersand" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1061146939" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000670" asserts="0">
+              <test-case id="0-1055" name="ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithAmpersand" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1061146939" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000826" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1054" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000482" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1054" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000514" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline with german umlauts äöüß ÄÖÜ" />
               </properties>
-              <test-case id="0-1053" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1171064073" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000414" asserts="0">
+              <test-case id="0-1053" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1171064073" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000397" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-suite type="ParameterizedMethod" id="0-1044" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" testcasecount="1" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000485" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1044" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" runstate="Runnable" testcasecount="1" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001620" total="1" passed="1" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
               </properties>
-              <test-case id="0-1043" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1072944492" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000362" asserts="0">
+              <test-case id="0-1043" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(&quot;pass_1&quot;,null)" methodname="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1072944492" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001512" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>
-            <test-case id="0-1042" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" methodname="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="657009205" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000588" asserts="0">
+            <test-case id="0-1042" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" methodname="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="657009205" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000547" asserts="0">
               <properties>
                 <property name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
               </properties>
               <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 50 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 70 into the calculator
--> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-> done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 When I press add
--> done: AdditionSteps.WhenIPressAdd() (0,0s)
+-> done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 120 on the screen
--> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)
+-> done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0.0s)
 ]]></output>
             </test-case>
-            <test-suite type="ParameterizedMethod" id="0-1052" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters" runstate="Runnable" testcasecount="7" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.003198" total="7" passed="7" failed="0" inconclusive="0" skipped="0" asserts="0">
+            <test-suite type="ParameterizedMethod" id="0-1052" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters" runstate="Runnable" testcasecount="7" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.003795" total="7" passed="7" failed="0" inconclusive="0" skipped="0" asserts="0">
               <properties>
                 <property name="Description" value="This scenario contains examples with Regex-special characters" />
               </properties>
-              <test-case id="0-1045" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1958916467" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.001010" asserts="0">
+              <test-case id="0-1045" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;**&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1958916467" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.001952" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '**'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1046" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="592696544" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000112" asserts="0">
+              <test-case id="0-1046" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;++&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="592696544" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000204" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '++'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1047" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1548583897" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000100" asserts="0">
+              <test-case id="0-1047" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;.*&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1548583897" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000169" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '.*'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1048" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="125979337" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000096" asserts="0">
+              <test-case id="0-1048" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;[]&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="125979337" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000178" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '[]'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1049" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="589179632" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000863" asserts="0">
+              <test-case id="0-1049" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;{}&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="589179632" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000148" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '{}'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1050" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000116" asserts="0">
+              <test-case id="0-1050" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;()&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="1141276088" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000146" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '()'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
-              <test-case id="0-1051" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="976149245" result="Passed" start-time="2016-09-28 07:33:25Z" end-time="2016-09-28 07:33:25Z" duration="0.000114" asserts="0">
+              <test-case id="0-1051" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" fullname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(&quot;^.*(?&lt;foo&gt;BAR)\\s[^0-9]{3,4}A+$&quot;,null)" methodname="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" classname="Pickles.TestHarness.nunit3.ScenariosWithSpecialCharactersFeature" runstate="Runnable" seed="976149245" result="Passed" start-time="2017-02-02 20:43:24Z" end-time="2017-02-02 20:43:24Z" duration="0.000147" asserts="0">
                 <output><![CDATA[Given the calculator has clean memory
--> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-> done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '^.*(?<foo>BAR)\s[^0-9]{3,4}A+$'
--> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?<foo>BAR)\s[...") (0,0s)
+-> done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?<foo>BAR)\s[...") (0.0s)
 Then the scenario will 'PASS'
--> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-> done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
 ]]></output>
               </test-case>
             </test-suite>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/results-example-vstest.trx
@@ -1,70 +1,70 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<TestRun id="4f5eb4bf-4203-4449-8f15-b5de997283e6" name="HKR@AS0283 2016-09-28 09:33:47" runUser="OEVERMANN\HKR" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
-  <Times creation="2016-09-28T09:33:47.3567497+02:00" queuing="2016-09-28T09:33:47.3567497+02:00" start="2016-09-28T09:33:47.1267535+02:00" finish="2016-09-28T09:33:47.5404780+02:00" />
-  <TestSettings name="default" id="99c7383c-f3a5-4d39-a348-a164b3690ccd">
+<TestRun id="90ba6dee-e437-4af7-b767-29995289d12f" name="Bas@LENOVOWERK 2017-02-02 21:43:47" runUser="LENOVOWERK\Bas" xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Times creation="2017-02-02T21:43:47.5052862+01:00" queuing="2017-02-02T21:43:47.5052862+01:00" start="2017-02-02T21:43:47.5102894+01:00" finish="2017-02-02T21:43:48.6190240+01:00" />
+  <TestSettings name="default" id="7fe50a62-aed7-4b76-80ec-bec1600bf003">
     <Execution>
       <TestTypeSpecific />
     </Execution>
-    <Deployment runDeploymentRoot="HKR_AS0283 2016-09-28 09_33_47" />
+    <Deployment runDeploymentRoot="Bas_LENOVOWERK 2017-02-02 21_43_47" />
     <Properties />
   </TestSettings>
   <Results>
-    <UnitTestResult executionId="1e6f4610-6037-47ce-ae89-724a1fdb0409" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="AS0283" duration="00:00:00.0463656" startTime="2016-09-28T09:33:47.1267535+02:00" endTime="2016-09-28T09:33:47.2587528+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1e6f4610-6037-47ce-ae89-724a1fdb0409">
+    <UnitTestResult executionId="9d051830-4934-4465-885a-2c150804960b" testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" testName="AddingSeveralNumbers_60" computerName="LENOVOWERK" duration="00:00:00.2258663" startTime="2017-02-02T21:43:46.0856955+01:00" endTime="2017-02-02T21:43:46.8187599+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9d051830-4934-4465-885a-2c150804960b">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3c333028-67e0-4098-a6f2-b687bdaba0f2" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="AS0283" duration="00:00:00.0004464" startTime="2016-09-28T09:33:47.2707513+02:00" endTime="2016-09-28T09:33:47.2707513+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3c333028-67e0-4098-a6f2-b687bdaba0f2">
+    <UnitTestResult executionId="8278c3af-51ad-4f43-ac73-a7d590d560e4" testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" testName="AddingSeveralNumbers_40" computerName="LENOVOWERK" duration="00:00:00.0005662" startTime="2017-02-02T21:43:46.8347713+01:00" endTime="2017-02-02T21:43:46.8357720+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8278c3af-51ad-4f43-ac73-a7d590d560e4">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
 And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d3e1412a-56b7-44c3-a111-cde4cf3cad8e" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="AS0283" duration="00:00:00.0004105" startTime="2016-09-28T09:33:47.2717514+02:00" endTime="2016-09-28T09:33:47.2717514+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d3e1412a-56b7-44c3-a111-cde4cf3cad8e">
+    <UnitTestResult executionId="93d52d47-3a92-4ecc-ac54-c3b49770d88e" testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" testName="AddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0005709" startTime="2017-02-02T21:43:46.8357720+01:00" endTime="2017-02-02T21:43:46.8367731+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="93d52d47-3a92-4ecc-ac54-c3b49770d88e">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0031c5d4-ae0c-4a5e-84f9-b61b9bfce1bd" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="AS0283" duration="00:00:00.0127697" startTime="2016-09-28T09:33:47.2717514+02:00" endTime="2016-09-28T09:33:47.2847514+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0031c5d4-ae0c-4a5e-84f9-b61b9bfce1bd">
+    <UnitTestResult executionId="a65c770a-d8ed-40f7-a8ec-bf9f2605e8a9" testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" testName="FailToAddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0360109" startTime="2017-02-02T21:43:46.8367731+01:00" endTime="2017-02-02T21:43:46.8727982+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a65c770a-d8ed-40f7-a8ec-bf9f2605e8a9">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -&gt; error: Input string was not in a correct format.</StdOut>
         <ErrorInfo>
@@ -86,17 +86,17 @@ System.FormatException: Input string was not in a correct format.</Message>
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Addition.feature:line 34
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature:line 34
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="f1eb023f-315e-469b-a93a-8964b4a09e0f" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="AS0283" startTime="2016-09-28T09:33:47.2847514+02:00" endTime="2016-09-28T09:33:47.2847514+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f1eb023f-315e-469b-a93a-8964b4a09e0f" />
-    <UnitTestResult executionId="d0cd3cc0-6525-4f9e-916d-93c6c9135767" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="AS0283" duration="00:00:00.0269222" startTime="2016-09-28T09:33:47.2847514+02:00" endTime="2016-09-28T09:33:47.3117516+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d0cd3cc0-6525-4f9e-916d-93c6c9135767">
+    <UnitTestResult executionId="d97a3a2b-b231-4441-9f17-92b219561a7b" testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" testName="IgnoredAddingTwoNumbers" computerName="LENOVOWERK" startTime="2017-02-02T21:43:46.8737989+01:00" endTime="2017-02-02T21:43:46.8737989+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d97a3a2b-b231-4441-9f17-92b219561a7b" />
+    <UnitTestResult executionId="f92aecfc-b519-4834-8fff-27be81a3b4f1" testId="8c3089df-e8ec-4931-e07f-19784ba313d4" testName="NotAutomatedAddingTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0812310" startTime="2017-02-02T21:43:46.8737989+01:00" endTime="2017-02-02T21:43:46.9558626+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="f92aecfc-b519-4834-8fff-27be81a3b4f1">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
@@ -156,13 +156,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Addition.feature:line 46
+   at Pickles.TestHarness.MsTest.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Addition.feature:line 46
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="017955ac-0a77-4ade-b12b-d7bcc1c02310" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="AS0283" duration="00:00:00.0107512" startTime="2016-09-28T09:33:47.3127509+02:00" endTime="2016-09-28T09:33:47.3247514+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="017955ac-0a77-4ade-b12b-d7bcc1c02310">
+    <UnitTestResult executionId="ecba1d57-5810-4c82-b373-ab24b5856cdd" testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" testName="AddTwoNumbers" computerName="LENOVOWERK" duration="00:00:00.0124447" startTime="2017-02-02T21:43:46.9558626+01:00" endTime="2017-02-02T21:43:46.9698733+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ecba1d57-5810-4c82-b373-ab24b5856cdd">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -191,20 +191,20 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 12
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 12
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="56da2732-fa29-4a3b-9490-320749efc7e4" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="AS0283" duration="00:00:00.0018554" startTime="2016-09-28T09:33:47.3247514+02:00" endTime="2016-09-28T09:33:47.3267516+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="56da2732-fa29-4a3b-9490-320749efc7e4">
+    <UnitTestResult executionId="3a7e876a-534e-45f4-84c2-51672eda6d5b" testId="bea8799b-89a4-d983-d6a9-57924ee5618e" testName="AddingSeveralNumbers_60" computerName="LENOVOWERK" duration="00:00:00.0018431" startTime="2017-02-02T21:43:46.9698733+01:00" endTime="2017-02-02T21:43:46.9718752+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3a7e876a-534e-45f4-84c2-51672eda6d5b">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -235,21 +235,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60()
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_60() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d5b8e832-7af0-4d3f-86e1-b5947f3896d1" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="AS0283" duration="00:00:00.0014563" startTime="2016-09-28T09:33:47.3267516+02:00" endTime="2016-09-28T09:33:47.3277543+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d5b8e832-7af0-4d3f-86e1-b5947f3896d1">
+    <UnitTestResult executionId="15be6a04-62ba-479d-a6c1-25139fb605c9" testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" testName="AddingSeveralNumbers_40" computerName="LENOVOWERK" duration="00:00:00.0015168" startTime="2017-02-02T21:43:46.9718752+01:00" endTime="2017-02-02T21:43:46.9738766+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="15be6a04-62ba-479d-a6c1-25139fb605c9">
       <Output>
         <StdOut>Given the background step fails
 -&gt; error: 
@@ -280,21 +280,21 @@ Shouldly.ChuckedAWobbly:
     1</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\FailingBackground.feature:line 19
-   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40()
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature:line 19
+   at Pickles.TestHarness.MsTest.FailingBackgroundFeature.AddingSeveralNumbers_40() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\FailingBackground.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="caf2a316-149f-469e-a1ff-64e695de86ed" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="AS0283" duration="00:00:00.0051432" startTime="2016-09-28T09:33:47.3327510+02:00" endTime="2016-09-28T09:33:47.3377522+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="caf2a316-149f-469e-a1ff-64e695de86ed">
+    <UnitTestResult executionId="69f889a4-4c43-4183-8ef0-3f57706e5ba9" testId="d2820219-bd97-2273-945a-4d371724085a" testName="NotAutomatedScenario1" computerName="LENOVOWERK" duration="00:00:00.0052511" startTime="2017-02-02T21:43:46.9738766+01:00" endTime="2017-02-02T21:43:46.9798804+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="69f889a4-4c43-4183-8ef0-3f57706e5ba9">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -363,13 +363,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 9
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 9
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fd5af870-6fea-4ae9-b911-3457e5381c4d" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="AS0283" duration="00:00:00.0033992" startTime="2016-09-28T09:33:47.3377522+02:00" endTime="2016-09-28T09:33:47.3417508+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fd5af870-6fea-4ae9-b911-3457e5381c4d">
+    <UnitTestResult executionId="9d61addd-5484-43d4-8aa3-eaf35582e24d" testId="8bc041bd-d809-7992-ff2a-09b84d713da5" testName="NotAutomatedScenario2" computerName="LENOVOWERK" duration="00:00:00.0048102" startTime="2017-02-02T21:43:46.9798804+01:00" endTime="2017-02-02T21:43:46.9848835+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9d61addd-5484-43d4-8aa3-eaf35582e24d">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -438,13 +438,13 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 14
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 14
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a9409d91-a76f-4a4a-9eb6-173e1b03414f" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="AS0283" duration="00:00:00.0076333" startTime="2016-09-28T09:33:47.3417508+02:00" endTime="2016-09-28T09:33:47.3497504+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a9409d91-a76f-4a4a-9eb6-173e1b03414f">
+    <UnitTestResult executionId="176502ca-df40-4aed-a675-3a812da1beea" testId="ee64b0d5-906e-5159-a108-531362c596d1" testName="NotAutomatedScenario3" computerName="LENOVOWERK" duration="00:00:00.0048350" startTime="2017-02-02T21:43:46.9858855+01:00" endTime="2017-02-02T21:43:46.9908938+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="176502ca-df40-4aed-a675-3a812da1beea">
       <Output>
         <StdOut>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
@@ -513,43 +513,43 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\DevProjects\Tools\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 19
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\NotAutomatedAtAll.feature:line 19
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="aa74ae12-11d5-4f8a-a46f-dda99071a584" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="AS0283" duration="00:00:00.0014260" startTime="2016-09-28T09:33:47.3497504+02:00" endTime="2016-09-28T09:33:47.3517504+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="aa74ae12-11d5-4f8a-a46f-dda99071a584">
+    <UnitTestResult executionId="a0c750a9-6056-4a35-8361-476babad5ba6" testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0011345" startTime="2017-02-02T21:43:46.9913946+01:00" endTime="2017-02-02T21:43:46.9928956+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a0c750a9-6056-4a35-8361-476babad5ba6">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="31ca2a56-0479-439d-b022-c376352d3fea" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="AS0283" duration="00:00:00.0001074" startTime="2016-09-28T09:33:47.3517504+02:00" endTime="2016-09-28T09:33:47.3517504+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="31ca2a56-0479-439d-b022-c376352d3fea">
+    <UnitTestResult executionId="cdf1908d-1f4c-46de-b462-7af35bc9fda4" testId="aa38c998-4087-fdeb-c742-f6a940beef87" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0001270" startTime="2017-02-02T21:43:46.9933960+01:00" endTime="2017-02-02T21:43:46.9933960+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cdf1908d-1f4c-46de-b462-7af35bc9fda4">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="04af37ad-d427-44d1-a00d-4738d08c9573" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="AS0283" duration="00:00:00.0001003" startTime="2016-09-28T09:33:47.3517504+02:00" endTime="2016-09-28T09:33:47.3517504+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="04af37ad-d427-44d1-a00d-4738d08c9573">
+    <UnitTestResult executionId="ecd22692-cc09-447c-a100-924f1b8afed7" testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" testName="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" computerName="LENOVOWERK" duration="00:00:00.0001270" startTime="2017-02-02T21:43:46.9938963+01:00" endTime="2017-02-02T21:43:46.9943967+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ecd22692-cc09-447c-a100-924f1b8afed7">
       <Output>
         <StdOut>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="0dd6c8d4-27e1-48a4-9641-60f8e425d51c" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="AS0283" duration="00:00:00.0001970" startTime="2016-09-28T09:33:47.3517504+02:00" endTime="2016-09-28T09:33:47.3527503+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0dd6c8d4-27e1-48a4-9641-60f8e425d51c">
+    <UnitTestResult executionId="5494935e-ea27-42cd-9393-64bbad15d92e" testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0002630" startTime="2017-02-02T21:43:46.9943967+01:00" endTime="2017-02-02T21:43:46.9948970+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5494935e-ea27-42cd-9393-64bbad15d92e">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="2273996b-f3b9-4cad-a67b-4df9d4ee9735" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="AS0283" duration="00:00:00.0000972" startTime="2016-09-28T09:33:47.3527503+02:00" endTime="2016-09-28T09:33:47.3527503+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="2273996b-f3b9-4cad-a67b-4df9d4ee9735">
+    <UnitTestResult executionId="bcf91c7f-6eb0-47fe-b018-a6fa8183fd0f" testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0001188" startTime="2017-02-02T21:43:46.9948970+01:00" endTime="2017-02-02T21:43:46.9953974+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="bcf91c7f-6eb0-47fe-b018-a6fa8183fd0f">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="dd77f87f-0336-43d5-b675-8eaeae3523ec" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="AS0283" duration="00:00:00.0020188" startTime="2016-09-28T09:33:47.3527503+02:00" endTime="2016-09-28T09:33:47.3547502+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dd77f87f-0336-43d5-b675-8eaeae3523ec">
+    <UnitTestResult executionId="eddb4add-c355-4692-90f5-a95f326b3e36" testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" testName="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" computerName="LENOVOWERK" duration="00:00:00.0037582" startTime="2017-02-02T21:43:46.9953974+01:00" endTime="2017-02-02T21:43:46.9993998+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="eddb4add-c355-4692-90f5-a95f326b3e36">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -562,26 +562,26 @@ namespace MyNamespace
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 21
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 21
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d0c1fd2f-6e62-4d04-b749-6a7256a9f4ac" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="AS0283" duration="00:00:00.0002112" startTime="2016-09-28T09:33:47.3547502+02:00" endTime="2016-09-28T09:33:47.3547502+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d0c1fd2f-6e62-4d04-b749-6a7256a9f4ac">
+    <UnitTestResult executionId="91438154-71c6-4b8c-8f9e-140493c0b14f" testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0003079" startTime="2017-02-02T21:43:46.9999006+01:00" endTime="2017-02-02T21:43:47.0004014+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="91438154-71c6-4b8c-8f9e-140493c0b14f">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="9a20b8b3-ac69-47bb-ac15-661154295623" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="AS0283" duration="00:00:00.0001009" startTime="2016-09-28T09:33:47.3557498+02:00" endTime="2016-09-28T09:33:47.3557498+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9a20b8b3-ac69-47bb-ac15-661154295623">
+    <UnitTestResult executionId="c119627b-22a3-4bc6-8881-646e22d819b8" testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0001214" startTime="2017-02-02T21:43:47.0004014+01:00" endTime="2017-02-02T21:43:47.0009013+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c119627b-22a3-4bc6-8881-646e22d819b8">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="fd5c9e92-342d-49a9-b823-46c4be51cb59" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="AS0283" duration="00:00:00.0032675" startTime="2016-09-28T09:33:47.3557498+02:00" endTime="2016-09-28T09:33:47.3587513+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fd5c9e92-342d-49a9-b823-46c4be51cb59">
+    <UnitTestResult executionId="0cdb8782-5144-4e00-aa3c-aa702e1ecf88" testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" testName="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" computerName="LENOVOWERK" duration="00:00:00.0038608" startTime="2017-02-02T21:43:47.0014016+01:00" endTime="2017-02-02T21:43:47.0054041+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0cdb8782-5144-4e00-aa3c-aa702e1ecf88">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -600,33 +600,33 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 34
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 34
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a5b37047-3b93-423e-bb06-38868e59b26c" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="AS0283" duration="00:00:00.0002269" startTime="2016-09-28T09:33:47.3587513+02:00" endTime="2016-09-28T09:33:47.3587513+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a5b37047-3b93-423e-bb06-38868e59b26c">
+    <UnitTestResult executionId="bca17350-e961-4559-8893-72fa3b77c31d" testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0002805" startTime="2017-02-02T21:43:47.0054041+01:00" endTime="2017-02-02T21:43:47.0059048+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="bca17350-e961-4559-8893-72fa3b77c31d">
       <Output>
         <StdOut>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="5b29b0eb-dea5-464c-80c7-b2ff92491ad3" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="AS0283" duration="00:00:00.0001091" startTime="2016-09-28T09:33:47.3597501+02:00" endTime="2016-09-28T09:33:47.3597501+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5b29b0eb-dea5-464c-80c7-b2ff92491ad3">
+    <UnitTestResult executionId="fc16e228-b9ca-4120-b555-96025a1832ed" testId="99ae1964-4272-f64b-08c7-beaae8bff30c" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" computerName="LENOVOWERK" duration="00:00:00.0001274" startTime="2017-02-02T21:43:47.0064052+01:00" endTime="2017-02-02T21:43:47.0064052+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="fc16e228-b9ca-4120-b555-96025a1832ed">
       <Output>
         <StdOut>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="667e5260-cb2f-4544-9009-f1abf3c0d7e0" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="AS0283" duration="00:00:00.0012293" startTime="2016-09-28T09:33:47.3597501+02:00" endTime="2016-09-28T09:33:47.3607502+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="667e5260-cb2f-4544-9009-f1abf3c0d7e0">
+    <UnitTestResult executionId="7a5a3b19-496f-461e-b958-40783e235ba9" testId="6aa57053-5392-ab46-85c8-7e37adaaee43" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" computerName="LENOVOWERK" duration="00:00:00.0015002" startTime="2017-02-02T21:43:47.0069055+01:00" endTime="2017-02-02T21:43:47.0084066+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="7a5a3b19-496f-461e-b958-40783e235ba9">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</StdOut>
@@ -639,14 +639,14 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="dce05fd5-4250-49ab-8909-6c7fb59e610b" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="AS0283" duration="00:00:00.0010805" startTime="2016-09-28T09:33:47.3607502+02:00" endTime="2016-09-28T09:33:47.3617523+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="dce05fd5-4250-49ab-8909-6c7fb59e610b">
+    <UnitTestResult executionId="8498526c-a434-4faa-a249-9b66c9c39888" testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" computerName="LENOVOWERK" duration="00:00:00.0013637" startTime="2017-02-02T21:43:47.0089070+01:00" endTime="2017-02-02T21:43:47.0104076+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8498526c-a434-4faa-a249-9b66c9c39888">
       <Output>
         <StdOut>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</StdOut>
@@ -659,14 +659,14 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a95307d6-6c09-4e4d-b4e5-066be4abc1b0" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="AS0283" duration="00:00:00.0014246" startTime="2016-09-28T09:33:47.3617523+02:00" endTime="2016-09-28T09:33:47.3637509+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a95307d6-6c09-4e4d-b4e5-066be4abc1b0">
+    <UnitTestResult executionId="eef41d41-9383-4724-bf2b-17e8f1e41584" testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" computerName="LENOVOWERK" duration="00:00:00.0015519" startTime="2017-02-02T21:43:47.0104076+01:00" endTime="2017-02-02T21:43:47.0124090+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="eef41d41-9383-4724-bf2b-17e8f1e41584">
       <Output>
         <StdOut>Then the scenario will 'fail_1'
 -&gt; error: 
@@ -685,21 +685,21 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a1f28660-7d52-4165-bc11-c662baf9ce1f" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="AS0283" duration="00:00:00.0013234" startTime="2016-09-28T09:33:47.3637509+02:00" endTime="2016-09-28T09:33:47.3647499+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a1f28660-7d52-4165-bc11-c662baf9ce1f">
+    <UnitTestResult executionId="cb5d1008-bf0a-4fba-ab2d-6068581e1371" testId="ed9be2e6-2632-9fc1-c693-fe530d107927" testName="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" computerName="LENOVOWERK" duration="00:00:00.0019492" startTime="2017-02-02T21:43:47.0124090+01:00" endTime="2017-02-02T21:43:47.0149116+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="cb5d1008-bf0a-4fba-ab2d-6068581e1371">
       <Output>
         <StdOut>Then the scenario will 'fail_2'
 -&gt; error: 
@@ -718,158 +718,158 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at lambda_method(Closure , IContextManager , String )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
-   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2()
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature:line 45
+   at Pickles.TestHarness.MsTest.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\ScenarioOutlines.feature.cs:line 0
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="332e9527-18f1-441b-b4ec-db746a3768ca" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="AS0283" duration="00:00:00.0005151" startTime="2016-09-28T09:33:47.3647499+02:00" endTime="2016-09-28T09:33:47.3657509+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="332e9527-18f1-441b-b4ec-db746a3768ca">
+    <UnitTestResult executionId="0d5e023b-bb07-4e7e-876e-ecd50e35da4d" testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" testName="DealCorrectlyWithBackslashesInTheExamples_CTemp" computerName="LENOVOWERK" duration="00:00:00.0006718" startTime="2017-02-02T21:43:47.0149116+01:00" endTime="2017-02-02T21:43:47.0159128+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0d5e023b-bb07-4e7e-876e-ecd50e35da4d">
       <Output>
         <StdOut>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="13a6ddb0-64dc-48c4-b0b7-57c992d2c540" testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="AS0283" duration="00:00:00.0004467" startTime="2016-09-28T09:33:47.3657509+02:00" endTime="2016-09-28T09:33:47.3667501+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="13a6ddb0-64dc-48c4-b0b7-57c992d2c540">
+    <UnitTestResult executionId="5cf1bb08-69e4-43ec-b284-7768cbd1c160" testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" testName="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" computerName="LENOVOWERK" duration="00:00:00.0006196" startTime="2017-02-02T21:43:47.0164127+01:00" endTime="2017-02-02T21:43:47.0169131+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5cf1bb08-69e4-43ec-b284-7768cbd1c160">
       <Output>
         <StdOut>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="13d885b8-6cee-47c4-8db9-fa1970d5b6ae" testId="9404b577-698b-61ca-64fc-88ff799201bd" testName="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" computerName="AS0283" duration="00:00:00.0004900" startTime="2016-09-28T09:33:47.3667501+02:00" endTime="2016-09-28T09:33:47.3667501+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="13d885b8-6cee-47c4-8db9-fa1970d5b6ae">
+    <UnitTestResult executionId="5525e9b7-d9ea-4f1f-b854-6d7c33f5b9f7" testId="9404b577-698b-61ca-64fc-88ff799201bd" testName="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" computerName="LENOVOWERK" duration="00:00:00.0080663" startTime="2017-02-02T21:43:47.0174134+01:00" endTime="2017-02-02T21:43:47.0259169+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="5525e9b7-d9ea-4f1f-b854-6d7c33f5b9f7">
       <Output>
         <StdOut>When I have a field with value 'Please enter a valid two letter country code (e.g. DE)!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0.0s)
 And I have a field with value 'This is just a very very very veery long error message!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="8fd24446-7b32-4dc3-90d8-7c0d6d98ff83" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="AS0283" duration="00:00:00.0000436" startTime="2016-09-28T09:33:47.3667501+02:00" endTime="2016-09-28T09:33:47.3667501+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="8fd24446-7b32-4dc3-90d8-7c0d6d98ff83" />
-    <UnitTestResult executionId="9908bf61-1a41-43d0-bd86-95373375863e" testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="AS0283" duration="00:00:00.0005613" startTime="2016-09-28T09:33:47.3667501+02:00" endTime="2016-09-28T09:33:47.3677494+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9908bf61-1a41-43d0-bd86-95373375863e">
+    <UnitTestResult executionId="195b6d31-b6cf-4c5f-98b7-92b3338d1458" testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" testName="TestMethod" computerName="LENOVOWERK" duration="00:00:00.0000453" startTime="2017-02-02T21:43:47.0264198+01:00" endTime="2017-02-02T21:43:47.0269201+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="195b6d31-b6cf-4c5f-98b7-92b3338d1458" />
+    <UnitTestResult executionId="ce57f7e6-cf84-4c16-8d7f-474cd1d8de62" testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" testName="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" computerName="LENOVOWERK" duration="00:00:00.0007214" startTime="2017-02-02T21:43:47.0269201+01:00" endTime="2017-02-02T21:43:47.0284212+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ce57f7e6-cf84-4c16-8d7f-474cd1d8de62">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 120 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)</StdOut>
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="afa93803-918e-41b8-9af3-b24008de09c9" testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="AS0283" duration="00:00:00.0005434" startTime="2016-09-28T09:33:47.3677494+02:00" endTime="2016-09-28T09:33:47.3687495+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="afa93803-918e-41b8-9af3-b24008de09c9">
+    <UnitTestResult executionId="0d3d3130-b0e0-4a95-8be2-63ea5e622aaf" testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" testName="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0003331" startTime="2017-02-02T21:43:47.0289211+01:00" endTime="2017-02-02T21:43:47.0294215+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="0d3d3130-b0e0-4a95-8be2-63ea5e622aaf">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3ae70376-aaac-400b-9e91-d965995dff7b" testId="860fe6a8-8ab8-da24-9ff4-8fc156cff05f" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" computerName="AS0283" duration="00:00:00.0007438" startTime="2016-09-28T09:33:47.3687495+02:00" endTime="2016-09-28T09:33:47.3697517+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3ae70376-aaac-400b-9e91-d965995dff7b">
+    <UnitTestResult executionId="efa65a21-6ff6-4e6a-8bbe-7513ec5643de" testId="860fe6a8-8ab8-da24-9ff4-8fc156cff05f" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" computerName="LENOVOWERK" duration="00:00:00.0008458" startTime="2017-02-02T21:43:47.0294215+01:00" endTime="2017-02-02T21:43:47.0304205+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="efa65a21-6ff6-4e6a-8bbe-7513ec5643de">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '**'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="48ea929d-b4ad-4d4e-9e7c-976579becf74" testId="a900fecb-3728-fcea-67f2-b24d9d94cd5e" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" computerName="AS0283" duration="00:00:00.0002275" startTime="2016-09-28T09:33:47.3697517+02:00" endTime="2016-09-28T09:33:47.3707518+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="48ea929d-b4ad-4d4e-9e7c-976579becf74">
+    <UnitTestResult executionId="65a442bd-d20e-4652-8d55-bb522955d401" testId="a900fecb-3728-fcea-67f2-b24d9d94cd5e" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" computerName="LENOVOWERK" duration="00:00:00.0002091" startTime="2017-02-02T21:43:47.0309238+01:00" endTime="2017-02-02T21:43:47.0314212+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="65a442bd-d20e-4652-8d55-bb522955d401">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '++'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4de9fff8-c7aa-45db-857e-4eea587fc4ee" testId="46f974ed-841e-26dd-a181-971cc88d892b" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" computerName="AS0283" duration="00:00:00.0002081" startTime="2016-09-28T09:33:47.3707518+02:00" endTime="2016-09-28T09:33:47.3707518+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4de9fff8-c7aa-45db-857e-4eea587fc4ee">
+    <UnitTestResult executionId="1f0d1f27-98ed-47bf-8038-79724b6139f0" testId="46f974ed-841e-26dd-a181-971cc88d892b" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" computerName="LENOVOWERK" duration="00:00:00.0003292" startTime="2017-02-02T21:43:47.0319237+01:00" endTime="2017-02-02T21:43:47.0324215+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="1f0d1f27-98ed-47bf-8038-79724b6139f0">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '.*'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="a90f1cf7-6ad2-494a-af5b-dd4269552adf" testId="52d27672-31de-19f1-70ce-05bf3e83b4d2" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" computerName="AS0283" duration="00:00:00.0002349" startTime="2016-09-28T09:33:47.3707518+02:00" endTime="2016-09-28T09:33:47.3717519+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="a90f1cf7-6ad2-494a-af5b-dd4269552adf">
+    <UnitTestResult executionId="efa06663-6381-44fb-9c87-4ff4f4fabd9e" testId="52d27672-31de-19f1-70ce-05bf3e83b4d2" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" computerName="LENOVOWERK" duration="00:00:00.0002557" startTime="2017-02-02T21:43:47.0329235+01:00" endTime="2017-02-02T21:43:47.0334226+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="efa06663-6381-44fb-9c87-4ff4f4fabd9e">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '[]'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="3d7de2b7-0753-42f6-bcd7-c0b945a3831a" testId="b0a09bca-247a-a5bc-25cf-8aa3774a2d40" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" computerName="AS0283" duration="00:00:00.0001850" startTime="2016-09-28T09:33:47.3717519+02:00" endTime="2016-09-28T09:33:47.3717519+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3d7de2b7-0753-42f6-bcd7-c0b945a3831a">
+    <UnitTestResult executionId="6ddaa1fd-eec1-4321-b66b-9bcb13fde24b" testId="b0a09bca-247a-a5bc-25cf-8aa3774a2d40" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" computerName="LENOVOWERK" duration="00:00:00.0003096" startTime="2017-02-02T21:43:47.0339225+01:00" endTime="2017-02-02T21:43:47.0344229+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="6ddaa1fd-eec1-4321-b66b-9bcb13fde24b">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '{}'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e94f753e-2842-4e5b-aad8-6bc9512bf884" testId="d4e92e37-b370-9951-cf08-d28c8be3df76" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" computerName="AS0283" duration="00:00:00.0002072" startTime="2016-09-28T09:33:47.3717519+02:00" endTime="2016-09-28T09:33:47.3717519+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e94f753e-2842-4e5b-aad8-6bc9512bf884">
+    <UnitTestResult executionId="9c9c96e5-024d-4526-a4d0-6579d5e022c6" testId="d4e92e37-b370-9951-cf08-d28c8be3df76" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" computerName="LENOVOWERK" duration="00:00:00.0003519" startTime="2017-02-02T21:43:47.0349237+01:00" endTime="2017-02-02T21:43:47.0354236+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9c9c96e5-024d-4526-a4d0-6579d5e022c6">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '()'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="17f4380f-2127-4853-9b88-b1be4e82a38e" testId="bd874ade-5d64-8f62-b83e-d52cd3e9a75c" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" computerName="AS0283" duration="00:00:00.0001570" startTime="2016-09-28T09:33:47.3717519+02:00" endTime="2016-09-28T09:33:47.3727529+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="17f4380f-2127-4853-9b88-b1be4e82a38e">
+    <UnitTestResult executionId="58b9cb93-56ae-46a0-990a-2b2ef1a99dac" testId="bd874ade-5d64-8f62-b83e-d52cd3e9a75c" testName="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" computerName="LENOVOWERK" duration="00:00:00.0003339" startTime="2017-02-02T21:43:47.0359248+01:00" endTime="2017-02-02T21:43:47.0369251+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="58b9cb93-56ae-46a0-990a-2b2ef1a99dac">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 When I have special characters for regexes in the value, for example a '^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0.0s)
 Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="c1829243-907e-45fe-9930-27dbc00e5305" testId="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36" testName="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" computerName="AS0283" duration="00:00:00.0002315" startTime="2016-09-28T09:33:47.3727529+02:00" endTime="2016-09-28T09:33:47.3727529+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="c1829243-907e-45fe-9930-27dbc00e5305">
+    <UnitTestResult executionId="509f92b9-ef35-449e-8ed6-15fdf7a95f18" testId="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36" testName="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0005401" startTime="2017-02-02T21:43:47.0384266+01:00" endTime="2017-02-02T21:43:47.0394307+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="509f92b9-ef35-449e-8ed6-15fdf7a95f18">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="39990363-fe0d-4c86-a788-8ad194e9f3b2" testId="0943a703-db7d-3781-87ab-a7405aa83a66" testName="ThisIsAScenarioOutlineWithAmpersand_Pass_1" computerName="AS0283" duration="00:00:00.0002286" startTime="2016-09-28T09:33:47.3727529+02:00" endTime="2016-09-28T09:33:47.3727529+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="39990363-fe0d-4c86-a788-8ad194e9f3b2">
+    <UnitTestResult executionId="29655e5f-86cd-4494-9eca-beaf969654c9" testId="0943a703-db7d-3781-87ab-a7405aa83a66" testName="ThisIsAScenarioOutlineWithAmpersand_Pass_1" computerName="LENOVOWERK" duration="00:00:00.0003652" startTime="2017-02-02T21:43:47.0399276+01:00" endTime="2017-02-02T21:43:47.0404280+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="29655e5f-86cd-4494-9eca-beaf969654c9">
       <Output>
         <StdOut>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)</StdOut>
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="258d1c7c-5e8d-4af7-88b2-d09888b59789" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0007783" startTime="2016-09-28T09:33:47.3727529+02:00" endTime="2016-09-28T09:33:47.3747503+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="258d1c7c-5e8d-4af7-88b2-d09888b59789">
+    <UnitTestResult executionId="ee8126c1-a341-444c-aba2-6da8d2aabed1" testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" testName="FailingFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0013214" startTime="2017-02-02T21:43:47.0409279+01:00" endTime="2017-02-02T21:43:47.0429345+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ee8126c1-a341-444c-aba2-6da8d2aabed1">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="4fcef19a-90c3-45ab-884a-9335ff7e9eb9" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="AS0283" duration="00:00:00.0020074" startTime="2016-09-28T09:33:47.3747503+02:00" endTime="2016-09-28T09:33:47.3767515+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="4fcef19a-90c3-45ab-884a-9335ff7e9eb9">
+    <UnitTestResult executionId="213cf038-4507-4a4f-b442-94858425f938" testId="68c045a3-263d-f215-70d9-bc46476ac556" testName="FailingFeatureInconclusiveScenario" computerName="LENOVOWERK" duration="00:00:00.0022943" startTime="2017-02-02T21:43:47.0429345+01:00" endTime="2017-02-02T21:43:47.0459362+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="213cf038-4507-4a4f-b442-94858425f938">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -882,13 +882,13 @@ Then the scenario will 'pass_1'
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="d9866c4e-a98b-4174-83c8-62ac376bbc42" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="AS0283" duration="00:00:00.0018796" startTime="2016-09-28T09:33:47.3767515+02:00" endTime="2016-09-28T09:33:47.3787543+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d9866c4e-a98b-4174-83c8-62ac376bbc42">
+    <UnitTestResult executionId="9658b86d-1d72-499e-87e6-4d7e56606a85" testId="27968872-ecbf-8ec7-3a98-d1be98533db7" testName="FailingFeatureFailingScenario" computerName="LENOVOWERK" duration="00:00:00.0023110" startTime="2017-02-02T21:43:47.0459362+01:00" endTime="2017-02-02T21:43:47.0479376+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Failed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="9658b86d-1d72-499e-87e6-4d7e56606a85">
       <Output>
         <StdOut>Then failing step
 -&gt; error: 
@@ -907,26 +907,26 @@ Shouldly.ChuckedAWobbly:
     True</Message>
           <StackTrace>    at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at lambda_method(Closure , IContextManager )
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 10
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Failing.feature:line 10
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="ab4d1b15-b899-43a0-afa6-08b4a5ab2175" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0004011" startTime="2016-09-28T09:33:47.3787543+02:00" endTime="2016-09-28T09:33:47.3797536+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="ab4d1b15-b899-43a0-afa6-08b4a5ab2175">
+    <UnitTestResult executionId="3b3c1d48-f9e0-4ea2-badb-0a72b34e76a5" testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" testName="InconclusiveFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0004781" startTime="2017-02-02T21:43:47.0489387+01:00" endTime="2017-02-02T21:43:47.0499394+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="3b3c1d48-f9e0-4ea2-badb-0a72b34e76a5">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="41dc6965-7cf0-449b-a5bd-f78cb008d7c9" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="AS0283" duration="00:00:00.0011597" startTime="2016-09-28T09:33:47.3797536+02:00" endTime="2016-09-28T09:33:47.3807540+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="41dc6965-7cf0-449b-a5bd-f78cb008d7c9">
+    <UnitTestResult executionId="53d7dfe7-2c00-47de-b189-d0290f476709" testId="8ec08426-4901-6383-e565-646137b3299c" testName="InconclusiveFeatureInconclusiveScenario" computerName="LENOVOWERK" duration="00:00:00.0016639" startTime="2017-02-02T21:43:47.0499394+01:00" endTime="2017-02-02T21:43:47.0519404+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="NotExecuted" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="53d7dfe7-2c00-47de-b189-d0290f476709">
       <Output>
         <StdOut>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()</StdOut>
@@ -939,274 +939,262 @@ Shouldly.ChuckedAWobbly:
    at TechTalk.SpecFlow.ErrorHandling.ErrorProvider.ThrowPendingError(TestStatus testStatus, String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
    at TechTalk.SpecFlow.TestRunner.CollectScenarioErrors()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup()
-   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature:line 7
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\MsTest\Minimal Features\Inconclusive.feature:line 7
 </StackTrace>
         </ErrorInfo>
       </Output>
     </UnitTestResult>
-    <UnitTestResult executionId="e9295a2f-869a-46e1-af51-ba21191255ac" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="AS0283" duration="00:00:00.0003806" startTime="2016-09-28T09:33:47.3807540+02:00" endTime="2016-09-28T09:33:47.3817536+02:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="e9295a2f-869a-46e1-af51-ba21191255ac">
+    <UnitTestResult executionId="d8b775ab-26cc-4971-b390-1e8ba2930d3c" testId="272cd0db-3670-5256-8896-fd6e5899a9e6" testName="PassingFeaturePassingScenario" computerName="LENOVOWERK" duration="00:00:00.0004729" startTime="2017-02-02T21:43:47.0519404+01:00" endTime="2017-02-02T21:43:47.0539423+01:00" testType="13cdc9d9-ddb5-4fa4-a97d-d965ccfc6d4b" outcome="Passed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" relativeResultsDirectory="d8b775ab-26cc-4971-b390-1e8ba2930d3c">
       <Output>
         <StdOut>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)</StdOut>
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)</StdOut>
       </Output>
     </UnitTestResult>
   </Results>
   <TestDefinitions>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
-      <TestCategory>
-        <TestCategoryItem TestCategory="tag2" />
-      </TestCategory>
-      <Execution id="1e6f4610-6037-47ce-ae89-724a1fdb0409" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="140c2ca4-3d30-406e-fdc9-be44c10a340a">
+      <Execution id="9d051830-4934-4465-885a-2c150804960b" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
-      <TestCategory>
-        <TestCategoryItem TestCategory="tag2" />
-      </TestCategory>
-      <Execution id="3c333028-67e0-4098-a6f2-b687bdaba0f2" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="21bcc183-2ce2-c7f7-4a75-61985a78b639">
+      <Execution id="8278c3af-51ad-4f43-ac73-a7d590d560e4" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
-      <TestCategory>
-        <TestCategoryItem TestCategory="tag1" />
-      </TestCategory>
-      <Execution id="d3e1412a-56b7-44c3-a111-cde4cf3cad8e" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1">
+      <Execution id="93d52d47-3a92-4ecc-ac54-c3b49770d88e" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="FailToAddTwoNumbers" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
-      <TestCategory>
-        <TestCategoryItem TestCategory="tag1" />
-      </TestCategory>
-      <Execution id="0031c5d4-ae0c-4a5e-84f9-b61b9bfce1bd" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
+    <UnitTest name="FailToAddTwoNumbers" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="0df655e6-c4cf-164c-b17f-7f9f92c19045">
+      <Execution id="a65c770a-d8ed-40f7-a8ec-bf9f2605e8a9" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="FailToAddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="IgnoredAddingTwoNumbers" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
-      <Execution id="f1eb023f-315e-469b-a93a-8964b4a09e0f" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
+    <UnitTest name="IgnoredAddingTwoNumbers" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="113ed7a2-61bc-45d6-3ad1-61ddbea77238">
+      <Execution id="d97a3a2b-b231-4441-9f17-92b219561a7b" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="IgnoredAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
-      <Execution id="d0cd3cc0-6525-4f9e-916d-93c6c9135767" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
+    <UnitTest name="NotAutomatedAddingTwoNumbers" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8c3089df-e8ec-4931-e07f-19784ba313d4">
+      <Execution id="f92aecfc-b519-4834-8fff-27be81a3b4f1" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.AdditionFeature" name="NotAutomatedAddingTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddTwoNumbers" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
-      <Execution id="017955ac-0a77-4ade-b12b-d7bcc1c02310" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
+    <UnitTest name="AddTwoNumbers" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="cd06647c-3ccf-9545-fdb0-c96daaba2ca8">
+      <Execution id="ecba1d57-5810-4c82-b373-ab24b5856cdd" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddTwoNumbers" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_60" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
-      <Execution id="56da2732-fa29-4a3b-9490-320749efc7e4" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
+    <UnitTest name="AddingSeveralNumbers_60" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="bea8799b-89a4-d983-d6a9-57924ee5618e">
+      <Execution id="3a7e876a-534e-45f4-84c2-51672eda6d5b" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_60" />
     </UnitTest>
-    <UnitTest name="AddingSeveralNumbers_40" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
-      <Execution id="d5b8e832-7af0-4d3f-86e1-b5947f3896d1" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
+    <UnitTest name="AddingSeveralNumbers_40" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="7ef69afa-3afb-8791-c4d2-657df7ba5408">
+      <Execution id="15be6a04-62ba-479d-a6c1-25139fb605c9" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.FailingBackgroundFeature" name="AddingSeveralNumbers_40" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
-      <Execution id="caf2a316-149f-469e-a1ff-64e695de86ed" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
+    <UnitTest name="NotAutomatedScenario1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d2820219-bd97-2273-945a-4d371724085a">
+      <Execution id="69f889a4-4c43-4183-8ef0-3f57706e5ba9" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario1" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
-      <Execution id="fd5af870-6fea-4ae9-b911-3457e5381c4d" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
+    <UnitTest name="NotAutomatedScenario2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8bc041bd-d809-7992-ff2a-09b84d713da5">
+      <Execution id="9d61addd-5484-43d4-8aa3-eaf35582e24d" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario2" />
     </UnitTest>
-    <UnitTest name="NotAutomatedScenario3" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
-      <Execution id="a9409d91-a76f-4a4a-9eb6-173e1b03414f" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
+    <UnitTest name="NotAutomatedScenario3" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ee64b0d5-906e-5159-a108-531362c596d1">
+      <Execution id="176502ca-df40-4aed-a675-3a812da1beea" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.NotAutomatedAtAllFeature" name="NotAutomatedScenario3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
-      <Execution id="aa74ae12-11d5-4f8a-a46f-dda99071a584" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="f9a64263-f40d-f64d-0a5b-22b6db10eb26">
+      <Execution id="a0c750a9-6056-4a35-8361-476babad5ba6" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
-      <Execution id="31ca2a56-0479-439d-b022-c376352d3fea" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="aa38c998-4087-fdeb-c742-f6a940beef87">
+      <Execution id="cdf1908d-1f4c-46de-b462-7af35bc9fda4" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
-      <Execution id="04af37ad-d427-44d1-a00d-4738d08c9573" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="90a44ab4-342d-ed3c-860e-39c8152c2fad">
+      <Execution id="ecd22692-cc09-447c-a100-924f1b8afed7" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereAllScenariosPass_Pass_3" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
-      <Execution id="0dd6c8d4-27e1-48a4-9641-60f8e425d51c" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="7e46cf81-dd4a-3fd0-4759-df967f754d0d">
+      <Execution id="5494935e-ea27-42cd-9393-64bbad15d92e" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
-      <Execution id="2273996b-f3b9-4cad-a67b-4df9d4ee9735" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea">
+      <Execution id="bcf91c7f-6eb0-47fe-b018-a6fa8183fd0f" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
-      <Execution id="dd77f87f-0336-43d5-b675-8eaeae3523ec" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b4fa0e1c-5a4e-dabb-6fb2-000597c04404">
+      <Execution id="eddb4add-c355-4692-90f5-a95f326b3e36" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
-      <Execution id="d0c1fd2f-6e62-4d04-b749-6a7256a9f4ac" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="e911cad1-80be-36f6-3c0c-eb83f516c0a2">
+      <Execution id="91438154-71c6-4b8c-8f9e-140493c0b14f" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
-      <Execution id="9a20b8b3-ac69-47bb-ac15-661154295623" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="f3327e4b-92ea-d5bf-ceff-5062ff9febf5">
+      <Execution id="c119627b-22a3-4bc6-8881-646e22d819b8" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Pass_2" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
-      <Execution id="fd5c9e92-342d-49a9-b823-46c4be51cb59" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="5309a9c5-1ee0-31a6-55f5-b76209e03db3">
+      <Execution id="0cdb8782-5144-4e00-aa3c-aa702e1ecf88" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="ThisIsAScenarioOutlineWhereOneScenarioFails_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
-      <Execution id="a5b37047-3b93-423e-bb06-38868e59b26c" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="635e5bc5-c3fe-72a8-367f-654037b1c1da">
+      <Execution id="bca17350-e961-4559-8893-72fa3b77c31d" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
-      <Execution id="5b29b0eb-dea5-464c-80c7-b2ff92491ad3" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="99ae1964-4272-f64b-08c7-beaae8bff30c">
+      <Execution id="fc16e228-b9ca-4120-b555-96025a1832ed" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet0_Pass_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
-      <Execution id="667e5260-cb2f-4544-9009-f1abf3c0d7e0" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="6aa57053-5392-ab46-85c8-7e37adaaee43">
+      <Execution id="7a5a3b19-496f-461e-b958-40783e235ba9" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
-      <Execution id="dce05fd5-4250-49ab-8909-6c7fb59e610b" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="e8c43f8a-7359-f15b-4250-8ed752528b1b">
+      <Execution id="8498526c-a434-4faa-a249-9b66c9c39888" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet1_Inconclusive_2" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
-      <Execution id="a95307d6-6c09-4e4d-b4e5-066be4abc1b0" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d6dd768f-20fc-ed4a-8542-86bee0adde9e">
+      <Execution id="eef41d41-9383-4724-bf2b-17e8f1e41584" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_1" />
     </UnitTest>
-    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
-      <Execution id="a1f28660-7d52-4165-bc11-c662baf9ce1f" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
+    <UnitTest name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ed9be2e6-2632-9fc1-c693-fe530d107927">
+      <Execution id="cb5d1008-bf0a-4fba-ab2d-6068581e1371" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="AndWeCanGoTotallyBonkersWithMultipleExampleSections__ExampleSet2_Fail_2" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
-      <Execution id="332e9527-18f1-441b-b4ec-db746a3768ca" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
+    <UnitTest name="DealCorrectlyWithBackslashesInTheExamples_CTemp" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b2578459-aaca-c2fd-c57f-0405fafa6c43">
+      <Execution id="0d5e023b-bb07-4e7e-876e-ecd50e35da4d" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithBackslashesInTheExamples_CTemp" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91">
-      <Execution id="13a6ddb0-64dc-48c4-b0b7-57c992d2c540" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
+    <UnitTest name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91">
+      <Execution id="5cf1bb08-69e4-43ec-b284-7768cbd1c160" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithParenthesisInTheExamples_ThisIsADescriptionAndMore" />
     </UnitTest>
-    <UnitTest name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="9404b577-698b-61ca-64fc-88ff799201bd">
-      <Execution id="13d885b8-6cee-47c4-8db9-fa1970d5b6ae" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" />
+    <UnitTest name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="9404b577-698b-61ca-64fc-88ff799201bd">
+      <Execution id="5525e9b7-d9ea-4f1f-b854-6d7c33f5b9f7" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenarioOutlinesFeature" name="DealCorrectlyWithOverlongExampleValues_PleaseEnterAValidTwoLetterCountryCodeE_G_DE" />
     </UnitTest>
-    <UnitTest name="TestMethod" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
-      <Execution id="8fd24446-7b32-4dc3-90d8-7c0d6d98ff83" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
+    <UnitTest name="TestMethod" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="9fb96cdc-a81e-252c-1a41-7ecd9a592065">
+      <Execution id="195b6d31-b6cf-4c5f-98b7-92b3338d1458" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.OrdinaryUnitTest" name="TestMethod" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f">
-      <Execution id="9908bf61-1a41-43d0-bd86-95373375863e" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
+    <UnitTest name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f">
+      <Execution id="ce57f7e6-cf84-4c16-8d7f-474cd1d8de62" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="efcbe7cc-31a8-2063-2ba3-daddc29b814d">
-      <Execution id="afa93803-918e-41b8-9af3-b24008de09c9" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="efcbe7cc-31a8-2063-2ba3-daddc29b814d">
+      <Execution id="0d3d3130-b0e0-4a95-8be2-63ea5e622aaf" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="860fe6a8-8ab8-da24-9ff4-8fc156cff05f">
-      <Execution id="3ae70376-aaac-400b-9e91-d965995dff7b" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="860fe6a8-8ab8-da24-9ff4-8fc156cff05f">
+      <Execution id="efa65a21-6ff6-4e6a-8bbe-7513ec5643de" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant0" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="a900fecb-3728-fcea-67f2-b24d9d94cd5e">
-      <Execution id="48ea929d-b4ad-4d4e-9e7c-976579becf74" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="a900fecb-3728-fcea-67f2-b24d9d94cd5e">
+      <Execution id="65a442bd-d20e-4652-8d55-bb522955d401" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant1" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="46f974ed-841e-26dd-a181-971cc88d892b">
-      <Execution id="4de9fff8-c7aa-45db-857e-4eea587fc4ee" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="46f974ed-841e-26dd-a181-971cc88d892b">
+      <Execution id="1f0d1f27-98ed-47bf-8038-79724b6139f0" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant2" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="52d27672-31de-19f1-70ce-05bf3e83b4d2">
-      <Execution id="a90f1cf7-6ad2-494a-af5b-dd4269552adf" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="52d27672-31de-19f1-70ce-05bf3e83b4d2">
+      <Execution id="efa06663-6381-44fb-9c87-4ff4f4fabd9e" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant3" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b0a09bca-247a-a5bc-25cf-8aa3774a2d40">
-      <Execution id="3d7de2b7-0753-42f6-bcd7-c0b945a3831a" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b0a09bca-247a-a5bc-25cf-8aa3774a2d40">
+      <Execution id="6ddaa1fd-eec1-4321-b66b-9bcb13fde24b" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant4" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d4e92e37-b370-9951-cf08-d28c8be3df76">
-      <Execution id="e94f753e-2842-4e5b-aad8-6bc9512bf884" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="d4e92e37-b370-9951-cf08-d28c8be3df76">
+      <Execution id="9c9c96e5-024d-4526-a4d0-6579d5e022c6" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant5" />
     </UnitTest>
-    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="bd874ade-5d64-8f62-b83e-d52cd3e9a75c">
-      <Execution id="17f4380f-2127-4853-9b88-b1be4e82a38e" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" />
+    <UnitTest name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="bd874ade-5d64-8f62-b83e-d52cd3e9a75c">
+      <Execution id="58b9cb93-56ae-46a0-990a-2b2ef1a99dac" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisScenarioContainsExamplesWithRegex_SpecialCharacters_Variant6" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36">
-      <Execution id="c1829243-907e-45fe-9930-27dbc00e5305" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36">
+      <Execution id="509f92b9-ef35-449e-8ed6-15fdf7a95f18" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU_Pass_1" />
     </UnitTest>
-    <UnitTest name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="0943a703-db7d-3781-87ab-a7405aa83a66">
-      <Execution id="39990363-fe0d-4c86-a788-8ad194e9f3b2" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" />
+    <UnitTest name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="0943a703-db7d-3781-87ab-a7405aa83a66">
+      <Execution id="29655e5f-86cd-4494-9eca-beaf969654c9" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.ScenariosWithSpecialCharactersFeature" name="ThisIsAScenarioOutlineWithAmpersand_Pass_1" />
     </UnitTest>
-    <UnitTest name="FailingFeaturePassingScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
-      <Execution id="258d1c7c-5e8d-4af7-88b2-d09888b59789" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
+    <UnitTest name="FailingFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="b08cd0c6-1fb7-422e-7264-d77da39fe00d">
+      <Execution id="ee8126c1-a341-444c-aba2-6da8d2aabed1" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
-      <Execution id="4fcef19a-90c3-45ab-884a-9335ff7e9eb9" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
+    <UnitTest name="FailingFeatureInconclusiveScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="68c045a3-263d-f215-70d9-bc46476ac556">
+      <Execution id="213cf038-4507-4a4f-b442-94858425f938" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="FailingFeatureFailingScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
-      <Execution id="d9866c4e-a98b-4174-83c8-62ac376bbc42" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
+    <UnitTest name="FailingFeatureFailingScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="27968872-ecbf-8ec7-3a98-d1be98533db7">
+      <Execution id="9658b86d-1d72-499e-87e6-4d7e56606a85" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.FailingFeature" name="FailingFeatureFailingScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
-      <Execution id="ab4d1b15-b899-43a0-afa6-08b4a5ab2175" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
+    <UnitTest name="InconclusiveFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3">
+      <Execution id="3b3c1d48-f9e0-4ea2-badb-0a72b34e76a5" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeaturePassingScenario" />
     </UnitTest>
-    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
-      <Execution id="41dc6965-7cf0-449b-a5bd-f78cb008d7c9" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
+    <UnitTest name="InconclusiveFeatureInconclusiveScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="8ec08426-4901-6383-e565-646137b3299c">
+      <Execution id="53d7dfe7-2c00-47de-b189-d0290f476709" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.InconclusiveFeature" name="InconclusiveFeatureInconclusiveScenario" />
     </UnitTest>
-    <UnitTest name="PassingFeaturePassingScenario" storage="c:\devprojects\tools\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
-      <Execution id="e9295a2f-869a-46e1-af51-ba21191255ac" />
-      <TestMethod codeBase="C:\DevProjects\Tools\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
+    <UnitTest name="PassingFeaturePassingScenario" storage="c:\users\bas\source\repos\pickles\test-harness\mstest\bin\debug\mstestharness.dll" id="272cd0db-3670-5256-8896-fd6e5899a9e6">
+      <Execution id="d8b775ab-26cc-4971-b390-1e8ba2930d3c" />
+      <TestMethod codeBase="C:\Users\Bas\Source\Repos\pickles\test-harness\mstest\bin\Debug\mstestHarness.dll" adapterTypeName="Microsoft.VisualStudio.TestTools.TestTypes.Unit.UnitTestAdapter" className="Pickles.TestHarness.MsTest.MinimalFeatures.PassingFeature" name="PassingFeaturePassingScenario" />
     </UnitTest>
   </TestDefinitions>
   <TestEntries>
-    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="1e6f4610-6037-47ce-ae89-724a1fdb0409" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="3c333028-67e0-4098-a6f2-b687bdaba0f2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="d3e1412a-56b7-44c3-a111-cde4cf3cad8e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="0031c5d4-ae0c-4a5e-84f9-b61b9bfce1bd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="f1eb023f-315e-469b-a93a-8964b4a09e0f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="d0cd3cc0-6525-4f9e-916d-93c6c9135767" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="017955ac-0a77-4ade-b12b-d7bcc1c02310" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="56da2732-fa29-4a3b-9490-320749efc7e4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="d5b8e832-7af0-4d3f-86e1-b5947f3896d1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="caf2a316-149f-469e-a1ff-64e695de86ed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="fd5af870-6fea-4ae9-b911-3457e5381c4d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="a9409d91-a76f-4a4a-9eb6-173e1b03414f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="aa74ae12-11d5-4f8a-a46f-dda99071a584" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="31ca2a56-0479-439d-b022-c376352d3fea" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="04af37ad-d427-44d1-a00d-4738d08c9573" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="0dd6c8d4-27e1-48a4-9641-60f8e425d51c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="2273996b-f3b9-4cad-a67b-4df9d4ee9735" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="dd77f87f-0336-43d5-b675-8eaeae3523ec" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="d0c1fd2f-6e62-4d04-b749-6a7256a9f4ac" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="9a20b8b3-ac69-47bb-ac15-661154295623" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="fd5c9e92-342d-49a9-b823-46c4be51cb59" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="a5b37047-3b93-423e-bb06-38868e59b26c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="5b29b0eb-dea5-464c-80c7-b2ff92491ad3" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="667e5260-cb2f-4544-9009-f1abf3c0d7e0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="dce05fd5-4250-49ab-8909-6c7fb59e610b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="a95307d6-6c09-4e4d-b4e5-066be4abc1b0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="a1f28660-7d52-4165-bc11-c662baf9ce1f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="332e9527-18f1-441b-b4ec-db746a3768ca" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" executionId="13a6ddb0-64dc-48c4-b0b7-57c992d2c540" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9404b577-698b-61ca-64fc-88ff799201bd" executionId="13d885b8-6cee-47c4-8db9-fa1970d5b6ae" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="8fd24446-7b32-4dc3-90d8-7c0d6d98ff83" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" executionId="9908bf61-1a41-43d0-bd86-95373375863e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" executionId="afa93803-918e-41b8-9af3-b24008de09c9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="860fe6a8-8ab8-da24-9ff4-8fc156cff05f" executionId="3ae70376-aaac-400b-9e91-d965995dff7b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="a900fecb-3728-fcea-67f2-b24d9d94cd5e" executionId="48ea929d-b4ad-4d4e-9e7c-976579becf74" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="46f974ed-841e-26dd-a181-971cc88d892b" executionId="4de9fff8-c7aa-45db-857e-4eea587fc4ee" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="52d27672-31de-19f1-70ce-05bf3e83b4d2" executionId="a90f1cf7-6ad2-494a-af5b-dd4269552adf" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b0a09bca-247a-a5bc-25cf-8aa3774a2d40" executionId="3d7de2b7-0753-42f6-bcd7-c0b945a3831a" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="d4e92e37-b370-9951-cf08-d28c8be3df76" executionId="e94f753e-2842-4e5b-aad8-6bc9512bf884" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="bd874ade-5d64-8f62-b83e-d52cd3e9a75c" executionId="17f4380f-2127-4853-9b88-b1be4e82a38e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36" executionId="c1829243-907e-45fe-9930-27dbc00e5305" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="0943a703-db7d-3781-87ab-a7405aa83a66" executionId="39990363-fe0d-4c86-a788-8ad194e9f3b2" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="258d1c7c-5e8d-4af7-88b2-d09888b59789" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="4fcef19a-90c3-45ab-884a-9335ff7e9eb9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="d9866c4e-a98b-4174-83c8-62ac376bbc42" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="ab4d1b15-b899-43a0-afa6-08b4a5ab2175" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="41dc6965-7cf0-449b-a5bd-f78cb008d7c9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
-    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="e9295a2f-869a-46e1-af51-ba21191255ac" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="140c2ca4-3d30-406e-fdc9-be44c10a340a" executionId="9d051830-4934-4465-885a-2c150804960b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="21bcc183-2ce2-c7f7-4a75-61985a78b639" executionId="8278c3af-51ad-4f43-ac73-a7d590d560e4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8b1ea73f-6162-3e0e-0c6c-d3a9edc3a6d1" executionId="93d52d47-3a92-4ecc-ac54-c3b49770d88e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0df655e6-c4cf-164c-b17f-7f9f92c19045" executionId="a65c770a-d8ed-40f7-a8ec-bf9f2605e8a9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="113ed7a2-61bc-45d6-3ad1-61ddbea77238" executionId="d97a3a2b-b231-4441-9f17-92b219561a7b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8c3089df-e8ec-4931-e07f-19784ba313d4" executionId="f92aecfc-b519-4834-8fff-27be81a3b4f1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="cd06647c-3ccf-9545-fdb0-c96daaba2ca8" executionId="ecba1d57-5810-4c82-b373-ab24b5856cdd" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="bea8799b-89a4-d983-d6a9-57924ee5618e" executionId="3a7e876a-534e-45f4-84c2-51672eda6d5b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7ef69afa-3afb-8791-c4d2-657df7ba5408" executionId="15be6a04-62ba-479d-a6c1-25139fb605c9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d2820219-bd97-2273-945a-4d371724085a" executionId="69f889a4-4c43-4183-8ef0-3f57706e5ba9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8bc041bd-d809-7992-ff2a-09b84d713da5" executionId="9d61addd-5484-43d4-8aa3-eaf35582e24d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ee64b0d5-906e-5159-a108-531362c596d1" executionId="176502ca-df40-4aed-a675-3a812da1beea" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f9a64263-f40d-f64d-0a5b-22b6db10eb26" executionId="a0c750a9-6056-4a35-8361-476babad5ba6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="aa38c998-4087-fdeb-c742-f6a940beef87" executionId="cdf1908d-1f4c-46de-b462-7af35bc9fda4" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="90a44ab4-342d-ed3c-860e-39c8152c2fad" executionId="ecd22692-cc09-447c-a100-924f1b8afed7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="7e46cf81-dd4a-3fd0-4759-df967f754d0d" executionId="5494935e-ea27-42cd-9393-64bbad15d92e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a83adabc-7eb9-5e21-a7bc-6907dc0d83ea" executionId="bcf91c7f-6eb0-47fe-b018-a6fa8183fd0f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b4fa0e1c-5a4e-dabb-6fb2-000597c04404" executionId="eddb4add-c355-4692-90f5-a95f326b3e36" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e911cad1-80be-36f6-3c0c-eb83f516c0a2" executionId="91438154-71c6-4b8c-8f9e-140493c0b14f" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="f3327e4b-92ea-d5bf-ceff-5062ff9febf5" executionId="c119627b-22a3-4bc6-8881-646e22d819b8" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="5309a9c5-1ee0-31a6-55f5-b76209e03db3" executionId="0cdb8782-5144-4e00-aa3c-aa702e1ecf88" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="635e5bc5-c3fe-72a8-367f-654037b1c1da" executionId="bca17350-e961-4559-8893-72fa3b77c31d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="99ae1964-4272-f64b-08c7-beaae8bff30c" executionId="fc16e228-b9ca-4120-b555-96025a1832ed" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="6aa57053-5392-ab46-85c8-7e37adaaee43" executionId="7a5a3b19-496f-461e-b958-40783e235ba9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="e8c43f8a-7359-f15b-4250-8ed752528b1b" executionId="8498526c-a434-4faa-a249-9b66c9c39888" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d6dd768f-20fc-ed4a-8542-86bee0adde9e" executionId="eef41d41-9383-4724-bf2b-17e8f1e41584" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ed9be2e6-2632-9fc1-c693-fe530d107927" executionId="cb5d1008-bf0a-4fba-ab2d-6068581e1371" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b2578459-aaca-c2fd-c57f-0405fafa6c43" executionId="0d5e023b-bb07-4e7e-876e-ecd50e35da4d" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="ece5cdce-c3f9-32d6-6d48-bb2f6fd1ba91" executionId="5cf1bb08-69e4-43ec-b284-7768cbd1c160" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9404b577-698b-61ca-64fc-88ff799201bd" executionId="5525e9b7-d9ea-4f1f-b854-6d7c33f5b9f7" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="9fb96cdc-a81e-252c-1a41-7ecd9a592065" executionId="195b6d31-b6cf-4c5f-98b7-92b3338d1458" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="53ebc13a-89fc-b58c-a6e0-dfd85e793e5f" executionId="ce57f7e6-cf84-4c16-8d7f-474cd1d8de62" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="efcbe7cc-31a8-2063-2ba3-daddc29b814d" executionId="0d3d3130-b0e0-4a95-8be2-63ea5e622aaf" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="860fe6a8-8ab8-da24-9ff4-8fc156cff05f" executionId="efa65a21-6ff6-4e6a-8bbe-7513ec5643de" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="a900fecb-3728-fcea-67f2-b24d9d94cd5e" executionId="65a442bd-d20e-4652-8d55-bb522955d401" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="46f974ed-841e-26dd-a181-971cc88d892b" executionId="1f0d1f27-98ed-47bf-8038-79724b6139f0" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="52d27672-31de-19f1-70ce-05bf3e83b4d2" executionId="efa06663-6381-44fb-9c87-4ff4f4fabd9e" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b0a09bca-247a-a5bc-25cf-8aa3774a2d40" executionId="6ddaa1fd-eec1-4321-b66b-9bcb13fde24b" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="d4e92e37-b370-9951-cf08-d28c8be3df76" executionId="9c9c96e5-024d-4526-a4d0-6579d5e022c6" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="bd874ade-5d64-8f62-b83e-d52cd3e9a75c" executionId="58b9cb93-56ae-46a0-990a-2b2ef1a99dac" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="eeac1cb9-e9d0-de27-eeb7-a74ca0b65a36" executionId="509f92b9-ef35-449e-8ed6-15fdf7a95f18" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="0943a703-db7d-3781-87ab-a7405aa83a66" executionId="29655e5f-86cd-4494-9eca-beaf969654c9" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="b08cd0c6-1fb7-422e-7264-d77da39fe00d" executionId="ee8126c1-a341-444c-aba2-6da8d2aabed1" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="68c045a3-263d-f215-70d9-bc46476ac556" executionId="213cf038-4507-4a4f-b442-94858425f938" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="27968872-ecbf-8ec7-3a98-d1be98533db7" executionId="9658b86d-1d72-499e-87e6-4d7e56606a85" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="4c1b1763-64a2-d451-5dd8-c0cd8cebb9f3" executionId="3b3c1d48-f9e0-4ea2-badb-0a72b34e76a5" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="8ec08426-4901-6383-e565-646137b3299c" executionId="53d7dfe7-2c00-47de-b189-d0290f476709" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
+    <TestEntry testId="272cd0db-3670-5256-8896-fd6e5899a9e6" executionId="d8b775ab-26cc-4971-b390-1e8ba2930d3c" testListId="8c84fa94-04c1-424b-9868-57a2d4851a1d" />
   </TestEntries>
   <TestLists>
     <TestList name="Results Not in a List" id="8c84fa94-04c1-424b-9868-57a2d4851a1d" />

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit1/results-example-xunit.xml
@@ -1,102 +1,11 @@
-<assembly name="C:\DevProjects\Tools\pickles\test-harness\xunit\bin\Debug\xunitHarness.dll" run-date="2016-09-28" run-time="09:33:38" configFile="C:\DevProjects\Tools\pickles\test-harness\xunit\bin\Debug\xunitHarness.dll.config" time="0.309" total="47" passed="29" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.259" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.173"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 60 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0,0s)
-And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
-And I have entered 130 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 260 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 40 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0,0s)
-And I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
-And I have entered 90 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 180 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+<assembly name="C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\bin\Debug\xunitHarness.dll" run-date="2017-02-02" run-time="21:43:33" configFile="C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\bin\Debug\xunitHarness.dll.config" time="0.547" total="47" passed="29" failed="17" skipped="1" environment="64-bit .NET 4.0.30319.42000" test-framework="xUnit.net 1.9.2.1705"><class time="0.442" name="Pickles.TestHarness.xunit.AdditionFeature" total="6" passed="3" failed="2" skipped="1"><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.220"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
-And I have entered 2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0,0s)
-When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
-Then the result should be 3 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.083"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-When unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-Then unimplemented step
--&gt; No matching step definition found for the step. Use the following code to create one:
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
-using System;
-using TechTalk.SpecFlow;
-
-namespace MyNamespace
-{
-    [Binding]
-    public class StepDefinitions
-    {
-        [Given(@"unimplemented step")]
-        public void GivenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [When(@"unimplemented step")]
-        public void WhenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-        
-        [Then(@"unimplemented step")]
-        public void ThenUnimplementedStep()
-        {
-            ScenarioContext.Current.Pending();
-        }
-    }
-}
-</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit\Addition.feature:line 46</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="FailToAddTwoNumbers" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Fail to add two numbers" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Given I have entered 1 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
 And I have entered 2.2 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2,2) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2.2) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 3.2 on the screen
 -&gt; error: Input string was not in a correct format.
 </output><failure exception-type="System.FormatException"><message>System.FormatException : Input string was not in a correct format.</message><stack-trace>   at System.Number.StringToNumber(String str, NumberStyles options, NumberBuffer&amp; number, NumberFormatInfo info, Boolean parseDecimal)
@@ -109,8 +18,129 @@ Then the result should be 3.2 on the screen
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit\Addition.feature:line 34</stack-trace></failure></test></class><class time="0.019" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.016"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Addition.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddTwoNumbers" result="Pass" time="0.070"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Add two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 1 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(1) (0.0s)
+And I have entered 2 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(2) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 3 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(3) (0.1s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.IgnoredAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="IgnoredAddingTwoNumbers" result="Skip"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Ignored adding two numbers" /></traits><reason><message>Ignored</message></reason></test><test name="Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit.AdditionFeature" method="NotAutomatedAddingTwoNumbers" result="Fail" time="0.150"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Not automated adding two numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+When unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+Then unimplemented step
+-&gt; No matching step definition found for the step. Use the following code to create one:
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.
+using System;
+using TechTalk.SpecFlow;
+
+namespace MyNamespace
+{
+    [Binding]
+    public class StepDefinitions
+    {
+        [Given(@"unimplemented step")]
+        public void GivenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [When(@"unimplemented step")]
+        public void WhenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+        
+        [Then(@"unimplemented step")]
+        public void ThenUnimplementedStep()
+        {
+            ScenarioContext.Current.Pending();
+        }
+    }
+}
+</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Addition.feature:line 46</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.002"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 60 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(60) (0.0s)
+And I have entered 70 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
+And I have entered 130 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(130) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 260 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(260) (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.AdditionFeature" method="AddingSeveralNumbers" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Addition" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Given I have entered 40 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(40) (0.0s)
+And I have entered 50 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
+And I have entered 90 into the calculator
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(90) (0.0s)
+When I press add
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
+Then the result should be 180 on the screen
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(180) (0.0s)
+</output></test></class><class time="0.039" name="Pickles.TestHarness.xunit.FailingBackgroundFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.032"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
+-&gt; error: 
+    1
+        should be
+    2
+        but was
+    1
+And the calculator has clean memory
+-&gt; skipped because of previous errors
+Given I have entered 50 into the calculator
+-&gt; skipped because of previous errors
+And I have entered 70 into the calculator
+-&gt; skipped because of previous errors
+When I press add
+-&gt; skipped because of previous errors
+Then the result should be 120 on the screen
+-&gt; skipped because of previous errors
+</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
+    1
+        should be
+    2
+        but was
+    1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.005"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -136,13 +166,13 @@ Then the result should be 260 on the screen
         but was
     1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddingSeveralNumbers" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Adding several numbers" /></traits><output>Given the background step fails
 -&gt; error: 
     1
         should be
@@ -168,43 +198,13 @@ Then the result should be 180 on the screen
         but was
     1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit.FailingBackgroundFeature" method="AddTwoNumbers" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Failing Background" /><trait name="Description" value="Add two numbers" /></traits><output>Given the background step fails
--&gt; error: 
-    1
-        should be
-    2
-        but was
-    1
-And the calculator has clean memory
--&gt; skipped because of previous errors
-Given I have entered 50 into the calculator
--&gt; skipped because of previous errors
-And I have entered 70 into the calculator
--&gt; skipped because of previous errors
-When I press add
--&gt; skipped because of previous errors
-Then the result should be 120 on the screen
--&gt; skipped because of previous errors
-</output><failure exception-type="Shouldly.ChuckedAWobbly"><message>Shouldly.ChuckedAWobbly : 
-    1
-        should be
-    2
-        but was
-    1</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit\FailingBackground.feature:line 12</stack-trace></failure></test></class><class time="0.014" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\FailingBackground.feature:line 19</stack-trace></failure></test></class><class time="0.031" name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" total="3" passed="0" failed="3" skipped="0"><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.008"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -266,8 +266,8 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\DevProjects\Tools\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" result="Fail" time="0.010"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 3" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -329,8 +329,8 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\DevProjects\Tools\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 2" /></traits><output>Given unimplemented step
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 19</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" result="Fail" time="0.013"><traits><trait name="FeatureTitle" value="Not Automated At All" /><trait name="Description" value="Not automated scenario 1" /></traits><output>Given unimplemented step
 -&gt; No matching step definition found for the step. Use the following code to create one:
         [Given(@"unimplemented step")]
         public void GivenUnimplementedStep()
@@ -392,21 +392,12 @@ namespace MyNamespace
 }
 </message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\DevProjects\Tools\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 14</stack-trace></failure></test></class><class time="0.012" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="18" passed="12" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.003"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
--&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
-</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
-  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\NotAutomatedAtAll.feature:line 9</stack-trace></failure></test></class><class time="0.023" name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" total="18" passed="12" failed="6" skipped="0"><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.002"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" result="Fail" time="0.009"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario fails" /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -420,27 +411,36 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 34</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'pass_2'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" result="Fail" time="0.006"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where one scenario is inconclusive" /></traits><output>Then the scenario will 'inconclusive_1'
+-&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
+</output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
+  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 21</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_1'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'inconclusive_2'
 -&gt; pending: ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_1'
 -&gt; error: 
     true
         should be
@@ -454,13 +454,13 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="And we can go totally bonkers with multiple example sections." /></traits><output>Then the scenario will 'fail_2'
 -&gt; error: 
     true
         should be
@@ -474,93 +474,93 @@ namespace MyNamespace
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\ScenarioOutlines.feature:line 45</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example an 'This is a description (and more)'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_2'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_2") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="This is a scenario outline where all scenarios pass" /></traits><output>Then the scenario will 'pass_3'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(overlyDescriptiveField: &quot;This is a description (and more)&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with parenthesis in the examples" /></traits><output>When I have parenthesis in the value, for example an 'This is a description (and more)'
--&gt; done: ScenarioOutlineSteps.WhenIHaveParenthesisInTheValueForExampleAnOverlyDescriptiveField("This is a descrip...") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(value1: &quot;Please enter a valid two letter country code (e.g.&quot;..., value2: &quot;This is just a very very very veery long error mes&quot;..., exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithOverlongExampleValues" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with overlong example values" /></traits><output>When I have a field with value 'Please enter a valid two letter country code (e.g. DE)!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_3") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(value1: &quot;Please enter a valid two letter country code (e.g.&quot;..., value2: &quot;This is just a very very very veery long error mes&quot;..., exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithOverlongExampleValues" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with overlong example values" /></traits><output>When I have a field with value 'Please enter a valid two letter country code (e.g. DE)!'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("Please enter a va...") (0.0s)
 And I have a field with value 'This is just a very very very veery long error message!'
--&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0,0s)
+-&gt; done: ScenarioOutlineSteps.WhenIHaveAFieldWithValue("This is just a ve...") (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenario Outlines" /><trait name="Description" value="Deal correctly with backslashes in the examples" /></traits><output>When I have backslashes in the value, for example a 'c:\Temp\'
--&gt; done: ScenarioOutlineSteps.WhenIHaveBackslashesInTheValueForExampleAFilePath("c:\Temp\") (0,0s)
-</output></test></class><class time="0.000" name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" total="11" passed="11" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario outline with german umlauts äöüß ÄÖÜ" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test></class><class time="0.003" name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" total="11" passed="11" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" result="Pass" time="0.002"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Given I have entered 50 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(50) (0.0s)
 And I have entered 70 into the calculator
--&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0,0s)
+-&gt; done: AdditionSteps.GivenIHaveEnteredIntoTheCalculator(70) (0.0s)
 When I press add
--&gt; done: AdditionSteps.WhenIPressAdd() (0,0s)
+-&gt; done: AdditionSteps.WhenIPressAdd() (0.0s)
 Then the result should be 120 on the screen
--&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0,0s)
+-&gt; done: AdditionSteps.ThenTheResultShouldBeOnTheScreen(120) (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;**&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '**'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;++&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '++'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;.*&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '.*'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;[]&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '[]'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;{}&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '{}'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;()&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '()'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
-</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
-When I have special characters for regexes in the value, for example a '^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$'
--&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0,0s)
-Then the scenario will 'PASS'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0,0s)
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithAmpersand(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithAmpersand" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario outline with ampersand &amp;" /></traits><output>Given the calculator has clean memory
--&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0,0s)
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
 Then the scenario will 'pass_1'
--&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0,0s)
-</output></test></class><class time="0.004" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;**&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '**'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("**") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;++&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '++'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("++") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;.*&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '.*'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex(".*") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;[]&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '[]'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("[]") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;{}&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '{}'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("{}") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;()&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '()'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("()") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This scenario contains examples with Regex-special characters" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+When I have special characters for regexes in the value, for example a '^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$'
+-&gt; done: ScenarioOutlineSteps.WhenIHaveSpecialCharactersForRegexesInTheValueForExampleARegex("^.*(?&lt;foo&gt;BAR)\s[...") (0.0s)
+Then the scenario will 'PASS'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("PASS") (0.0s)
+</output></test><test name="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU(result: &quot;pass_1&quot;, exampleTags: System.String[])" type="Pickles.TestHarness.xunit.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithGermanUmlautsAouBAOU" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Scenarios With Special Characters" /><trait name="Description" value="This is a scenario outline with german umlauts äöüß ÄÖÜ" /></traits><output>Given the calculator has clean memory
+-&gt; done: AdditionSteps.GivenTheCalculatorHasCleanMemory() (0.0s)
+Then the scenario will 'pass_1'
+-&gt; done: ScenarioOutlineSteps.ThenTheScenarioWill("pass_1") (0.0s)
+</output></test></class><class time="0.006" name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" total="3" passed="1" failed="2" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" result="Fail" time="0.004"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Failing Scenario" /></traits><output>Then failing step
 -&gt; error: 
     true
         should be
@@ -574,26 +574,26 @@ Then the scenario will 'pass_1'
         but was
     True</message><stack-trace>   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan&amp; duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Failing.feature:line 10</stack-trace></failure></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" result="Fail" time="0.002"><traits><trait name="FeatureTitle" value="Failing" /><trait name="Description" value="Failing Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit\Minimal Features\Failing.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Failing.feature:line 7</stack-trace></failure></test></class><class time="0.002" name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" total="2" passed="1" failed="1" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
 </output></test><test name="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" result="Fail" time="0.001"><traits><trait name="FeatureTitle" value="Inconclusive" /><trait name="Description" value="Inconclusive Feature Inconclusive Scenario" /></traits><output>Then inconclusive step
 -&gt; pending: MinimalSteps.ThenInconclusiveStep()
 </output><failure exception-type="TechTalk.SpecFlow.SpecFlowException"><message>TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.
   MinimalSteps.ThenInconclusiveStep()</message><stack-trace>   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.000" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.000"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
--&gt; done: MinimalSteps.ThenPassingStep() (0,0s)
+   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.xunit.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit\Minimal Features\Inconclusive.feature:line 7</stack-trace></failure></test></class><class time="0.001" name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" total="1" passed="1" failed="0" skipped="0"><test name="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" result="Pass" time="0.001"><traits><trait name="FeatureTitle" value="Passing" /><trait name="Description" value="Passing Feature Passing Scenario" /></traits><output>Then passing step
+-&gt; done: MinimalSteps.ThenPassingStep() (0.0s)
 </output></test></class></assembly>

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/XUnit/XUnit2/results-example-xunit2.xml
@@ -1,155 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <assemblies>
-  <assembly name="C:\DevProjects\Tools\pickles\test-harness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2016-09-28" run-time="09:33:40" config-file="C:\DevProjects\Tools\pickles\test-harness\xunit2\bin\Debug\xunit2Harness.dll.config" total="45" passed="27" failed="17" skipped="1" time="1.054" errors="0">
+  <assembly name="C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\bin\Debug\xunit2Harness.DLL" environment="64-bit .NET 4.0.30319.42000 [collection-per-class, non-parallel]" test-framework="xUnit.net 2.1.0.3179" run-date="2017-02-02" run-time="21:43:35" config-file="C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\bin\Debug\xunit2Harness.dll.config" total="45" passed="27" failed="17" skipped="1" time="1.617" errors="0">
     <errors />
-    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.002">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0006666" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0015844" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Inconclusive" />
-          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="9" passed="9" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" time="0.008">
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" time="0.0010171" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" time="0.0014659" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;**&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0013383" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;++&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0006313" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;.*&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.000592" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;[]&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0007163" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;{}&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0005019" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;()&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0005888" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0008825" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
-          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
-        </traits>
-      </test>
-    </collection>
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.021">
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0135057" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing Background" />
-          <trait name="Description" value="Adding several numbers" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0037641" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing Background" />
-          <trait name="Description" value="Adding several numbers" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.003636" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Failing Background" />
-          <trait name="Description" value="Add two numbers" />
-        </traits>
-        <failure exception-type="Shouldly.ChuckedAWobbly">
-          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
-          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
-   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
-   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit2\FailingBackground.feature:line 12]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.001">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0007925" result="Pass">
-        <traits>
-          <trait name="FeatureTitle" value="Passing" />
-          <trait name="Description" value="Passing Feature Passing Scenario" />
-        </traits>
-      </test>
-    </collection>
-    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.230">
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0842995" result="Pass">
+    <collection total="3" passed="1" failed="2" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" time="0.065">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeaturePassingScenario" time="0.0062757" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Passing Scenario" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.1413118" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureFailingScenario" time="0.0514799" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Failing Scenario" />
@@ -158,16 +18,16 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
+   at AutomationLayer.MinimalFeatures.MinimalSteps.ThenFailingStep() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\MinimalFeatures\MinimalSteps.cs:line 24
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureFailingScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Failing.feature:line 10]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.004062" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature" method="FailingFeatureInconclusiveScenario" time="0.0069261" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Failing" />
           <trait name="Description" value="Failing Feature Inconclusive Scenario" />
@@ -175,25 +35,94 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\DevProjects\Tools\pickles\test-harness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Failing.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.FailingFeature.FailingFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Failing.feature:line 7]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.015">
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0044315" result="Pass">
+    <collection total="2" passed="1" failed="1" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" time="0.004">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeaturePassingScenario" time="0.0029935" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Passing Scenario" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature" method="InconclusiveFeatureInconclusiveScenario" time="0.0013727" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Inconclusive" />
+          <trait name="Description" value="Inconclusive Feature Inconclusive Scenario" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  MinimalSteps.ThenInconclusiveStep()]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Inconclusive.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.MinimalFeatures.InconclusiveFeature.InconclusiveFeatureInconclusiveScenario() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Minimal Features\Inconclusive.feature:line 7]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.031">
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.0119514" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 2" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0084371" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 3" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0103512" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Not Automated At All" />
+          <trait name="Description" value="Not automated scenario 1" />
+        </traits>
+        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
+          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
+          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
+        </failure>
+      </test>
+    </collection>
+    <collection total="1" passed="1" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" time="0.001">
+      <test name="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature.PassingFeaturePassingScenario" type="Pickles.TestHarness.xunit2.MinimalFeatures.PassingFeature" method="PassingFeaturePassingScenario" time="0.0007449" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Passing" />
+          <trait name="Description" value="Passing Feature Passing Scenario" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="6" passed="3" failed="2" skipped="1" name="Test collection for Pickles.TestHarness.xunit2.AdditionFeature" time="0.603">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.4001866" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0009193" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddingSeveralNumbers" time="0.0027924" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Adding several numbers" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.0047779" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="NotAutomatedAddingTwoNumbers" time="0.1936092" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Not automated adding two numbers" />
@@ -202,11 +131,11 @@
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit2\Addition.feature:line 46]]></stack-trace>
+   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.AdditionFeature.NotAutomatedAddingTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Addition.feature:line 46]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0018984" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="AddTwoNumbers" time="0.0023161" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Add two numbers" />
@@ -219,7 +148,7 @@
         </traits>
         <reason><![CDATA[Ignored]]></reason>
       </test>
-      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0034442" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers" type="Pickles.TestHarness.xunit2.AdditionFeature" method="FailToAddTwoNumbers" time="0.0040548" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Addition" />
           <trait name="Description" value="Fail to add two numbers" />
@@ -236,84 +165,43 @@
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.GetExecuteArguments(BindingMatch match)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in C:\DevProjects\Tools\pickles\test-harness\xunit2\Addition.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.xunit2.AdditionFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Addition.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.AdditionFeature.FailToAddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\Addition.feature:line 34]]></stack-trace>
         </failure>
       </test>
     </collection>
-    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" time="0.187">
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario2" time="0.1700003" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 2" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario2() in C:\DevProjects\Tools\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 14]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario3" time="0.0067657" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 3" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario3() in C:\DevProjects\Tools\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 19]]></stack-trace>
-        </failure>
-      </test>
-      <test name="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1" type="Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature" method="NotAutomatedScenario1" time="0.0100018" result="Fail">
-        <traits>
-          <trait name="FeatureTitle" value="Not Automated At All" />
-          <trait name="Description" value="Not automated scenario 1" />
-        </traits>
-        <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
-          <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: No matching step definition found for one or more steps.\r\nusing System;\r\nusing TechTalk.SpecFlow;\r\n\r\nnamespace MyNamespace\r\n{\r\n    [Binding]\r\n    public class StepDefinitions\r\n    {\r\n        [Given(@"unimplemented step")]\r\n        public void GivenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [When(@"unimplemented step")]\r\n        public void WhenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n        \r\n        [Then(@"unimplemented step")]\r\n        public void ThenUnimplementedStep()\r\n        {\r\n            ScenarioContext.Current.Pending();\r\n        }\r\n    }\r\n}\r\n]]></message>
-          <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.NotAutomatedAtAllFeature.NotAutomatedScenario1() in C:\DevProjects\Tools\pickles\test-harness\xunit2\NotAutomatedAtAll.feature:line 9]]></stack-trace>
-        </failure>
-      </test>
-    </collection>
-    <collection total="18" passed="12" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.024">
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0032672" result="Pass">
+    <collection total="18" passed="12" failed="6" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" time="0.029">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0012191" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where all scenarios pass" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0003494" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0001897" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where all scenarios pass" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0003625" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereAllScenariosPass(result: &quot;pass_3&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereAllScenariosPass" time="0.0001478" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where all scenarios pass" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003707" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0003724" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario fails" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.000227" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.000102" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario fails" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0052905" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioFails" time="0.0027997" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario fails" />
@@ -322,34 +210,34 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioFails(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 34]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(value1: &quot;Please enter a valid two letter country code (e.g.&quot;..., value2: &quot;This is just a very very very veery long error mes&quot;..., exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithOverlongExampleValues" time="0.0016517" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithOverlongExampleValues(value1: &quot;Please enter a valid two letter country code (e.g.&quot;..., value2: &quot;This is just a very very very veery long error mes&quot;..., exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithOverlongExampleValues" time="0.0042551" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="Deal correctly with overlong example values" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0005558" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0006152" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.000265" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0003163" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0015565" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive" time="0.0016557" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="This is a scenario outline where one scenario is inconclusive" />
@@ -357,23 +245,23 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ThisIsAScenarioOutlineWhereOneScenarioIsInconclusive(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 21]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0006858" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0005772" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0002764" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;pass_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0034891" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0015648" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0016356" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
@@ -381,11 +269,11 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_1")]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0014079" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;inconclusive_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0010959" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
@@ -393,11 +281,11 @@
         <failure exception-type="TechTalk.SpecFlow.SpecFlowException">
           <message><![CDATA[TechTalk.SpecFlow.SpecFlowException : Test pending: One or more step definitions are not implemented yet.\r\n  ScenarioOutlineSteps.ThenTheScenarioWill("inconclusive_2")]]></message>
           <stack-trace><![CDATA[   at TechTalk.SpecFlow.UnitTestProvider.XUnitRuntimeProvider.TestPending(String message)
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0019759" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0018196" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
@@ -406,16 +294,16 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0019827" result="Fail">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(result: &quot;fail_2&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="AndWeCanGoTotallyBonkersWithMultipleExampleSections_" time="0.0023374" result="Fail">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="And we can go totally bonkers with multiple example sections." />
@@ -424,26 +312,138 @@
           <message><![CDATA[Shouldly.ChuckedAWobbly : \n    true\n        should be\n    False\n        but was\n    True]]></message>
           <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
    at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
-   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\DevProjects\Tools\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
+   at AutomationLayer.ScenarioOutlineSteps.ThenTheScenarioWill(String result) in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\ScenarioOutlineSteps.cs:line 21
    at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
    at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup()
-   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\DevProjects\Tools\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.AndWeCanGoTotallyBonkersWithMultipleExampleSections_(String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\ScenarioOutlines.feature:line 45]]></stack-trace>
         </failure>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0010647" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithParenthesisInTheExamples(description: &quot;This is a description (and more)&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithParenthesisInTheExamples" time="0.0051226" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="Deal correctly with parenthesis in the examples" />
         </traits>
       </test>
-      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0009096" result="Pass">
+      <test name="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature.DealCorrectlyWithBackslashesInTheExamples(filePath: &quot;c:\Temp\&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenarioOutlinesFeature" method="DealCorrectlyWithBackslashesInTheExamples" time="0.0009386" result="Pass">
         <traits>
           <trait name="FeatureTitle" value="Scenario Outlines" />
           <trait name="Description" value="Deal correctly with backslashes in the examples" />
         </traits>
+      </test>
+    </collection>
+    <collection total="9" passed="9" failed="0" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" time="0.011">
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40(result: &quot;pass_1&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioOutlineWithParenthesesHyphenAndComma10_2030_40" time="0.0036644" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This is a scenario outline with parentheses, hyphen and comma (10-20, 30-40)" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisIsAScenarioWithParenthesesHyphenAndComma10_2030_40" time="0.0009116" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This is a scenario with parentheses, hyphen and comma (10-20, 30-40)" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;**&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0041725" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;++&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0003501" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;.*&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0003852" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;[]&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0003509" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;{}&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0003394" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;()&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0002684" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature.ThisScenarioContainsExamplesWithRegex_SpecialCharacters(regex: &quot;^.*(?&lt;foo&gt;BAR)\s[^0-9]{3,4}A+$&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.ScenariosWithSpecialCharactersFeature" method="ThisScenarioContainsExamplesWithRegex_SpecialCharacters" time="0.0003047" result="Pass">
+        <traits>
+          <trait name="FeatureTitle" value="Scenarios With Special Characters" />
+          <trait name="Description" value="This scenario contains examples with Regex-special characters" />
+        </traits>
+      </test>
+    </collection>
+    <collection total="3" passed="0" failed="3" skipped="0" name="Test collection for Pickles.TestHarness.xunit2.FailingBackgroundFeature" time="0.015">
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;60&quot;, secondNumber: &quot;70&quot;, thirdNumber: &quot;130&quot;, result: &quot;260&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0092747" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing Background" />
+          <trait name="Description" value="Adding several numbers" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(firstNumber: &quot;40&quot;, secondNumber: &quot;50&quot;, thirdNumber: &quot;90&quot;, result: &quot;180&quot;, exampleTags: [])" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddingSeveralNumbers" time="0.0029464" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing Background" />
+          <trait name="Description" value="Adding several numbers" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddingSeveralNumbers(String firstNumber, String secondNumber, String thirdNumber, String result, String[] exampleTags) in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature:line 19]]></stack-trace>
+        </failure>
+      </test>
+      <test name="Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers" type="Pickles.TestHarness.xunit2.FailingBackgroundFeature" method="AddTwoNumbers" time="0.0032509" result="Fail">
+        <traits>
+          <trait name="FeatureTitle" value="Failing Background" />
+          <trait name="Description" value="Add two numbers" />
+        </traits>
+        <failure exception-type="Shouldly.ChuckedAWobbly">
+          <message><![CDATA[Shouldly.ChuckedAWobbly : \n    1\n        should be\n    2\n        but was\n    1]]></message>
+          <stack-trace><![CDATA[   at Shouldly.ShouldlyCoreExtensions.AssertAwesomely[T](T actual, Func`2 specifiedConstraint, Object originalActual, Object originalExpected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldlyCoreExtensions.cs:line 18
+   at Shouldly.ShouldBeTestExtensions.ShouldBe[T](T actual, T expected) in c:\TeamCity\buildAgent\work\10efaabfa8adbd4e\src\Shouldly\ShouldBeTestExtensions.cs:line 17
+   at AutomationLayer.AdditionSteps.GivenTheBackgroundStepFails() in C:\Users\Bas\Source\Repos\pickles\test-harness\AutomationLayer\AdditionSteps.cs:line 25
+   at TechTalk.SpecFlow.Bindings.BindingInvoker.InvokeBinding(IBinding binding, IContextManager contextManager, Object[] arguments, ITestTracer testTracer, TimeSpan& duration)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStepMatch(BindingMatch match, Object[] arguments)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.ExecuteStep(StepInstance stepInstance)
+   at TechTalk.SpecFlow.Infrastructure.TestExecutionEngine.OnAfterLastStep()
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.ScenarioCleanup() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature.cs:line 0
+   at Pickles.TestHarness.xunit2.FailingBackgroundFeature.AddTwoNumbers() in C:\Users\Bas\Source\Repos\pickles\test-harness\xunit2\FailingBackground.feature:line 12]]></stack-trace>
+        </failure>
       </test>
     </collection>
   </assembly>

--- a/src/Pickles/Pickles/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentParser.cs
@@ -26,6 +26,7 @@ using System.Reflection;
 using NDesk.Options;
 
 using TextWriter = System.IO.TextWriter;
+using PicklesDoc.Pickles.Extensions;
 
 namespace PicklesDoc.Pickles
 {
@@ -118,8 +119,9 @@ namespace PicklesDoc.Pickles
             if (!string.IsNullOrEmpty(this.testResultsFile))
             {
                 var files = this.testResultsFile.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-
-                configuration.AddTestResultFiles(files.Select(f => this.fileSystem.FileInfo.FromFileName(f)));
+                configuration.AddTestResultFiles(files
+                    .SelectMany(f => PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(f, this.fileSystem))
+                    .Select(f => this.fileSystem.FileInfo.FromFileName(f)));
             }
 
             if (!string.IsNullOrEmpty(this.systemUnderTestName))

--- a/src/Pickles/Pickles/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentParser.cs
@@ -118,8 +118,10 @@ namespace PicklesDoc.Pickles
 
             if (!string.IsNullOrEmpty(this.testResultsFile))
             {
-                configuration.AddTestResultFiles(
-                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.testResultsFile, this.fileSystem));
+                var files = this.testResultsFile.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                configuration.AddTestResultFiles(files
+                    .SelectMany(f => PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(f, this.fileSystem))
+                    .Select(f => this.fileSystem.FileInfo.FromFileName(f)));
             }
 
             if (!string.IsNullOrEmpty(this.systemUnderTestName))

--- a/src/Pickles/Pickles/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentParser.cs
@@ -118,10 +118,8 @@ namespace PicklesDoc.Pickles
 
             if (!string.IsNullOrEmpty(this.testResultsFile))
             {
-                var files = this.testResultsFile.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-                configuration.AddTestResultFiles(files
-                    .SelectMany(f => PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalWildCards(f, this.fileSystem))
-                    .Select(f => this.fileSystem.FileInfo.FromFileName(f)));
+                configuration.AddTestResultFiles(
+                    PathExtensions.GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(this.testResultsFile, this.fileSystem));
             }
 
             if (!string.IsNullOrEmpty(this.systemUnderTestName))

--- a/src/Pickles/Pickles/Extensions/PathExtensions.cs
+++ b/src/Pickles/Pickles/Extensions/PathExtensions.cs
@@ -19,7 +19,9 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO.Abstractions;
+using System.Linq;
 
 namespace PicklesDoc.Pickles.Extensions
 {
@@ -78,12 +80,21 @@ namespace PicklesDoc.Pickles.Extensions
             return MakeRelativePath(from.FullName, to.FullName, fileSystem);
         }
 
-        public static string[] GetAllFilesFromPathAndFileNameWithOptionalWildCards(string fileFullName, IFileSystem fileSystem)
+        private static string[] GetAllFilesFromPathAndFileNameWithOptionalWildCards(string fileFullName, IFileSystem fileSystem)
         {
             var path = fileSystem.Path.GetDirectoryName(fileFullName);
             var wildcardFileName = fileSystem.Path.GetFileName(fileFullName);
-            return fileSystem.Directory.GetFiles(path, wildcardFileName);
+            // GetFiles returns an array with 1 empty string when wildcard match is not found.
+            return fileSystem.Directory.GetFiles(path, wildcardFileName).Where(x => !string.IsNullOrEmpty(x)).ToArray();
         }
 
+        public static IEnumerable<FileInfoBase> GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(string fileFullName, IFileSystem fileSystem)
+        {
+            var files = fileFullName.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            return files.SelectMany(f => GetAllFilesFromPathAndFileNameWithOptionalWildCards(f, fileSystem))
+                    .Distinct()
+                    .Select(f => fileSystem.FileInfo.FromFileName(f));
+        }
+        
     }
 }

--- a/src/Pickles/Pickles/Extensions/PathExtensions.cs
+++ b/src/Pickles/Pickles/Extensions/PathExtensions.cs
@@ -77,5 +77,13 @@ namespace PicklesDoc.Pickles.Extensions
 
             return MakeRelativePath(from.FullName, to.FullName, fileSystem);
         }
+
+        public static string[] GetAllFilesFromPathAndFileNameWithOptionalWildCards(string fileFullName, IFileSystem fileSystem)
+        {
+            var path = fileSystem.Path.GetDirectoryName(fileFullName);
+            var wildcardFileName = fileSystem.Path.GetFileName(fileFullName);
+            return fileSystem.Directory.GetFiles(path, wildcardFileName);
+        }
+
     }
 }

--- a/src/Pickles/Pickles/Extensions/PathExtensions.cs
+++ b/src/Pickles/Pickles/Extensions/PathExtensions.cs
@@ -19,9 +19,7 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.IO.Abstractions;
-using System.Linq;
 
 namespace PicklesDoc.Pickles.Extensions
 {
@@ -80,21 +78,12 @@ namespace PicklesDoc.Pickles.Extensions
             return MakeRelativePath(from.FullName, to.FullName, fileSystem);
         }
 
-        private static string[] GetAllFilesFromPathAndFileNameWithOptionalWildCards(string fileFullName, IFileSystem fileSystem)
+        public static string[] GetAllFilesFromPathAndFileNameWithOptionalWildCards(string fileFullName, IFileSystem fileSystem)
         {
             var path = fileSystem.Path.GetDirectoryName(fileFullName);
             var wildcardFileName = fileSystem.Path.GetFileName(fileFullName);
-            // GetFiles returns an array with 1 empty string when wildcard match is not found.
-            return fileSystem.Directory.GetFiles(path, wildcardFileName).Where(x => !string.IsNullOrEmpty(x)).ToArray();
+            return fileSystem.Directory.GetFiles(path, wildcardFileName);
         }
 
-        public static IEnumerable<FileInfoBase> GetAllFilesFromPathAndFileNameWithOptionalSemicolonsAndWildCards(string fileFullName, IFileSystem fileSystem)
-        {
-            var files = fileFullName.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-            return files.SelectMany(f => GetAllFilesFromPathAndFileNameWithOptionalWildCards(f, fileSystem))
-                    .Distinct()
-                    .Select(f => fileSystem.FileInfo.FromFileName(f));
-        }
-        
     }
 }


### PR DESCRIPTION
Wildcards can be used for testresult files like: 
C:\results\*.trx 
or 
C:\runs\Acceptance*.xml;C:\dev\unit*.xml

Works in combination with semicolon.
Multiple files are selected as wildcard matches more than one files.

All tests pass, new tests added.
Commandline use tested in the wild.

Code is implemented for commandline, powershell, msbuild and for future use in UI*. All other behaviour in these configs is kept the same (like: semicolon use is only implemented for commandline).

\* UI does a check on the existing of the file before the GENERATE button becomes enabled. This does not work wild wild cards.

Known Limitations: 
- does not work when path is empty
- unknown if relative paths are supported
- breaks when path does not exist

Above limited behaviour is not described or tested in the master version, please advice.