### PR TITLE
Release 2.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,24 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+### Security
+
+## [2.17.0] - 2017-11-06
+
+### Added
+
+- Added error handling for Markdown parsing exceptions ([497](https://github.com/picklesdoc/pickles/pull/497)) (by [@joebuschmann](https://github.com/joebuschmann)) 
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 - PowerShell Runner Shows Only First Test Result File ([485](https://github.com/picklesdoc/pickles/pull/485)) (by [@dirkrombauts](https://github.com/dirkrombauts))
-- Fixed ExcludeTags Typo In MSBuild targets ([478](https://github.com/picklesdoc/pickles/pull/478)) (by [@nachereshata](https://github.com/nachereshata)) 
+- Fixed ExcludeTags Typo In MSBuild targets ([478](https://github.com/picklesdoc/pickles/pull/478)) (by [@nachereshata](https://github.com/nachereshata))
 
 ### Security
 

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 @echo off
-set "picklesVersion=2.16.2"
+set "picklesVersion=2.17.0"
 
 cls
 

--- a/src/Pickles/VersionInfo.cs
+++ b/src/Pickles/VersionInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademarkAttribute("")]
 [assembly: AssemblyCultureAttribute("")]
 [assembly: ComVisibleAttribute(false)]
-[assembly: AssemblyVersionAttribute("2.16.2")]
-[assembly: AssemblyFileVersionAttribute("2.16.2")]
+[assembly: AssemblyVersionAttribute("2.17.0")]
+[assembly: AssemblyFileVersionAttribute("2.17.0")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyProduct = "Pickles";
@@ -18,7 +18,7 @@ namespace System {
         internal const System.String AssemblyTrademark = "";
         internal const System.String AssemblyCulture = "";
         internal const System.Boolean ComVisible = false;
-        internal const System.String AssemblyVersion = "2.16.2";
-        internal const System.String AssemblyFileVersion = "2.16.2";
+        internal const System.String AssemblyVersion = "2.17.0";
+        internal const System.String AssemblyFileVersion = "2.17.0";
     }
 }


### PR DESCRIPTION
## [2.17.0] - 2017-11-06

### Added

- Added error handling for Markdown parsing exceptions ([497](https://github.com/picklesdoc/pickles/pull/497)) (by [@joebuschmann](https://github.com/joebuschmann)) 

### Changed

### Deprecated

### Removed

### Fixed

- PowerShell Runner Shows Only First Test Result File ([485](https://github.com/picklesdoc/pickles/pull/485)) (by [@dirkrombauts](https://github.com/dirkrombauts))
- Fixed ExcludeTags Typo In MSBuild targets ([478](https://github.com/picklesdoc/pickles/pull/478)) (by [@nachereshata](https://github.com/nachereshata))

### Security