### PR TITLE
Release 2.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Features in Experimental are subject to change and removal without being conside
 
 This document is formatted according to the principles of [Keep A CHANGELOG](http://keepachangelog.com).
 
-## Unreleased
+## [2.16.1] - 2017-08-07
 
 ### Fixed
 

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
-set "picklesVersion=2.16.0"
+set "picklesVersion=2.16.1"
 
 cls
 

--- a/src/Pickles/VersionInfo.cs
+++ b/src/Pickles/VersionInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademarkAttribute("")]
 [assembly: AssemblyCultureAttribute("")]
 [assembly: ComVisibleAttribute(false)]
-[assembly: AssemblyVersionAttribute("2.16.0")]
-[assembly: AssemblyFileVersionAttribute("2.16.0")]
+[assembly: AssemblyVersionAttribute("2.16.1")]
+[assembly: AssemblyFileVersionAttribute("2.16.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "Pickles";
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyTrademark = "";
         internal const System.String AssemblyCulture = "";
         internal const System.Boolean ComVisible = false;
-        internal const System.String AssemblyVersion = "2.16.0";
-        internal const System.String AssemblyFileVersion = "2.16.0";
+        internal const System.String AssemblyVersion = "2.16.1";
+        internal const System.String AssemblyFileVersion = "2.16.1";
     }
 }


### PR DESCRIPTION
## [2.16.1] - 2017-08-07

### Fixed

- Remove unnecessary backslash conversion in json feature tree ([469](https://github.com/picklesdoc/pickles/pull/469)) (by [@AntoineTheb](https://github.com/AntoineTheb))
- Pickles cannot deal with languages that have a hyphen in the name ([478](https://github.com/picklesdoc/pickles/pull/478)) (by [@dirkrombauts](https://github.com/dirkrombauts))