### PR TITLE
Cache the feature scan results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Removed
 
 ### Fixed
+- Cache the NUnit feature scan results to improve performance on large solutions ([503](https://github.com/picklesdoc/pickles/pull/503)) (by [@tlecomte](https://github.com/tlecomte))
 
 ### Security
 

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2SingleResults.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2SingleResults.cs
@@ -20,7 +20,6 @@
 
 using System;
 using System.Linq;
-using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 using PicklesDoc.Pickles.ObjectModel;
@@ -29,6 +28,8 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit2
 {
     public class NUnit2SingleResults : NUnitSingleResultsBase
     {
+        private readonly ILookup<string, XElement> featureElements;
+
         public NUnit2SingleResults(XDocument resultsDocument)
             : base(
                 resultsDocument,
@@ -40,6 +41,10 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit2
                         new TestResultAndName(TestResult.Passed, "Success"),
                     })
         {
+            this.featureElements = resultsDocument
+                .Descendants("test-suite")
+                .Where(x => x.Attribute("description") != null)
+                .ToLookup(x => x.Attribute("description").Value);
         }
 
         protected override XElement GetScenarioElement(Scenario scenario)
@@ -75,10 +80,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit2
 
         protected override XElement GetFeatureElement(Feature feature)
         {
-            return this.resultsDocument
-                .Descendants("test-suite")
-                .Where(x => x.Attribute("description") != null)
-                .FirstOrDefault(x => x.Attribute("description").Value == feature.Name);
+            return this.featureElements[feature.Name].FirstOrDefault();
         }
 
         protected override XElement GetExamplesElement(ScenarioOutline scenarioOutline, string[] values)

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitSingleResultsBase.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnitSingleResultsBase.cs
@@ -32,11 +32,8 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit
 
         protected NUnitSingleResultsBase(XDocument resultsDocument, TestResultAndName[] testResultAndNames)
         {
-            this.resultsDocument = resultsDocument;
             this.testResultAndNames = testResultAndNames;
         }
-
-        protected XDocument resultsDocument { get; }
 
         public override TestResult GetFeatureResult(Feature feature)
         {


### PR DESCRIPTION
On a solution with about 6000 test scenarios, Pickles.exe takes about 16 seconds on my machine to process.
This is with the following options:
Pickles.exe -f xxx -o xxx --trfmt=nunit3 --enableComments=false -df=json -lr=xxx

Profiling shows that a large part of this time is spent scanning the NUnit results. More precisely, scanning by feature name is done repeatedly on the xml results.
In this commit, the time is reduced to 5 seconds by scanning the xml once and storing the results in a C# lookup, which is optimized for fast-access by key.

Unit tests pass.
The resulting json files are identical (except "GeneratedOn" datetime, obviously).