### PR TITLE
Feature/add ignore tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.DS_Store
 
 #Visual Studio files
+.vs
 *.[Oo]bj
 *.user
 *.aps

--- a/src/Pickles/Pickles.MSBuild/Pickles.cs
+++ b/src/Pickles/Pickles.MSBuild/Pickles.cs
@@ -51,6 +51,8 @@ namespace PicklesDoc.Pickles.MSBuild
 
         public string EnableComments { get; set; }
 
+        public string IgnoreTag { get; set; }
+
         public override bool Execute()
         {
             try
@@ -112,6 +114,11 @@ namespace PicklesDoc.Pickles.MSBuild
             if (!string.IsNullOrEmpty(this.DocumentationFormat))
             {
                 configuration.DocumentationFormat = (DocumentationFormat)Enum.Parse(typeof(DocumentationFormat), this.DocumentationFormat, true);
+            }
+            
+            if (!string.IsNullOrEmpty(this.IgnoreTag))
+            {
+                configuration.IgnoreTag = this.IgnoreTag;
             }
 
             bool shouldEnableExperimentalFeatures;

--- a/src/Pickles/Pickles.MSBuild/Pickles.cs
+++ b/src/Pickles/Pickles.MSBuild/Pickles.cs
@@ -51,7 +51,7 @@ namespace PicklesDoc.Pickles.MSBuild
 
         public string EnableComments { get; set; }
 
-        public string IgnoreTag { get; set; }
+        public string ExcludeTags { get; set; }
 
         public override bool Execute()
         {
@@ -116,9 +116,9 @@ namespace PicklesDoc.Pickles.MSBuild
                 configuration.DocumentationFormat = (DocumentationFormat)Enum.Parse(typeof(DocumentationFormat), this.DocumentationFormat, true);
             }
             
-            if (!string.IsNullOrEmpty(this.IgnoreTag))
+            if (!string.IsNullOrEmpty(this.ExcludeTags))
             {
-                configuration.IgnoreTag = this.IgnoreTag;
+                configuration.ExcludeTags = this.ExcludeTags;
             }
 
             bool shouldEnableExperimentalFeatures;

--- a/src/Pickles/Pickles.ObjectModel/IConfiguration.cs
+++ b/src/Pickles/Pickles.ObjectModel/IConfiguration.cs
@@ -47,7 +47,7 @@ namespace PicklesDoc.Pickles
 
         bool ShouldIncludeExperimentalFeatures { get; }
 
-        string IgnoreTag { get; set; }
+        string ExcludeTags { get; set; }
 
         void AddTestResultFile(FileInfoBase fileInfoBase);
 

--- a/src/Pickles/Pickles.ObjectModel/IConfiguration.cs
+++ b/src/Pickles/Pickles.ObjectModel/IConfiguration.cs
@@ -47,6 +47,8 @@ namespace PicklesDoc.Pickles
 
         bool ShouldIncludeExperimentalFeatures { get; }
 
+        string IgnoreTag { get; set; }
+
         void AddTestResultFile(FileInfoBase fileInfoBase);
 
         void AddTestResultFiles(IEnumerable<FileInfoBase> fileInfoBases);

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -61,6 +61,9 @@ namespace PicklesDoc.Pickles.PowerShell
         [Parameter(HelpMessage = CommandLineArgumentParser.HelpEnableComments, Mandatory = false)]
         public string EnableComments { get; set; }
 
+        [Parameter(HelpMessage = CommandLineArgumentParser.HelpIgnoreTag, Mandatory = false)]
+        public string IgnoreTag { get; set; }
+
         protected override void ProcessRecord()
         {
             var builder = new ContainerBuilder();
@@ -118,6 +121,11 @@ namespace PicklesDoc.Pickles.PowerShell
             if (this.IncludeExperimentalFeatures.IsPresent)
             {
                 configuration.EnableExperimentalFeatures();
+            }
+
+            if (!string.IsNullOrEmpty(this.IgnoreTag))
+            {
+                configuration.IgnoreTag = this.IgnoreTag;
             }
 
             bool shouldEnableComments;

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -61,8 +61,8 @@ namespace PicklesDoc.Pickles.PowerShell
         [Parameter(HelpMessage = CommandLineArgumentParser.HelpEnableComments, Mandatory = false)]
         public string EnableComments { get; set; }
 
-        [Parameter(HelpMessage = CommandLineArgumentParser.HelpIgnoreTag, Mandatory = false)]
-        public string IgnoreTag { get; set; }
+        [Parameter(HelpMessage = CommandLineArgumentParser.HelpExcludeTags, Mandatory = false)]
+        public string ExcludeTags { get; set; }
 
         protected override void ProcessRecord()
         {
@@ -123,9 +123,9 @@ namespace PicklesDoc.Pickles.PowerShell
                 configuration.EnableExperimentalFeatures();
             }
 
-            if (!string.IsNullOrEmpty(this.IgnoreTag))
+            if (!string.IsNullOrEmpty(this.ExcludeTags))
             {
-                configuration.IgnoreTag = this.IgnoreTag;
+                configuration.ExcludeTags = this.ExcludeTags;
             }
 
             bool shouldEnableComments;

--- a/src/Pickles/Pickles.Test/BaseFixture.cs
+++ b/src/Pickles/Pickles.Test/BaseFixture.cs
@@ -44,7 +44,7 @@ namespace PicklesDoc.Pickles.Test
                 {
                     var builder = new ContainerBuilder();
 
-                    var configuration = new Configuration() { ExcludeTags = "ignore-tag" };
+                    var configuration = new Configuration() { ExcludeTags = "exclude-tag" };
                     builder.RegisterAssemblyTypes(typeof(Runner).Assembly);
                     builder.Register<MockFileSystem>(_ => CreateMockFileSystem()).As<IFileSystem>().SingleInstance();
                     builder.RegisterModule<PicklesModule>();

--- a/src/Pickles/Pickles.Test/BaseFixture.cs
+++ b/src/Pickles/Pickles.Test/BaseFixture.cs
@@ -43,9 +43,12 @@ namespace PicklesDoc.Pickles.Test
                 if (this.container == null)
                 {
                     var builder = new ContainerBuilder();
+
+                    var configuration = new Configuration() { ExcludeTags = "ignore-tag" };
                     builder.RegisterAssemblyTypes(typeof(Runner).Assembly);
                     builder.Register<MockFileSystem>(_ => CreateMockFileSystem()).As<IFileSystem>().SingleInstance();
                     builder.RegisterModule<PicklesModule>();
+                    builder.RegisterInstance(configuration).As<IConfiguration>().SingleInstance();
                     this.container = builder.Build();
                 }
 
@@ -88,7 +91,7 @@ namespace PicklesDoc.Pickles.Test
             this.AddFakeFolderAndFiles("AcceptanceTest", new[] { "AdvancedFeature.feature", "LevelOne.feature" });
             this.AddFakeFolderAndFiles("EmptyFolderTests", new string[0]);
 
-            this.AddFakeFolderAndFiles("FeatureCrawlerTests", new[] { "index.md", "LevelOne.feature", "image.png" });
+            this.AddFakeFolderAndFiles("FeatureCrawlerTests", new[] { "index.md", "LevelOne.feature", "image.png", "LevelOneIgnoredFeature.feature" });
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne", new[] { "ignorethisfile.ignore", "LevelOneSublevelOne.feature", "LevelOneSublevelTwo.feature" });
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne\SubLevelTwo", new[] { "LevelOneSublevelOneSubLevelTwo.feature" });
             this.AddFakeFolderAndFiles(@"FeatureCrawlerTests\SubLevelOne\SubLevelTwo\IgnoreThisDirectory", new[] { "IgnoreThisFile.ignore" });

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/FeatureCrawlerTests/LevelOneIgnoredFeature.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/FeatureCrawlerTests/LevelOneIgnoredFeature.feature
@@ -1,4 +1,4 @@
-﻿@ignore-tag
+﻿@exclude-tag
 Feature: Addition
 	In order to avoid silly mistakes
 	As a math idiot

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/FeatureCrawlerTests/LevelOneIgnoredFeature.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/FeatureCrawlerTests/LevelOneIgnoredFeature.feature
@@ -1,0 +1,12 @@
+﻿@ignore-tag
+Feature: Addition
+	In order to avoid silly mistakes
+	As a math idiot
+	I want to be told the sum of two numbers
+
+@mytag
+Scenario: Add two numbers
+	Given I have entered 50 into the calculator
+	And I have entered 70 into the calculator
+	When I press add
+	Then the result should be 120 on the screen

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -216,6 +216,7 @@
     <EmbeddedResource Include="FakeFolderStructures\OrderingTests\B\b-b.feature">
       <LastGenOutput>a-b.feature.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\FeatureCrawlerTests\LevelOneIgnoredFeature.feature" />
     <None Include="Resources\test.jpg" />
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -489,17 +489,16 @@ namespace PicklesDoc.Pickles.Test
         }
 
         [Test]
-        public void ThenCanParseIgnoreTagSuccessfully()
+        public void ThenCanParseExcludeTagsSuccessfully()
         {
-            var ignoreTag = "ignore-tag";
-            var args = new[] { $@"-ignoreTag={ignoreTag}" };
+            var args = new[] { @"-excludeTags=ignore-tag" };
 
             var configuration = new Configuration();
             var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
             bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
 
             Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.IgnoreTag).IsEqualTo(ignoreTag);
+            Check.That(configuration.ExcludeTags).IsEqualTo("ignore-tag");
         }
     }
 }

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -491,14 +491,14 @@ namespace PicklesDoc.Pickles.Test
         [Test]
         public void ThenCanParseExcludeTagsSuccessfully()
         {
-            var args = new[] { @"-excludeTags=ignore-tag" };
+            var args = new[] { @"-excludeTags=exclude-tag" };
 
             var configuration = new Configuration();
             var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
             bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
 
             Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.ExcludeTags).IsEqualTo("ignore-tag");
+            Check.That(configuration.ExcludeTags).IsEqualTo("exclude-tag");
         }
     }
 }

--- a/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingCommandLineArguments.cs
@@ -487,5 +487,19 @@ namespace PicklesDoc.Pickles.Test
 
             Check.That(configuration.Language).IsEqualTo("en");
         }
+
+        [Test]
+        public void ThenCanParseIgnoreTagSuccessfully()
+        {
+            var ignoreTag = "ignore-tag";
+            var args = new[] { $@"-ignoreTag={ignoreTag}" };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.IgnoreTag).IsEqualTo(ignoreTag);
+        }
     }
 }

--- a/src/Pickles/Pickles.Test/WhenParsingFeatureFiles.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingFeatureFiles.cs
@@ -21,6 +21,7 @@
 using System.Linq;
 
 using Autofac;
+using DocumentFormat.OpenXml.Bibliography;
 using NFluent;
 using NUnit.Framework;
 using PicklesDoc.Pickles.Extensions;
@@ -400,7 +401,7 @@ Feature: Test
         {
             var featureText =
                 @"# ignore this comment
-@feature-tag @ignore-tag
+@feature-tag @exclude-tag
 Feature: Test
     In order to do something
     As a user
@@ -434,7 +435,7 @@ Feature: Test
     When it runs
     Then I should see that this thing happens
 
-    @scenario-tag-1 @scenario-tag-2 @ignore-tag
+    @scenario-tag-1 @scenario-tag-2 @exclude-tag
   Scenario: B scenario
     Given some feature
     When it runs
@@ -466,14 +467,51 @@ Feature: Test
     As a user
     I want to run this scenario
 
-    @scenario-tag-1 @scenario-tag-2 @Ignore-Tag
+    @scenario-tag-1 @scenario-tag-2 @Exclude-Tag
   Scenario: A scenario
     Given some feature
     When it runs
     Then I should see that this thing happens
 
-    @scenario-tag-1 @scenario-tag-2 @ignore-tag
+    @scenario-tag-1 @scenario-tag-2 @exclude-tag
   Scenario: B scenario
+    Given some feature
+    When it runs
+    Then I should see that this thing happens";
+
+            var parser = Container.Resolve<FeatureParser>();
+            var feature = parser.Parse(new StringReader(featureText));
+
+            Check.That(feature).IsNotNull();
+            Check.That(feature.FeatureElements).IsEmpty();
+        }
+
+        [Test]
+        public void Then_can_parse_and_ignore_with_with_tag_without_sensitivity()
+        {
+
+            var featureText =
+                @"# ignore this comment
+@feature-tag
+Feature: Test
+    In order to do something
+    As a user
+    I want to run this scenario
+
+    @scenario-tag-1 @scenario-tag-2 @Exclude-Tag
+  Scenario: A scenario
+    Given some feature
+    When it runs
+    Then I should see that this thing happens
+
+    @scenario-tag-1 @scenario-tag-2 @exclude-tag
+  Scenario: B scenario
+    Given some feature
+    When it runs
+    Then I should see that this thing happens
+
+    @scenario-tag-1 @scenario-tag-2 @ExClUdE-tAg
+  Scenario: C scenario
     Given some feature
     When it runs
     Then I should see that this thing happens";

--- a/src/Pickles/Pickles.Test/WhenParsingFeatureFiles.cs
+++ b/src/Pickles/Pickles.Test/WhenParsingFeatureFiles.cs
@@ -18,8 +18,6 @@
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.IO.Abstractions;
 using System.Linq;
 
 using Autofac;
@@ -400,10 +398,9 @@ Feature: Test
         [Test]
         public void Then_can_parse_and_ignore_feature_with_tag_in_configuration_ignore_tag()
         {
-            var ignoreTag = "ignore-tag";
-            string featureText =
-                $@"# ignore this comment
-@feature-tag @{ignoreTag}
+            var featureText =
+                @"# ignore this comment
+@feature-tag @ignore-tag
 Feature: Test
     In order to do something
     As a user
@@ -415,18 +412,16 @@ Feature: Test
     When it runs
     Then I should see that this thing happens";
 
-            var parser = new FeatureParser(Container.Resolve<IFileSystem>(), new Configuration { IgnoreTag = ignoreTag });
+            var parser = Container.Resolve<FeatureParser>();
             var feature = parser.Parse(new StringReader(featureText));
-
             Check.That(feature).IsNull();
         }
 
         [Test]
         public void Then_can_parse_and_ignore_scenario_with_tag_in_configuration_ignore_tag()
         {
-            var ignoreTag = "ignore-tag";
-            string featureText =
-                $@"# ignore this comment
+            var featureText =
+                @"# ignore this comment
 @feature-tag
 Feature: Test
     In order to do something
@@ -439,7 +434,7 @@ Feature: Test
     When it runs
     Then I should see that this thing happens
 
-    @scenario-tag-1 @scenario-tag-2 @{ignoreTag}
+    @scenario-tag-1 @scenario-tag-2 @ignore-tag
   Scenario: B scenario
     Given some feature
     When it runs
@@ -450,8 +445,8 @@ Feature: Test
     Given some feature
     When it runs
     Then I should see that this thing happens";
-
-            var parser = new FeatureParser(Container.Resolve<IFileSystem>(), new Configuration { IgnoreTag = ignoreTag });
+ 
+            var parser = Container.Resolve<FeatureParser>();
             var feature = parser.Parse(new StringReader(featureText));
 
             Check.That(feature.FeatureElements.Count).IsEqualTo(2);
@@ -463,28 +458,27 @@ Feature: Test
         [Test]
         public void Then_can_parse_and_ignore_scenario_with_tag_in_configuration_ignore_tag_and_keep_feature()
         {
-            var ignoreTag = "ignore-tag";
-            string featureText =
-                $@"# ignore this comment
+            var featureText =
+                @"# ignore this comment
 @feature-tag
 Feature: Test
     In order to do something
     As a user
     I want to run this scenario
 
-    @scenario-tag-1 @scenario-tag-2 @{ignoreTag}
+    @scenario-tag-1 @scenario-tag-2 @Ignore-Tag
   Scenario: A scenario
     Given some feature
     When it runs
     Then I should see that this thing happens
 
-    @scenario-tag-1 @scenario-tag-2 @{ignoreTag}
+    @scenario-tag-1 @scenario-tag-2 @ignore-tag
   Scenario: B scenario
     Given some feature
     When it runs
     Then I should see that this thing happens";
 
-            var parser = new FeatureParser(Container.Resolve<IFileSystem>(), new Configuration { IgnoreTag = ignoreTag });
+            var parser = Container.Resolve<FeatureParser>();
             var feature = parser.Parse(new StringReader(featureText));
 
             Check.That(feature).IsNotNull();

--- a/src/Pickles/Pickles.UserInterface/MainWindow.xaml
+++ b/src/Pickles/Pickles.UserInterface/MainWindow.xaml
@@ -3,117 +3,121 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:mahapps="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
                      xmlns:nlogViewer="clr-namespace:NlogViewer;assembly=NlogViewer"
-                     Title="Pickles" Height="700" Width="800" Loaded="MetroWindow_Loaded" Closed="MetroWindow_Closed"  DataContextChanged="MainWindow_OnDataContextChanged"
+                     Title="Pickles" Height="700" Width="1000" Loaded="MetroWindow_Loaded" Closed="MetroWindow_Closed"  DataContextChanged="MainWindow_OnDataContextChanged"
                      DataContext="{Binding Main, Source={StaticResource Locator}}"
                      Icon="Pickles.ico">
-  <Window.TaskbarItemInfo>
-    <TaskbarItemInfo x:Name="taskBarItemInfo" />
-  </Window.TaskbarItemInfo>
-  <Window.Resources>
-    <ResourceDictionary>
-      <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Green.xaml" />
+    <Window.TaskbarItemInfo>
+        <TaskbarItemInfo x:Name="taskBarItemInfo" />
+    </Window.TaskbarItemInfo>
+    <Window.Resources>
         <ResourceDictionary>
-          <Color x:Key="HighlightDarkColor">#CC2F8200</Color>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Colors.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/Green.xaml" />
+                <ResourceDictionary>
+                    <Color x:Key="HighlightDarkColor">#CC2F8200</Color>
 
-          <BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter" />
+                    <BooleanToVisibilityConverter x:Key="booleanToVisibilityConverter" />
 
+                </ResourceDictionary>
+
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
+                <ResourceDictionary Source="CoolCheckBox.xaml" />
+            </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
-
-        <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Accents/BaseLight.xaml" />
-        <ResourceDictionary Source="CoolCheckBox.xaml" />
-      </ResourceDictionary.MergedDictionaries>
-    </ResourceDictionary>
-  </Window.Resources>
+    </Window.Resources>
     <mahapps:MetroWindow.RightWindowCommands>
         <mahapps:WindowCommands>
             <Button Content="open output folder" Command="{Binding Path=OpenOutputDirectory}" />
         </mahapps:WindowCommands>
     </mahapps:MetroWindow.RightWindowCommands>
     <Grid Margin="0,0,0,20">
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="*" />
-    </Grid.RowDefinitions>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="Auto" />
-      <ColumnDefinition />
-      <ColumnDefinition Width="Auto"  />
-      <ColumnDefinition Width="Auto" />
-      <ColumnDefinition Width="130" />
-    </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition />
+            <ColumnDefinition Width="Auto"  />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="130" />
+            <ColumnDefinition Width="250" />
+        </Grid.ColumnDefinitions>
 
-    <mahapps:MetroProgressBar IsIndeterminate="true"  Height="5" Visibility="Hidden" Grid.Row="0" Grid.ColumnSpan="5" x:Name="progressIndicator" x:FieldModifier="private"/>
+        <mahapps:MetroProgressBar IsIndeterminate="true"  Height="5" Visibility="Hidden" Grid.Row="0" Grid.ColumnSpan="5" x:Name="progressIndicator" x:FieldModifier="private"/>
 
-    <Label Content="Feature Directory" Grid.Column="0" Grid.Row="1" VerticalAlignment="Top" />
-    <TextBox Text="{Binding FeatureFolder}" Grid.Column="1" Grid.Row="1" mahapps:TextBoxHelper.Watermark="Browse To The Location Of Your Feature Files" VerticalAlignment="Top" />
-    <Button Command="{Binding BrowseForFeatureFolder}" Content="Browse ..." Grid.Row="1" Grid.Column="2" VerticalAlignment="Top" />
-    <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="1" IsChecked="{Binding Path=IsFeatureDirectoryValid}" IsEnabled="False" VerticalAlignment="Top" />
+        <Label Content="Feature Directory" Grid.Column="0" Grid.Row="1" VerticalAlignment="Top" />
+        <TextBox Text="{Binding FeatureFolder}" Grid.Column="1" Grid.Row="1" mahapps:TextBoxHelper.Watermark="Browse To The Location Of Your Feature Files" VerticalAlignment="Top" />
+        <Button Command="{Binding BrowseForFeatureFolder}" Content="Browse ..." Grid.Row="1" Grid.Column="2" VerticalAlignment="Top" />
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="1" IsChecked="{Binding Path=IsFeatureDirectoryValid}" IsEnabled="False" VerticalAlignment="Top" />
 
-    <Label Content="Output Directory" Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" />
+        <Label Content="Output Directory" Grid.Column="0" Grid.Row="2" VerticalAlignment="Top" />
         <TextBox Text="{Binding OutputFolder}" Grid.Column="1" Grid.Row="2" mahapps:TextBoxHelper.Watermark="Browse To The Location Of The Living Documentation" VerticalAlignment="Top" />
-    <Button Command="{Binding BrowseForOutputFolder}" Content="Browse ..." Grid.Column="2" Grid.Row="2" HorizontalAlignment="Left" Width="62" VerticalAlignment="Top" />
+        <Button Command="{Binding BrowseForOutputFolder}" Content="Browse ..." Grid.Column="2" Grid.Row="2" HorizontalAlignment="Left" Width="62" VerticalAlignment="Top" />
         <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="2" IsChecked="{Binding Path=IsOutputDirectoryValid}" IsEnabled="False" VerticalAlignment="Top"/>
 
-    <mahapps:ToggleSwitch Header="Create Directory For Each Output Format" Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=CreateDirectoryForEachOutputFormat, Mode=TwoWay}" Margin="0,0,0,5" />
+        <Label Content="Exclude Tags" Grid.Column="0" Grid.Row="3" VerticalAlignment="Top" />
+        <TextBox Text="{Binding ExcludeTags}" Grid.Column="1" Grid.Row="3" mahapps:TextBoxHelper.Watermark="Exclude scenarios that match this tag" VerticalAlignment="Top" />
+
+        <mahapps:ToggleSwitch Header="Create Directory For Each Output Format" Grid.Row="4" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=CreateDirectoryForEachOutputFormat, Mode=TwoWay}" Margin="0,0,0,5" />
 
 
-    <ListBox ItemsSource="{Binding DocumentationFormatValues}" Grid.Column="4" Grid.Row="1" Grid.ColumnSpan="1" Grid.RowSpan="11">
-      <ListBox.ItemsPanel>
-        <ItemsPanelTemplate>
-          <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" />
-        </ItemsPanelTemplate>
-      </ListBox.ItemsPanel>
-      <ListBox.ItemTemplate>
-        <DataTemplate>
-          <mahapps:ToggleSwitch Header="{Binding Path=Item}" IsChecked="{Binding Path=IsSelected, Mode=TwoWay}" Width="120" />
-        </DataTemplate>
-      </ListBox.ItemTemplate>
-    </ListBox>
+        <ListBox ItemsSource="{Binding DocumentationFormatValues}" Grid.Column="4" Grid.Row="1" Grid.ColumnSpan="1" Grid.RowSpan="12">
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <StackPanel Orientation="Vertical" HorizontalAlignment="Stretch" />
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <mahapps:ToggleSwitch Header="{Binding Path=Item}" IsChecked="{Binding Path=IsSelected, Mode=TwoWay}" Width="120" />
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
 
-    <Label Content="Project Name" Grid.Column="0" Grid.Row="4" VerticalAlignment="Top" />
-        <TextBox Text="{Binding ProjectName}" Grid.Column="1" Grid.Row="4" Grid.ColumnSpan="2" mahapps:TextBoxHelper.Watermark="Enter The Name Of Your Project Here" VerticalAlignment="Top" />
-        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="4" IsChecked="{Binding Path=IsProjectNameValid}" IsEnabled="False" VerticalAlignment="Top"/>
+        <Label Content="Project Name" Grid.Column="0" Grid.Row="5" VerticalAlignment="Top" />
+        <TextBox Text="{Binding ProjectName}" Grid.Column="1" Grid.Row="5" Grid.ColumnSpan="2" mahapps:TextBoxHelper.Watermark="Enter The Name Of Your Project Here" VerticalAlignment="Top" />
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="5" IsChecked="{Binding Path=IsProjectNameValid}" IsEnabled="False" VerticalAlignment="Top"/>
 
-    <Label Content="Project Version" Grid.Column="0" Grid.Row="5" VerticalAlignment="Top" />
-        <TextBox Text="{Binding ProjectVersion}" Grid.Column="1" Grid.Row="5" Grid.ColumnSpan="2" mahapps:TextBoxHelper.Watermark="Enter The Version Of Your Project Here" VerticalAlignment="Top" />
-        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="5" IsChecked="{Binding Path=IsProjectVersionValid}" IsEnabled="False" VerticalAlignment="Top"/>
+        <Label Content="Project Version" Grid.Column="0" Grid.Row="6" VerticalAlignment="Top" />
+        <TextBox Text="{Binding ProjectVersion}" Grid.Column="1" Grid.Row="6" Grid.ColumnSpan="2" mahapps:TextBoxHelper.Watermark="Enter The Version Of Your Project Here" VerticalAlignment="Top" />
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="6" IsChecked="{Binding Path=IsProjectVersionValid}" IsEnabled="False" VerticalAlignment="Top"/>
 
-    <Label Content="Include Test Results" Grid.Column="0" Grid.Row="7" Visibility="Hidden" />
-    <mahapps:ToggleSwitch Header="Include Test Results" Grid.Row="6" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=IncludeTests, Mode=TwoWay}" Margin="0,0,0,5" />
+        <Label Content="Include Test Results" Grid.Column="0" Grid.Row="8" Visibility="Hidden" />
+        <mahapps:ToggleSwitch Header="Include Test Results" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=IncludeTests, Mode=TwoWay}" Margin="0,0,0,5" />
 
-    <Label Content="Test Results File" Grid.Column="0" Grid.Row="7" VerticalAlignment="Top" />
-        <TextBox Text="{Binding TestResultsFile}" Grid.Column="1" Grid.Row="7" IsEnabled="{Binding Path=IncludeTests}" mahapps:TextBoxHelper.Watermark="Browse To The Location Of Your Test Results File" VerticalAlignment="Top" />
-    <Button Command="{Binding BrowseForTestResultsFile}" Content="Browse" Grid.Row="7" Grid.Column="2" IsEnabled="{Binding Path=IncludeTests}" VerticalAlignment="Top" />
-        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="7" IsChecked="{Binding Path=IsTestResultsFileValid}" Visibility="{Binding Path=IncludeTests, Converter={StaticResource ResourceKey=booleanToVisibilityConverter}}" IsEnabled="False" />
+        <Label Content="Test Results File" Grid.Column="0" Grid.Row="8" VerticalAlignment="Top" />
+        <TextBox Text="{Binding TestResultsFile}" Grid.Column="1" Grid.Row="8" IsEnabled="{Binding Path=IncludeTests}" mahapps:TextBoxHelper.Watermark="Browse To The Location Of Your Test Results File" VerticalAlignment="Top" />
+        <Button Command="{Binding BrowseForTestResultsFile}" Content="Browse" Grid.Row="8" Grid.Column="2" IsEnabled="{Binding Path=IncludeTests}" VerticalAlignment="Top" />
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="8" IsChecked="{Binding Path=IsTestResultsFileValid}" Visibility="{Binding Path=IncludeTests, Converter={StaticResource ResourceKey=booleanToVisibilityConverter}}" IsEnabled="False" />
 
-    <Label Content="Test Results Format" Grid.Column="0"  Grid.Row="8" VerticalAlignment="Top"/>
-        <ComboBox ItemsSource="{Binding TestResultsFormatValues}" Grid.Column="1" Grid.Row="8" Grid.ColumnSpan="2" IsEnabled="{Binding Path=IncludeTests}" SelectedItem="{Binding SelectedTestResultsFormat}" VerticalAlignment="Top"></ComboBox>
-        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="8" IsChecked="{Binding Path=IsTestResultsFormatValid}" Visibility="{Binding Path=IncludeTests, Converter={StaticResource ResourceKey=booleanToVisibilityConverter}}" IsEnabled="False" />
+        <Label Content="Test Results Format" Grid.Column="0"  Grid.Row="9" VerticalAlignment="Top"/>
+        <ComboBox ItemsSource="{Binding TestResultsFormatValues}" Grid.Column="1" Grid.Row="9" Grid.ColumnSpan="2" IsEnabled="{Binding Path=IncludeTests}" SelectedItem="{Binding SelectedTestResultsFormat}" VerticalAlignment="Top"></ComboBox>
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="9" IsChecked="{Binding Path=IsTestResultsFormatValid}" Visibility="{Binding Path=IncludeTests, Converter={StaticResource ResourceKey=booleanToVisibilityConverter}}" IsEnabled="False" />
 
-    <Label Content="Gherkin Language" Grid.Column="0" Grid.Row="9" VerticalAlignment="Top" />
-    <ComboBox ItemsSource="{Binding LanguageValues}" Grid.Column="1" SelectedItem="{Binding SelectedLanguage}" Grid.Row="9"  Grid.ColumnSpan="2" DisplayMemberPath="NativeName" VerticalAlignment="Top"/>
-        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="9" IsChecked="{Binding Path=IsLanguageValid}" IsEnabled="False" VerticalAlignment="Top"/>
+        <Label Content="Gherkin Language" Grid.Column="0" Grid.Row="10" VerticalAlignment="Top" />
+        <ComboBox ItemsSource="{Binding LanguageValues}" Grid.Column="1" SelectedItem="{Binding SelectedLanguage}" Grid.Row="10"  Grid.ColumnSpan="2" DisplayMemberPath="NativeName" VerticalAlignment="Top"/>
+        <CheckBox Template="{StaticResource ResourceKey=myCheckBox}" Grid.Column="3" Grid.Row="10" IsChecked="{Binding Path=IsLanguageValid}" IsEnabled="False" VerticalAlignment="Top"/>
 
-        <mahapps:ToggleSwitch Header="Enable Comments" Grid.Row="10" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=EnableComments, Mode=TwoWay}" Margin="0,0,0,5" />
-        <mahapps:ToggleSwitch Header="Include Experimental Features" Grid.Row="11" Grid.Column="1" Grid.ColumnSpan="2" IsChecked="{Binding Path=IncludeExperimentalFeatures, Mode=TwoWay}" Margin="0,0,0,5" />
+        <mahapps:ToggleSwitch Header="Enable Comments" Grid.Row="1" Grid.RowSpan="2" Grid.Column="5" Grid.ColumnSpan="1" IsChecked="{Binding Path=EnableComments, Mode=TwoWay}" Margin="5,0,0,5" />
+        <mahapps:ToggleSwitch Header="Include Experimental Features" Grid.RowSpan="2" Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="1" IsChecked="{Binding Path=IncludeExperimentalFeatures, Mode=TwoWay}" Margin="5,0,0,5" />
 
-        <Button Command="{Binding GeneratePickles}" Content="Generate" Grid.Row="12" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" FontSize="24" Padding="15" Grid.ColumnSpan="2" Margin="0,20" />
-        <nlogViewer:NlogViewer x:Name="logCtrl" Grid.Column="0" Grid.ColumnSpan="5" Grid.Row="13" LevelWidth="auto" ExceptionWidth="auto" MessageWidth="auto" />
-  </Grid>
+        <Button Command="{Binding GeneratePickles}" Content="Generate" Grid.Row="11" Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Center" FontSize="24" Padding="15" Grid.ColumnSpan="2" Margin="0,0,20,20" />
+        <nlogViewer:NlogViewer x:Name="logCtrl" Grid.Column="0" Grid.ColumnSpan="6" Grid.Row="12
+                               " LevelWidth="auto" ExceptionWidth="auto" MessageWidth="auto" />
+    </Grid>
 </mahapps:MetroWindow>

--- a/src/Pickles/Pickles.UserInterface/Settings/MainModel.cs
+++ b/src/Pickles/Pickles.UserInterface/Settings/MainModel.cs
@@ -61,5 +61,8 @@ namespace PicklesDoc.Pickles.UserInterface.Settings
 
         [DataMember(Name = "enableComments", IsRequired = false)]
         public bool EnableComments { get; set; }
+
+        [DataMember(Name = "excludeTags", IsRequired = false)]
+        public string ExcludeTags { get; set; }
     }
 }

--- a/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
+++ b/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
@@ -87,6 +87,8 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
 
         private bool includeTests;
 
+        private string excludeTags;
+
         private bool isRunning;
 
         private bool isFeatureDirectoryValid;
@@ -208,6 +210,13 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
             set { this.Set(() => this.IncludeTests, ref this.includeTests, value); }
         }
 
+        public string ExcludeTags
+        {
+            get { return this.excludeTags; }
+
+            set { this.Set(nameof(this.ExcludeTags), ref this.excludeTags, value); }
+        }
+
         public ICommand GeneratePickles
         {
             get { return this.generateCommand; }
@@ -323,7 +332,8 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
                     this.documentationFormats.Where(item => item.IsSelected).Select(item => item.Item).ToArray(),
                 CreateDirectoryForEachOutputFormat = this.createDirectoryForEachOutputFormat,
                 IncludeExperimentalFeatures = this.includeExperimentalFeatures,
-                EnableComments = this.enableComments
+                EnableComments = this.enableComments,
+                ExcludeTags = this.excludeTags
             };
 
             this.mainModelSerializer.Write(mainModel);
@@ -359,6 +369,7 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
             this.CreateDirectoryForEachOutputFormat = mainModel.CreateDirectoryForEachOutputFormat;
             this.IncludeExperimentalFeatures = mainModel.IncludeExperimentalFeatures;
             this.EnableComments = mainModel.EnableComments;
+            this.ExcludeTags = mainModel.ExcludeTags;
         }
 
         private void DocumentationFormatsOnCollectionChanged(object sender, EventArgs notifyCollectionChangedEventArgs)
@@ -515,6 +526,8 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
                     : CultureInfo.CurrentUICulture.TwoLetterISOLanguageName;
 
                 configuration.DocumentationFormat = documentationFormat;
+
+                configuration.ExcludeTags = this.ExcludeTags;
 
                 if (this.includeExperimentalFeatures)
                 {

--- a/src/Pickles/Pickles/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentParser.cs
@@ -40,6 +40,7 @@ namespace PicklesDoc.Pickles
         public const string HelpTestResultsFormat = "the format of the linked test results (nunit|nunit3|xunit|xunit2|mstest |cucumberjson|specrun|vstest)";
         public const string HelpIncludeExperimentalFeatures = "whether to include experimental features";
         public const string HelpEnableComments = "whether to enable comments in the output";
+        public const string HelpIgnoreTag = "tag used for ignore feature or scenario";
 
         public const string HelpTestResultsFile =
             "the path to the linked test results file (can be a semicolon-separated list of files)";
@@ -58,6 +59,7 @@ namespace PicklesDoc.Pickles
         private bool versionRequested;
         private bool includeExperimentalFeatures;
         private string enableCommentsValue;
+        private string ignoreTag;
 
         public CommandLineArgumentParser(IFileSystem fileSystem)
         {
@@ -75,7 +77,8 @@ namespace PicklesDoc.Pickles
                 { "v|version", v => this.versionRequested = v != null },
                 { "h|?|help", v => this.helpRequested = v != null },
                 { "exp|include-experimental-features", HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
-                { "cmt|enableComments=", HelpEnableComments, v => this.enableCommentsValue = v }
+                { "cmt|enableComments=", HelpEnableComments, v => this.enableCommentsValue = v },
+                { "it|ignoreTag=", HelpIgnoreTag, v => this.ignoreTag = v }
             };
         }
 
@@ -146,6 +149,11 @@ namespace PicklesDoc.Pickles
             if (this.includeExperimentalFeatures)
             {
                 configuration.EnableExperimentalFeatures();
+            }
+
+            if (!string.IsNullOrEmpty(this.ignoreTag))
+            {
+                configuration.IgnoreTag = this.ignoreTag;
             }
 
             bool enableComments;

--- a/src/Pickles/Pickles/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentParser.cs
@@ -40,7 +40,7 @@ namespace PicklesDoc.Pickles
         public const string HelpTestResultsFormat = "the format of the linked test results (nunit|nunit3|xunit|xunit2|mstest |cucumberjson|specrun|vstest)";
         public const string HelpIncludeExperimentalFeatures = "whether to include experimental features";
         public const string HelpEnableComments = "whether to enable comments in the output";
-        public const string HelpIgnoreTag = "tag used for ignore feature or scenario";
+        public const string HelpExcludeTags = "exclude scenarios that match this tag";
 
         public const string HelpTestResultsFile =
             "the path to the linked test results file (can be a semicolon-separated list of files)";
@@ -59,7 +59,7 @@ namespace PicklesDoc.Pickles
         private bool versionRequested;
         private bool includeExperimentalFeatures;
         private string enableCommentsValue;
-        private string ignoreTag;
+        private string excludeTags;
 
         public CommandLineArgumentParser(IFileSystem fileSystem)
         {
@@ -78,7 +78,7 @@ namespace PicklesDoc.Pickles
                 { "h|?|help", v => this.helpRequested = v != null },
                 { "exp|include-experimental-features", HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
                 { "cmt|enableComments=", HelpEnableComments, v => this.enableCommentsValue = v },
-                { "it|ignoreTag=", HelpIgnoreTag, v => this.ignoreTag = v }
+                { "et|excludeTags=", HelpExcludeTags, v => this.excludeTags = v }
             };
         }
 
@@ -151,9 +151,9 @@ namespace PicklesDoc.Pickles
                 configuration.EnableExperimentalFeatures();
             }
 
-            if (!string.IsNullOrEmpty(this.ignoreTag))
+            if (!string.IsNullOrEmpty(this.excludeTags))
             {
-                configuration.IgnoreTag = this.ignoreTag;
+                configuration.ExcludeTags = this.excludeTags;
             }
 
             bool enableComments;

--- a/src/Pickles/Pickles/Configuration.cs
+++ b/src/Pickles/Pickles/Configuration.cs
@@ -107,6 +107,8 @@ namespace PicklesDoc.Pickles
             }
         }
 
+        public string IgnoreTag { get; set; }
+
         private void AddTestResultFileIfItExists(FileInfoBase fileInfoBase)
         {
             if (fileInfoBase.Exists)

--- a/src/Pickles/Pickles/Configuration.cs
+++ b/src/Pickles/Pickles/Configuration.cs
@@ -107,7 +107,7 @@ namespace PicklesDoc.Pickles
             }
         }
 
-        public string IgnoreTag { get; set; }
+        public string ExcludeTags { get; set; }
 
         private void AddTestResultFileIfItExists(FileInfoBase fileInfoBase)
         {

--- a/src/Pickles/Pickles/ConfigurationReporter.cs
+++ b/src/Pickles/Pickles/ConfigurationReporter.cs
@@ -35,7 +35,7 @@ namespace PicklesDoc.Pickles
             writeToLog($"Language                       : {configuration.Language}");
             writeToLog($"Incorporate Test Results?      : {(configuration.HasTestResults ? "Yes" : "No")}");
             writeToLog($"Include Experimental Features? : {(configuration.ShouldIncludeExperimentalFeatures ? "Yes" : "No")}");
-            writeToLog($"Ignore Tag                       : {configuration.IgnoreTag}");
+            writeToLog($"Ignore Tag                       : {configuration.ExcludeTags}");
 
             if (configuration.HasTestResults)
             {

--- a/src/Pickles/Pickles/ConfigurationReporter.cs
+++ b/src/Pickles/Pickles/ConfigurationReporter.cs
@@ -35,7 +35,7 @@ namespace PicklesDoc.Pickles
             writeToLog($"Language                       : {configuration.Language}");
             writeToLog($"Incorporate Test Results?      : {(configuration.HasTestResults ? "Yes" : "No")}");
             writeToLog($"Include Experimental Features? : {(configuration.ShouldIncludeExperimentalFeatures ? "Yes" : "No")}");
-            writeToLog($"Ignore Tag                       : {configuration.ExcludeTags}");
+            writeToLog($"Exclude Tag                    : {configuration.ExcludeTags}");
 
             if (configuration.HasTestResults)
             {

--- a/src/Pickles/Pickles/ConfigurationReporter.cs
+++ b/src/Pickles/Pickles/ConfigurationReporter.cs
@@ -35,6 +35,7 @@ namespace PicklesDoc.Pickles
             writeToLog($"Language                       : {configuration.Language}");
             writeToLog($"Incorporate Test Results?      : {(configuration.HasTestResults ? "Yes" : "No")}");
             writeToLog($"Include Experimental Features? : {(configuration.ShouldIncludeExperimentalFeatures ? "Yes" : "No")}");
+            writeToLog($"Ignore Tag                       : {configuration.IgnoreTag}");
 
             if (configuration.HasTestResults)
             {

--- a/src/Pickles/Pickles/DirectoryCrawler/DirectoryTreeCrawler.cs
+++ b/src/Pickles/Pickles/DirectoryCrawler/DirectoryTreeCrawler.cs
@@ -106,7 +106,8 @@ namespace PicklesDoc.Pickles.DirectoryCrawler
             foreach (FileInfoBase file in directory.GetFiles().Where(file => this.relevantFileDetector.IsRelevant(file)))
             {
                 INode node = this.featureNodeFactory.Create(rootNode.OriginalLocation, file);
-                collectedNodes.Add(node);
+                if(node != null)
+                    collectedNodes.Add(node);
             }
 
             foreach (var node in OrderFileNodes(collectedNodes))

--- a/src/Pickles/Pickles/DirectoryCrawler/FeatureNodeFactory.cs
+++ b/src/Pickles/Pickles/DirectoryCrawler/FeatureNodeFactory.cs
@@ -23,7 +23,6 @@ using System.IO.Abstractions;
 using System.Xml.Linq;
 
 using PicklesDoc.Pickles.DocumentationBuilders.Html;
-using PicklesDoc.Pickles.DocumentationBuilders.Word.TableOfContentsAdder;
 using PicklesDoc.Pickles.Extensions;
 using PicklesDoc.Pickles.ObjectModel;
 

--- a/src/Pickles/Pickles/DirectoryCrawler/FeatureNodeFactory.cs
+++ b/src/Pickles/Pickles/DirectoryCrawler/FeatureNodeFactory.cs
@@ -23,6 +23,7 @@ using System.IO.Abstractions;
 using System.Xml.Linq;
 
 using PicklesDoc.Pickles.DocumentationBuilders.Html;
+using PicklesDoc.Pickles.DocumentationBuilders.Word.TableOfContentsAdder;
 using PicklesDoc.Pickles.Extensions;
 using PicklesDoc.Pickles.ObjectModel;
 
@@ -57,12 +58,7 @@ namespace PicklesDoc.Pickles.DirectoryCrawler
             if (this.relevantFileDetector.IsFeatureFile(file))
             {
                 Feature feature = this.featureParser.Parse(file.FullName);
-                if (feature != null)
-                {
-                    return new FeatureNode(file, relativePathFromRoot, feature);
-                }
-
-                throw new InvalidOperationException("This feature file could not be read and will be excluded");
+                return feature != null ? new FeatureNode(file, relativePathFromRoot, feature) : null;
             }
             else if (this.relevantFileDetector.IsMarkdownFile(file))
             {

--- a/src/Pickles/Pickles/FeatureParser.cs
+++ b/src/Pickles/Pickles/FeatureParser.cs
@@ -93,8 +93,6 @@ namespace PicklesDoc.Pickles
             return language;
         }
 
-
-
         private Feature RemoveFeatureWithIgnoreTag(Feature result)
         {
             if (result.Tags.Any(t => t == $"@{configuration.IgnoreTag}"))

--- a/src/Pickles/Pickles/FeatureParser.cs
+++ b/src/Pickles/Pickles/FeatureParser.cs
@@ -74,7 +74,7 @@ namespace PicklesDoc.Pickles
                 new Gherkin.TokenMatcher(new CultureAwareDialectProvider(language)));
 
             Feature result = new Mapper(this.configuration, gherkinDocument.Feature.Language).MapToFeature(gherkinDocument);
-            result = this.RemoveFeatureWithIgnoreTag(result);
+            result = this.RemoveFeatureWithExcludeTags(result);
 
             if (result != null)
                 this.descriptionProcessor.Process(result);
@@ -93,12 +93,12 @@ namespace PicklesDoc.Pickles
             return language;
         }
 
-        private Feature RemoveFeatureWithIgnoreTag(Feature result)
+        private Feature RemoveFeatureWithExcludeTags(Feature result)
         {
-            if (result.Tags.Any(t => t == $"@{configuration.IgnoreTag}"))
+            if (result.Tags.Any(t => t.Equals($"@{configuration.ExcludeTags}", StringComparison.InvariantCultureIgnoreCase)))
                 return null;
 
-            var wantedFeatures = result.FeatureElements.Where(fe => fe.Tags.All(t => t != $"@{configuration.IgnoreTag}")).ToList();
+            var wantedFeatures = result.FeatureElements.Where(fe => fe.Tags.All(t => !t.Equals($"@{configuration.ExcludeTags}", StringComparison.InvariantCultureIgnoreCase))).ToList();
 
             result.FeatureElements.Clear();
             result.FeatureElements.AddRange(wantedFeatures);

--- a/src/Pickles/Pickles/FeatureParser.cs
+++ b/src/Pickles/Pickles/FeatureParser.cs
@@ -20,7 +20,7 @@
 
 using System;
 using System.IO.Abstractions;
-
+using System.Linq;
 using PicklesDoc.Pickles.ObjectModel;
 
 using TextReader = System.IO.TextReader;
@@ -74,8 +74,10 @@ namespace PicklesDoc.Pickles
                 new Gherkin.TokenMatcher(new CultureAwareDialectProvider(language)));
 
             Feature result = new Mapper(this.configuration, gherkinDocument.Feature.Language).MapToFeature(gherkinDocument);
+            result = this.RemoveFeatureWithIgnoreTag(result);
 
-            this.descriptionProcessor.Process(result);
+            if (result != null)
+                this.descriptionProcessor.Process(result);
 
             return result;
         }
@@ -89,6 +91,21 @@ namespace PicklesDoc.Pickles
                 language = this.configuration.Language;
             }
             return language;
+        }
+
+
+
+        private Feature RemoveFeatureWithIgnoreTag(Feature result)
+        {
+            if (result.Tags.Any(t => t == $"@{configuration.IgnoreTag}"))
+                return null;
+
+            var wantedFeatures = result.FeatureElements.Where(fe => fe.Tags.All(t => t != $"@{configuration.IgnoreTag}")).ToList();
+
+            result.FeatureElements.Clear();
+            result.FeatureElements.AddRange(wantedFeatures);
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
I use Pickles in order to generate Living documentation. I faced the same issue described in: Idea: Exclude Scenarios or Features by tags #18

1. An IgnoreTag feature has been added: ignore some scenarios or features during living documentation generation
2. IgnoreTag parameter has been implemented for all runners