### PR TITLE
Improve FeatureParser performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 ### Fixed
 - Cache the NUnit feature scan results to improve performance on large solutions ([503](https://github.com/picklesdoc/pickles/pull/503)) (by [@tlecomte](https://github.com/tlecomte))
 - Use lookups in JSONDocumentation Builder to improve performance on large solutions ([504](https://github.com/picklesdoc/pickles/pull/504)) (by [@tlecomte](https://github.com/tlecomte))
+- Cache LanguageServices and GherkinDialectProvider in FeatureParser to improve performance on large solutions ([505](https://github.com/picklesdoc/pickles/pull/505)) (by [@tlecomte](https://github.com/tlecomte))
 
 ### Security
 

--- a/src/Pickles/Pickles.Test/ObjectModel/Factory.cs
+++ b/src/Pickles/Pickles.Test/ObjectModel/Factory.cs
@@ -38,7 +38,8 @@ namespace PicklesDoc.Pickles.Test.ObjectModel
 
         internal Mapper CreateMapper(IConfiguration configuration, string defaultLanguage = "en")
         {
-            var mapper = new Mapper(configuration, defaultLanguage);
+            var languageServices = new LanguageServices(defaultLanguage);
+            var mapper = new Mapper(configuration, languageServices);
             return mapper;
         }
 

--- a/src/Pickles/Pickles/LanguageServicesRegistry.cs
+++ b/src/Pickles/Pickles/LanguageServicesRegistry.cs
@@ -17,13 +17,26 @@
 //  limitations under the License.
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
+using System.Collections.Generic;
+
 namespace PicklesDoc.Pickles
 {
     public class LanguageServicesRegistry : ILanguageServicesRegistry
     {
+        private static readonly IDictionary<string, ILanguageServices> LanguageServices = new Dictionary<string, ILanguageServices>();
+
         public ILanguageServices GetLanguageServicesForLanguage(string language)
         {
-            return new LanguageServices(language ?? DefaultLanguage);
+            language = language ?? DefaultLanguage;
+
+            if (LanguageServices.ContainsKey(language))
+            {
+                return LanguageServices[language];
+            }
+
+            var services = new LanguageServices(language);
+            LanguageServices[language] = services;
+            return services;
         }
 
         public string DefaultLanguage

--- a/src/Pickles/Pickles/ObjectModel/Mapper.cs
+++ b/src/Pickles/Pickles/ObjectModel/Mapper.cs
@@ -35,10 +35,10 @@ namespace PicklesDoc.Pickles.ObjectModel
 
         private readonly ILanguageServices languageServices;
 
-        public Mapper(IConfiguration configuration, string featureLanguage)
+        public Mapper(IConfiguration configuration, ILanguageServices languageServices)
         {
             this.configuration = configuration;
-            this.languageServices = new LanguageServices(featureLanguage);
+            this.languageServices = languageServices;
         }
 
         public string MapToString(G.TableCell cell)


### PR DESCRIPTION
Improve FeatureParser performance by caching CultureAwareDialectProvider and LanguageServices.

Profiling shows that creating the CultureAwareDialectProvider and LanguageServices objects is quite costly.
FeatureParser is creating them repeatedly. In this commit, these objects are cached in dictionaries.

This has been tested on a solution with 6000 test scenarios, with the following options:
Pickles.exe -f xxx -o xxx --trfmt=nunit3 --enableComments=false -df=json -lr=xxx

Before: 4.3 seconds
After: 2.0 seconds

Unit tests pass.
The resulting json files are identical (except "GeneratedOn" datetime).