### PR TITLE
Encoded files different from default cannot be parsed

### DIFF
--- a/src/Pickles/Pickles.Test/EncodingDetectorTests.cs
+++ b/src/Pickles/Pickles.Test/EncodingDetectorTests.cs
@@ -1,0 +1,123 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="EncodingDetectorTests.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO.Abstractions.TestingHelpers;
+using System.Text;
+using NFluent;
+using NUnit.Framework;
+
+namespace PicklesDoc.Pickles.Test
+{
+    [TestFixture]
+    public class EncodingDetectorTests : BaseFixture
+    {
+        [Test]
+        public void GetEncoding_NullArgument_ThrowsArgumentNullException()
+        {
+            var detector = this.CreateDetector();
+
+            Check.ThatCode(() => detector.GetEncoding(null)).Throws<ArgumentNullException>();
+        }
+
+        private EncodingDetector CreateDetector()
+        {
+            return new EncodingDetector(FileSystem);
+        }
+
+        [Test]
+        public void GetEncoding_FileDoesNotExist_DoesNotThrowException()
+        {
+            var detector = this.CreateDetector();
+
+            Check.ThatCode(() => detector.GetEncoding("file-does-not-exist.feature")).DoesNotThrow();
+        }
+
+        [Test]
+        public void GetEncoding_FileIsLessThanFourBytes_DoesNotThrowException()
+        {
+            FileSystem.AddFile("temp.feature", new MockFileData(new byte[3]));
+
+            var detector = this.CreateDetector();
+
+            Check.ThatCode(() => detector.GetEncoding("temp.feature")).DoesNotThrow();
+        }
+
+        [Test]
+        public void GetEncoding_UTF7BOM_ReturnsUTF()
+        {
+            FileSystem.AddFile("utf7.feature", new MockFileData(new byte[] { 0x2b, 0x2f, 0x76 }));
+
+            var detector = this.CreateDetector();
+
+            var encoding = detector.GetEncoding("utf7.feature");
+
+            Check.That(encoding).IsEqualTo(Encoding.UTF7);
+        }
+
+        [Test]
+        public void GetEncoding_UTF16LEBOM_ReturnsUnicode()
+        {
+            FileSystem.AddFile("utf16le.feature", new MockFileData(new byte[] { 0xff, 0xfe }));
+
+            var detector = this.CreateDetector();
+
+            var encoding = detector.GetEncoding("utf16le.feature");
+
+            Check.That(encoding).IsEqualTo(Encoding.Unicode);
+        }
+
+        [Test]
+        public void GetEncoding_UTF16BEBOM_ReturnsUnicode()
+        {
+            FileSystem.AddFile("utf16be.feature", new MockFileData(new byte[] { 0xfe, 0xff }));
+
+            var detector = this.CreateDetector();
+
+            var encoding = detector.GetEncoding("utf16be.feature");
+
+            Check.That(encoding).IsEqualTo(Encoding.BigEndianUnicode);
+        }
+
+        [Test]
+        public void GetEncoding_UTF32BOM_ReturnsUnicode()
+        {
+            FileSystem.AddFile("utf32.feature", new MockFileData(new byte[] { 0, 0, 0xfe, 0xff }));
+
+            var detector = this.CreateDetector();
+
+            var encoding = detector.GetEncoding("utf32.feature");
+
+            Check.That(encoding).IsEqualTo(Encoding.UTF32);
+        }
+
+        [Test]
+        public void GetEncoding_Default_ReturnsUTF8()
+        {
+            FileSystem.AddFile("other.feature", new MockFileData(new byte[] { 0xab, 0xcd, 0xef, 0x01 }));
+
+            var detector = this.CreateDetector();
+
+            var encoding = detector.GetEncoding("other.feature");
+
+            Check.That(encoding).IsEqualTo(Encoding.UTF8);
+        }
+    }
+}

--- a/src/Pickles/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles/Pickles.Test/Pickles.Test.csproj
@@ -103,6 +103,7 @@
     <Compile Include="DescriptionProcessorTests.cs" />
     <Compile Include="DirectoryCrawlers\ImageFileDetectorTests.cs" />
     <Compile Include="DirectoryCrawlers\RelevantFileDetectorTests.cs" />
+    <Compile Include="EncodingDetectorTests.cs" />
     <Compile Include="FeatureNodeFactoryTests.cs" />
     <Compile Include="FeatureParserTests.cs" />
     <Compile Include="FileSystemBasedFeatureParserTests.cs" />

--- a/src/Pickles/Pickles/EncodingDetector.cs
+++ b/src/Pickles/Pickles/EncodingDetector.cs
@@ -15,6 +15,11 @@ namespace PicklesDoc.Pickles
 
         public Encoding GetEncoding(string filename)
         {
+            if (filename == null)
+            {
+                throw new ArgumentNullException();
+            }
+
             var bom = new byte[4];
             using (var file = this.fileSystem.FileInfo.FromFileName(filename).OpenRead())
             {

--- a/src/Pickles/Pickles/EncodingDetector.cs
+++ b/src/Pickles/Pickles/EncodingDetector.cs
@@ -1,0 +1,33 @@
+using System;
+using System.IO.Abstractions;
+using System.Text;
+
+namespace PicklesDoc.Pickles
+{
+    public class EncodingDetector
+    {
+        private readonly IFileSystem fileSystem;
+
+        public EncodingDetector(IFileSystem fileSystem)
+        {
+            this.fileSystem = fileSystem;
+        }
+
+        public Encoding GetEncoding(string filename)
+        {
+            var bom = new byte[4];
+            using (var file = this.fileSystem.FileInfo.FromFileName(filename).OpenRead())
+            {
+                file.Read(bom, 0, 4);
+            }
+
+            // Analyze the BOM
+            if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76) return Encoding.UTF7;
+            if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf) return Encoding.UTF8;
+            if (bom[0] == 0xff && bom[1] == 0xfe) return Encoding.Unicode; //UTF-16LE
+            if (bom[0] == 0xfe && bom[1] == 0xff) return Encoding.BigEndianUnicode; //UTF-16BE
+            if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff) return Encoding.UTF32;
+            return Encoding.UTF8;
+        }
+    }
+}

--- a/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
+++ b/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
@@ -81,7 +81,7 @@ namespace PicklesDoc.Pickles
             if (bom[0] == 0xff && bom[1] == 0xfe) return Encoding.Unicode; //UTF-16LE
             if (bom[0] == 0xfe && bom[1] == 0xff) return Encoding.BigEndianUnicode; //UTF-16BE
             if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff) return Encoding.UTF32;
-            return Encoding.Default;
+            return Encoding.UTF8;
         }
     }
 }

--- a/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
+++ b/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
@@ -32,10 +32,13 @@ namespace PicklesDoc.Pickles
 
         private readonly FeatureParser parser;
 
+        private readonly EncodingDetector encodingDetector;
+
         public FileSystemBasedFeatureParser(FeatureParser parser, IFileSystem fileSystem)
         {
             this.parser = parser;
             this.fileSystem = fileSystem;
+            this.encodingDetector = new EncodingDetector(this.fileSystem);
         }
 
         public Feature Parse(string filename)
@@ -69,19 +72,7 @@ namespace PicklesDoc.Pickles
 
         private Encoding GetEncoding(string filename)
         {
-            var bom = new byte[4];
-            using (var file = this.fileSystem.FileInfo.FromFileName(filename).OpenRead())
-            {
-                file.Read(bom, 0, 4);
-            }
-
-            // Analyze the BOM
-            if (bom[0] == 0x2b && bom[1] == 0x2f && bom[2] == 0x76) return Encoding.UTF7;
-            if (bom[0] == 0xef && bom[1] == 0xbb && bom[2] == 0xbf) return Encoding.UTF8;
-            if (bom[0] == 0xff && bom[1] == 0xfe) return Encoding.Unicode; //UTF-16LE
-            if (bom[0] == 0xfe && bom[1] == 0xff) return Encoding.BigEndianUnicode; //UTF-16BE
-            if (bom[0] == 0 && bom[1] == 0 && bom[2] == 0xfe && bom[3] == 0xff) return Encoding.UTF32;
-            return Encoding.UTF8;
+            return this.encodingDetector.GetEncoding(filename);
         }
     }
 }

--- a/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
+++ b/src/Pickles/Pickles/FileSystemBasedFeatureParser.cs
@@ -44,7 +44,7 @@ namespace PicklesDoc.Pickles
         public Feature Parse(string filename)
         {
             Feature feature = null;
-            var encoding = this.GetEncoding(filename);
+            var encoding = this.encodingDetector.GetEncoding(filename);
             using (var fileStream = this.fileSystem.FileInfo.FromFileName(filename).OpenRead())
             {
                 using (var specificEncoderReader = new StreamReader(fileStream, encoding))
@@ -68,11 +68,6 @@ namespace PicklesDoc.Pickles
             }
 
             return feature;
-        }
-
-        private Encoding GetEncoding(string filename)
-        {
-            return this.encodingDetector.GetEncoding(filename);
         }
     }
 }

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -101,6 +101,7 @@
     <Compile Include="DescriptionProcessor.cs" />
     <Compile Include="DirectoryCrawler\ImageFileDetector.cs" />
     <Compile Include="DirectoryCrawler\ParsingReport.cs" />
+    <Compile Include="EncodingDetector.cs" />
     <Compile Include="Extensions\PathExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="DirectoryCrawler\FeatureNodeFactory.cs" />


### PR DESCRIPTION
Encoded files different from default cannot be parsed.
This commit, deduce encoding for each file, by reading first 4 bytes (BOM). Fallback is default encoding.