### PR TITLE
Use name mapping from SpecFlow

### DIFF
--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/StandardTestSuite.cs
@@ -276,7 +276,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests
 
           var feature = new Feature { Name = "Scenarios With Special Characters" };
 
-          var scenarioOutline = new ScenarioOutline { Name = "This is a scenario outline with german umlauts äöüß ÄÖÜ", Feature = feature };
+          var scenarioOutline = new ScenarioOutline { Name = "This is a scenario outline with german umlauts Ã¤Ã¶Ã¼ÃŸ Ã„Ã–Ãœ", Feature = feature };
 
           var actualResult = results.GetExampleResult(scenarioOutline, new string[] { "pass_1" });
 
@@ -289,7 +289,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests
 
             var feature = new Feature { Name = "Scenarios With Special Characters" };
 
-            var scenario = new Scenario {Name = "This is a scenario with danish characters æøå ÆØÅ", Feature = feature };
+            var scenario = new Scenario {Name = "This is a scenario with danish characters Ã¦Ã¸Ã¥ Ã†Ã˜Ã…", Feature = feature };
 
             var actualResult = results.GetScenarioResult(scenario);
 

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2ExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2ExampleSignatureBuilder.cs
@@ -31,17 +31,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit2
         {
             var stringBuilder = new StringBuilder();
 
-            var name = SpecFlowNameMapping.Build(scenarioOutline.Name.ToLowerInvariant());
+            var name = SpecFlowNameMapping.Build(scenarioOutline.Name);
             stringBuilder.Append(name).Append("\\(");
 
             foreach (var value in row)
             {
-                stringBuilder.AppendFormat("\"{0}\",", Regex.Escape(value.ToLowerInvariant()));
+                stringBuilder.AppendFormat("\"{0}\",", Regex.Escape(value));
             }
 
             stringBuilder.Remove(stringBuilder.Length - 1, 1);
 
-            return new Regex(stringBuilder.ToString());
+            return new Regex(stringBuilder.ToString(), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2ScenarioOutlineExampleMatcher.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit2/NUnit2ScenarioOutlineExampleMatcher.cs
@@ -39,7 +39,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit2
         internal static bool IsMatchingTestCase(XElement x, Regex exampleSignature)
         {
             var name = x.Attribute("name");
-            return name != null && exampleSignature.IsMatch(name.Value.ToLowerInvariant().Replace(@"\\", @"\"));
+            return name != null && exampleSignature.IsMatch(name.Value.Replace(@"\\", @"\"));
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit3/NUnit3ExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit3/NUnit3ExampleSignatureBuilder.cs
@@ -32,17 +32,17 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit3
         {
             var stringBuilder = new StringBuilder();
 
-            var name = SpecFlowNameMapping.Build(scenarioOutline.Name.ToLowerInvariant());
+            var name = SpecFlowNameMapping.Build(scenarioOutline.Name);
             stringBuilder.Append(name).Append("\\(");
 
             foreach (var value in row)
             {
-                stringBuilder.AppendFormat("\"{0}\",", Regex.Escape(value.ToLowerInvariant()));
+                stringBuilder.AppendFormat("\"{0}\",", Regex.Escape(value));
             }
 
             stringBuilder.Remove(stringBuilder.Length - 1, 1);
 
-            return new Regex(stringBuilder.ToString());
+            return new Regex(stringBuilder.ToString(), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit3/NUnit3ScenarioOutlineExampleMatcher.cs
+++ b/src/Pickles/Pickles.TestFrameworks/NUnit/NUnit3/NUnit3ScenarioOutlineExampleMatcher.cs
@@ -39,7 +39,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.NUnit.NUnit3
         internal static bool IsMatchingTestCase(XElement x, Regex exampleSignature)
         {
             var name = x.Attribute("name");
-            return name != null && exampleSignature.IsMatch(name.Value.ToLowerInvariant().Replace(@"\\", @"\"));
+            return name != null && exampleSignature.IsMatch(name.Value.Replace(@"\\", @"\"));
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
+++ b/src/Pickles/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
@@ -39,8 +39,14 @@
     <Reference Include="System.IO.Abstractions, Version=2.1.0.178, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Abstractions.2.1.0.178\lib\net40\System.IO.Abstractions.dll</HintPath>
     </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="TechTalk.SpecFlow, Version=2.3.0.0, Culture=neutral, PublicKeyToken=0778194805d6db41, processorArchitecture=MSIL">
+      <HintPath>..\packages\SpecFlow.2.3.0\lib\net45\TechTalk.SpecFlow.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CucumberJson\CucumberJsonResults.cs" />

--- a/src/Pickles/Pickles.TestFrameworks/SpecFlowNameMapping.cs
+++ b/src/Pickles/Pickles.TestFrameworks/SpecFlowNameMapping.cs
@@ -1,32 +1,12 @@
-﻿using System.Text.RegularExpressions;
+﻿using TechTalk.SpecFlow.Tracing;
 
 namespace PicklesDoc.Pickles.TestFrameworks
 {
-	internal static class SpecFlowNameMapping
-	{
-		private static readonly Regex PunctuationCharactersRegex = new Regex(@"[\n\.-]+", RegexOptions.Compiled);
-		private static readonly Regex NonIdentifierCharacterRegex = new Regex(@"[^\p{Ll}\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}\p{Pc}]", RegexOptions.Compiled);
-
-	    public static string Build(string name)
-	    {
-	        name = PunctuationCharactersRegex.Replace(name, "_");
-	        name = NonIdentifierCharacterRegex.Replace(name, string.Empty);
-	        name = name
-	            .Replace('ä', 'a')
-	            .Replace('ö', 'o')
-	            .Replace('ü', 'u')
-	            .Replace('Ä', 'A')
-	            .Replace('Ö', 'O')
-	            .Replace('Ü', 'U')
-	            .Replace('ß', 'b')
-	            .Replace("æ", "ae")
-	            .Replace('ø', 'o')
-	            .Replace('å', 'a')
-	            .Replace("Æ", "AE")
-	            .Replace('Ø', 'O')
-	            .Replace('Å', 'A');
-
-	        return name;
-	    }
-	}
+    internal static class SpecFlowNameMapping
+    {
+        public static string Build(string name)
+        {
+            return CodeFormattingExtensions.ToIdentifier(name);
+        }
+    }
 }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit1/XUnit1ScenarioOutlineExampleMatcher.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit1/XUnit1ScenarioOutlineExampleMatcher.cs
@@ -38,7 +38,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit1
 
         internal static bool IsMatchingTestCase(XElement x, Regex exampleSignature)
         {
-            return exampleSignature.IsMatch(x.Attribute("name").Value.ToLowerInvariant());
+            return exampleSignature.IsMatch(x.Attribute("name").Value);
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/XUnit2ScenarioOutlineExampleMatcher.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/XUnit2/XUnit2ScenarioOutlineExampleMatcher.cs
@@ -38,8 +38,8 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit.XUnit2
         {
             var testNameWithExample = exampleElement.name;
             var testNameOnly = testNameWithExample.Split('(')[0];
-            testNameWithExample = testNameWithExample.Replace(testNameOnly, Regex.Replace(testNameOnly, @"\s+", string.Empty)).ToLowerInvariant();
-            return signature.IsMatch(exampleElement.name.ToLowerInvariant()) || signature.IsMatch(testNameWithExample);
+            testNameWithExample = testNameWithExample.Replace(testNameOnly, Regex.Replace(testNameOnly, @"\s+", string.Empty));
+            return signature.IsMatch(exampleElement.name) || signature.IsMatch(testNameWithExample);
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
+++ b/src/Pickles/Pickles.TestFrameworks/XUnit/xUnitExampleSignatureBuilder.cs
@@ -34,15 +34,15 @@ namespace PicklesDoc.Pickles.TestFrameworks.XUnit
         {
             var stringBuilder = new StringBuilder();
 
-            var name = SpecFlowNameMapping.Build(scenarioOutline.Name.ToLowerInvariant());
+            var name = SpecFlowNameMapping.Build(scenarioOutline.Name);
             stringBuilder.Append(name).Append("\\(");
 
             foreach (var value in row.Select(v => v.Length > MaxExampleValueLength ? new { Value = v.Substring(0, MaxExampleValueLength), Ellipsis = "..." } : new { Value = v, Ellipsis = "" }))
-                stringBuilder.AppendFormat("(.*): \"{0}\"{1}, ", Regex.Escape(value.Value.ToLowerInvariant()), value.Ellipsis);
+                stringBuilder.AppendFormat("(.*): \"{0}\"{1}, ", Regex.Escape(value.Value), value.Ellipsis);
 
             stringBuilder.Remove(stringBuilder.Length - 2, 2);
 
-            return new Regex(stringBuilder.ToString());
+            return new Regex(stringBuilder.ToString(), RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
         }
     }
 }

--- a/src/Pickles/Pickles.TestFrameworks/packages.config
+++ b/src/Pickles/Pickles.TestFrameworks/packages.config
@@ -2,4 +2,6 @@
 <packages>
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="2.1.0.178" targetFramework="net45" />
+  <package id="SpecFlow" version="2.3.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
To avoid handling special characters differently reading results for scenarios and scenario outlines use the class from SpecFlow instead of custom implementation. 