### PR TITLE
Seems like Encoding.Default passed to StreamReader will solve issue

### DIFF
--- a/src/Pickles/Pickles.Test/BaseFixture.cs
+++ b/src/Pickles/Pickles.Test/BaseFixture.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Reflection;
-
+using System.Text;
 using Autofac;
 
 using NUnit.Framework;
@@ -123,8 +123,9 @@ namespace PicklesDoc.Pickles.Test
             System.IO.Stream manifestResourceStream =
                 Assembly.GetCallingAssembly().GetManifestResourceStream(resourceName);
 
-            using (var reader = new System.IO.StreamReader(manifestResourceStream))
+            using (var reader = new System.IO.StreamReader(manifestResourceStream, Encoding.Default, true))
             {
+                //reader.Peek();
                 resultFile = reader.ReadToEnd();
             }
 

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/UTF8/UTF8WithBOM.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/UTF8/UTF8WithBOM.feature
@@ -1,0 +1,10 @@
+﻿#language: no
+Egenskap: Charset UTF8 Codepage 65001 inkl. BOM - Norwegian with letters ÆØÅ
+	In norwegian, we use the letters æøå and ÆØÅ.
+    It should be parsable even without BOM.
+
+@mytag
+Scenario: A scenario with æøå
+	Gitt at jeg skriver æ
+    Når jeg trykker ø
+    Så kan jeg også parse å

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/UTF8/UTF8WithoutBOM.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/UTF8/UTF8WithoutBOM.feature
@@ -1,0 +1,10 @@
+﻿#language: no
+Egenskap: Charset UTF8 Codepage 65001 w/o BOM - Norwegian with letters ÆØÅ
+	In norwegian, we use the letters æøå and ÆØÅ.
+    It should be parsable even without BOM.
+
+@mytag
+Scenario: A scenario with æøå
+	Gitt at jeg skriver æ
+    Når jeg trykker ø
+    Så kan jeg også parse å

--- a/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/WesternEuropean/WesternEuropean1252.feature
+++ b/src/Pickles/Pickles.Test/FakeFolderStructures/Encodings/WesternEuropean/WesternEuropean1252.feature
@@ -1,0 +1,10 @@
+#language: no
+Egenskap: ISO-8859-1 CP 1252 Norwegian with letters ÆØÅ
+	In norwegian, we use the letters æøå and ÆØÅ.
+    It should be parsable even without BOM.
+
+@mytag
+Scenario: A scenario with æøå
+	Gitt at jeg skriver æ
+    Når jeg trykker ø
+    Så kan jeg også parse å

--- a/src/Pickles/Pickles.Test/FileSystemBasedFeatureParserTests.cs
+++ b/src/Pickles/Pickles.Test/FileSystemBasedFeatureParserTests.cs
@@ -39,5 +39,16 @@ namespace PicklesDoc.Pickles.Test
                              Environment.NewLine + @"Errormessage was: 'Unable to parse feature'");
         }
 
+
+        [Test]
+        public void Parse_WesternEuropeanEncoding()
+        {
+            var parser = new FileSystemBasedFeatureParser(new FeatureParser(Configuration), FileSystem);
+            AddFakeFolderAndFiles(@"Encodings", new string[0]);
+            //AddFakeFolderAndFiles(@"Encodings\UTF8", new[] { "UTF8WithBOM.feature", "UTF8WithoutBOM.feature" });
+            AddFakeFolderAndFiles(@"Encodings\WesternEuropean", new[] { "WesternEuropean1252.feature" });
+
+            parser.Parse(@"c:\temp\FakeFolderStructures\Encodings\WesternEuropean\WesternEuropean1252.feature");
+        }
     }
 }

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -222,6 +222,15 @@
       <LastGenOutput>a-b.feature.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="FakeFolderStructures\FeatureCrawlerTests\LevelOneIgnoredFeature.feature" />
+    <EmbeddedResource Include="FakeFolderStructures\Encodings\WesternEuropean\WesternEuropean1252.feature">
+      <LastGenOutput>ISO-8859-1 CP 1252 Norwegian.feature.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\Encodings\UTF8\UTF8WithBOM.feature">
+      <LastGenOutput>CharsetUTF8CodePage65001WithBOMNorwegian.feature.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="FakeFolderStructures\Encodings\UTF8\UTF8WithoutBOM.feature">
+      <LastGenOutput>CharsetUTF8CodePage65001WithoutBOMNorwegian.feature.cs</LastGenOutput>
+    </EmbeddedResource>
     <None Include="Resources\test.jpg" />
     <EmbeddedResource Include="Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Pickles/Pickles.sln
+++ b/src/Pickles/Pickles.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pickles", "Pickles\Pickles.csproj", "{38BAD6E0-78AB-4AC3-91A8-BF72AF5EE394}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
+++ b/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
@@ -19,7 +19,9 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.IO;
 using System.IO.Abstractions;
+using System.Text;
 using PicklesDoc.Pickles.ObjectModel;
 
 namespace PicklesDoc.Pickles
@@ -39,21 +41,26 @@ namespace PicklesDoc.Pickles
         public Feature Parse(string filename)
         {
             Feature feature = null;
-            using (var reader = this.fileSystem.FileInfo.FromFileName(filename).OpenText())
-            {
-                try
-                {
-                    feature = this.parser.Parse(reader);
-                }
-                catch (FeatureParseException e)
-                {
-                    string message =
-                        $"There was an error parsing the feature file here: {this.fileSystem.Path.GetFullPath(filename)}" + Environment.NewLine +
-                        $"Errormessage was: '{e.Message}'";
-                    throw new FeatureParseException(message, e);
-                }
 
-                reader.Close();
+            using (var stream = this.fileSystem.FileInfo.FromFileName(filename).Open(FileMode.Open))
+            {
+                using (var reader = new StreamReader(stream, Encoding.Default, true))
+                {
+                    reader.Peek();
+                    try
+                    {
+                        feature = this.parser.Parse(reader);
+                    }
+                    catch (FeatureParseException e)
+                    {
+                        string message =
+                            $"There was an error parsing the feature file here: {this.fileSystem.Path.GetFullPath(filename)}" + Environment.NewLine +
+                            $"Errormessage was: '{e.Message}'";
+                        throw new FeatureParseException(message, e);
+                    }
+
+                    reader.Close();
+                }
             }
 
             return feature;


### PR DESCRIPTION
But it also seems like the MockFileSystem has issues with encoding.
So test won't pass unless the FS "behaves".
Currently reads nicely into BaseFixture helper, but test FS uses UTF8 as default, and I can't spot the place to swap it out.
Manuel test shows that the WesternEuropean file can be parsed - on MY box. Using Encoding.Default will probably default to whatever's default on the user's box. But it might be better than defaulting to UTF8 when it's not. UTF8 files with and without BOM still parses nicely.

Dunno if you have an idea for the FS problem. Might just read the files from disk, but I really like the mocked one. :)