### PR TITLE
Remove unnecessary backslash conversion in json feature tree

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
@@ -85,9 +85,7 @@ function getFeaturesMatching(searchString, features) {
 }
 
 function findFeatureByRelativeFolder(path, features) {
-    // make sure path is not url encoded, and replace forward-slashes with back-slashes to match JSON
     path = decodeURIComponent(path);
-    path = path.replace(/\//g, '\\');
 
     var feature = _.find(features, function(featureTesting) {
         return featureTesting.RelativeFolder == path;


### PR DESCRIPTION
In accordance to
https://github.com/picklesdoc/pickles/issues/468