### PR TITLE
Improve JSONDocumentationBuilder performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 - Cache the NUnit feature scan results to improve performance on large solutions ([503](https://github.com/picklesdoc/pickles/pull/503)) (by [@tlecomte](https://github.com/tlecomte))
+- Use lookups in JSONDocumentation Builder to improve performance on large solutions ([504](https://github.com/picklesdoc/pickles/pull/504)) (by [@tlecomte](https://github.com/tlecomte))
 
 ### Security
 


### PR DESCRIPTION
Improve JSONDocumentationBuilder performance by preparing lookups instead of using Where repeatedly.

This has been tested on a solution with 6000 test scenarios, with the following options:
Pickles.exe -f xxx -o xxx --trfmt=nunit3 --enableComments=false -df=json -lr=xxx

Before: 5.3 seconds
After: 4.3 seconds

Unit tests pass.
The resulting json files are identical (except "GeneratedOn" datetime).