### PR TITLE
find test-suites in the results file by description and tags

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingNUnitResultsFile.cs
@@ -71,6 +71,24 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit2
         }
 
         [Test]
+        public new void ThenCanReadFeatureWithMatchingNameAndNoCategoriesCorrectly()
+        {
+            base.ThenCanReadFeatureWithMatchingNameAndNoCategoriesCorrectly();
+        }
+    
+        [Test]
+        public new void ThenCanReadFeatureWithMatchingNameAndCategoryCorrectly()
+        {
+            base.ThenCanReadFeatureWithMatchingNameAndCategoryCorrectly();
+        }
+    
+        [Test]
+        public new void ThenCanReadFeatureWithMatchingNameAndUnknownCategoryCorrectly()
+        {
+            base.ThenCanReadFeatureWithMatchingNameAndUnknownCategoryCorrectly();
+        }
+
+        [Test]
         public new void ThenCanReadInconclusiveFeatureResultSuccessfully()
         {
             base.ThenCanReadInconclusiveFeatureResultSuccessfully();

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingProblematicScenarioOutlineResults.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/NUnit/NUnit2/WhenParsingProblematicScenarioOutlineResults.cs
@@ -42,7 +42,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.NUnit.NUnit2
         {
             var results = ParseResultsFile();
 
-            var feature = new Feature { Name = "ExampleWebFeature" };
+            var feature = new Feature { Name = "ExampleWebFeature" , Tags = { "@web" }};
 
             var scenarioOutline = new ScenarioOutline { Name = "Login", Feature = feature };
 

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
@@ -164,6 +164,31 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests
 
             Check.That(result).IsEqualTo(TestResult.Inconclusive);
         }
+    
+
+        public void ThenCanReadFeatureWithMatchingNameAndNoCategoriesCorrectly()
+        {
+            var results = ParseResultsFile();
+            var result = results.GetFeatureResult(new Feature { Name = "Adding several numbers" });
+
+            Check.That(result).IsEqualTo(TestResult.Failed);
+        }
+
+        public void ThenCanReadFeatureWithMatchingNameAndCategoryCorrectly()
+        {
+            var results = ParseResultsFile();
+            var result = results.GetFeatureResult(new Feature { Name = "Adding several numbers", Tags = { "@tag2" }});
+
+            Check.That(result).IsEqualTo(TestResult.Passed);
+        }
+
+        public void ThenCanReadFeatureWithMatchingNameAndUnknownCategoryCorrectly()
+        {
+            var results = ParseResultsFile();
+            var result = results.GetFeatureResult(new Feature { Name = "Adding several numbers", Tags = { "@tag2", "@unknown" }});
+
+            Check.That(result).IsEqualTo(TestResult.Passed);
+        }
 
         public void ThenCanReadResultsWithBackslashes()
         {


### PR DESCRIPTION
When finding the test-suite element in nunit results for a given Feature, search by description and category list. If no matching element is found, revert to the previous behavior of only searching based on description.