### PR TITLE
Remove duplication of help texts

### DIFF
--- a/src/Pickles/Pickles.CommandLine/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles.CommandLine/CommandLineArgumentParser.cs
@@ -52,20 +52,20 @@ namespace PicklesDoc.Pickles.CommandLine
             this.fileSystem = fileSystem;
             this.options = new OptionSet
             {
-                { "f|feature-directory=", CommandLinArgumentHelpTexts.HelpFeatureDir, v => this.featureDirectory = v },
-                { "o|output-directory=", CommandLinArgumentHelpTexts.HelpOutputDir, v => this.outputDirectory = v },
-                { "trfmt|test-results-format=", CommandLinArgumentHelpTexts.HelpTestResultsFormat, v => this.testResultsFormat = v },
-                { "lr|link-results-file=", CommandLinArgumentHelpTexts.HelpTestResultsFile, v => this.testResultsFile = v },
-                { "sn|system-under-test-name=", CommandLinArgumentHelpTexts.HelpSutName, v => this.systemUnderTestName = v },
-                { "sv|system-under-test-version=", CommandLinArgumentHelpTexts.HelpSutVersion, v => this.systemUnderTestVersion = v },
-                { "l|language=", CommandLinArgumentHelpTexts.HelpLanguageFeatureFiles, v => this.language = v },
-                { "df|documentation-format=", CommandLinArgumentHelpTexts.HelpDocumentationFormat, v => this.documentationFormat = v },
+                { "f|feature-directory=", CommandLineArgumentHelpTexts.HelpFeatureDir, v => this.featureDirectory = v },
+                { "o|output-directory=", CommandLineArgumentHelpTexts.HelpOutputDir, v => this.outputDirectory = v },
+                { "trfmt|test-results-format=", CommandLineArgumentHelpTexts.HelpTestResultsFormat, v => this.testResultsFormat = v },
+                { "lr|link-results-file=", CommandLineArgumentHelpTexts.HelpTestResultsFile, v => this.testResultsFile = v },
+                { "sn|system-under-test-name=", CommandLineArgumentHelpTexts.HelpSutName, v => this.systemUnderTestName = v },
+                { "sv|system-under-test-version=", CommandLineArgumentHelpTexts.HelpSutVersion, v => this.systemUnderTestVersion = v },
+                { "l|language=", CommandLineArgumentHelpTexts.HelpLanguageFeatureFiles, v => this.language = v },
+                { "df|documentation-format=", CommandLineArgumentHelpTexts.HelpDocumentationFormat, v => this.documentationFormat = v },
                 { "v|version", v => this.versionRequested = v != null },
                 { "h|?|help", v => this.helpRequested = v != null },
-                { "exp|include-experimental-features", CommandLinArgumentHelpTexts.HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
-                { "cmt|enableComments=", CommandLinArgumentHelpTexts.HelpEnableComments, v => this.enableCommentsValue = v },
-                { "et|excludeTags=", CommandLinArgumentHelpTexts.HelpExcludeTags, v => this.excludeTags = v },
-                { "ht|hideTags=", CommandLinArgumentHelpTexts.HelpHideTags, v => this.hideTags = v }
+                { "exp|include-experimental-features", CommandLineArgumentHelpTexts.HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
+                { "cmt|enableComments=", CommandLineArgumentHelpTexts.HelpEnableComments, v => this.enableCommentsValue = v },
+                { "et|excludeTags=", CommandLineArgumentHelpTexts.HelpExcludeTags, v => this.excludeTags = v },
+                { "ht|hideTags=", CommandLineArgumentHelpTexts.HelpHideTags, v => this.hideTags = v }
             };
         }
 

--- a/src/Pickles/Pickles.CommandLine/CommandLineArgumentParser.cs
+++ b/src/Pickles/Pickles.CommandLine/CommandLineArgumentParser.cs
@@ -30,21 +30,6 @@ namespace PicklesDoc.Pickles.CommandLine
 {
     public class CommandLineArgumentParser
     {
-        public const string HelpFeatureDir = "directory to start scanning recursively for features";
-        public const string HelpOutputDir = "directory where output files will be placed";
-        public const string HelpSutName = "the name of the system under test";
-        public const string HelpSutVersion = "the version of the system under test";
-        public const string HelpLanguageFeatureFiles = "the language of the feature files";
-        public const string HelpDocumentationFormat = "the format of the output documentation";
-        public const string HelpTestResultsFormat = "the format of the linked test results (nunit|nunit3|xunit|xunit2|mstest |cucumberjson|specrun|vstest)";
-        public const string HelpIncludeExperimentalFeatures = "whether to include experimental features";
-        public const string HelpEnableComments = "whether to enable comments in the output";
-        public const string HelpExcludeTags = "exclude scenarios that match this tag";
-        public const string HelpHideTags = "Technical tags that shouldn't be displayed";
-
-        public const string HelpTestResultsFile =
-            "the path to the linked test results file (can be a semicolon-separated list of files)";
-
         private readonly IFileSystem fileSystem;
         private readonly OptionSet options;
         private string documentationFormat;
@@ -67,20 +52,20 @@ namespace PicklesDoc.Pickles.CommandLine
             this.fileSystem = fileSystem;
             this.options = new OptionSet
             {
-                { "f|feature-directory=", HelpFeatureDir, v => this.featureDirectory = v },
-                { "o|output-directory=", HelpOutputDir, v => this.outputDirectory = v },
-                { "trfmt|test-results-format=", HelpTestResultsFormat, v => this.testResultsFormat = v },
-                { "lr|link-results-file=", HelpTestResultsFile, v => this.testResultsFile = v },
-                { "sn|system-under-test-name=", HelpSutName, v => this.systemUnderTestName = v },
-                { "sv|system-under-test-version=", HelpSutVersion, v => this.systemUnderTestVersion = v },
-                { "l|language=", HelpLanguageFeatureFiles, v => this.language = v },
-                { "df|documentation-format=", HelpDocumentationFormat, v => this.documentationFormat = v },
+                { "f|feature-directory=", CommandLinArgumentHelpTexts.HelpFeatureDir, v => this.featureDirectory = v },
+                { "o|output-directory=", CommandLinArgumentHelpTexts.HelpOutputDir, v => this.outputDirectory = v },
+                { "trfmt|test-results-format=", CommandLinArgumentHelpTexts.HelpTestResultsFormat, v => this.testResultsFormat = v },
+                { "lr|link-results-file=", CommandLinArgumentHelpTexts.HelpTestResultsFile, v => this.testResultsFile = v },
+                { "sn|system-under-test-name=", CommandLinArgumentHelpTexts.HelpSutName, v => this.systemUnderTestName = v },
+                { "sv|system-under-test-version=", CommandLinArgumentHelpTexts.HelpSutVersion, v => this.systemUnderTestVersion = v },
+                { "l|language=", CommandLinArgumentHelpTexts.HelpLanguageFeatureFiles, v => this.language = v },
+                { "df|documentation-format=", CommandLinArgumentHelpTexts.HelpDocumentationFormat, v => this.documentationFormat = v },
                 { "v|version", v => this.versionRequested = v != null },
                 { "h|?|help", v => this.helpRequested = v != null },
-                { "exp|include-experimental-features", HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
-                { "cmt|enableComments=", HelpEnableComments, v => this.enableCommentsValue = v },
-                { "et|excludeTags=", HelpExcludeTags, v => this.excludeTags = v },
-                { "ht|hideTags=", HelpHideTags, v => this.hideTags = v }
+                { "exp|include-experimental-features", CommandLinArgumentHelpTexts.HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
+                { "cmt|enableComments=", CommandLinArgumentHelpTexts.HelpEnableComments, v => this.enableCommentsValue = v },
+                { "et|excludeTags=", CommandLinArgumentHelpTexts.HelpExcludeTags, v => this.excludeTags = v },
+                { "ht|hideTags=", CommandLinArgumentHelpTexts.HelpHideTags, v => this.hideTags = v }
             };
         }
 

--- a/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
+++ b/src/Pickles/Pickles.PowerShell/Pickle_Features.cs
@@ -33,40 +33,40 @@ namespace PicklesDoc.Pickles.PowerShell
     [Cmdlet("Pickle", "Features")]
     public class Pickle_Features : PSCmdlet
     {
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpFeatureDir, Mandatory = true)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpFeatureDir, Mandatory = true)]
         public string FeatureDirectory { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpOutputDir, Mandatory = true)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpOutputDir, Mandatory = true)]
         public string OutputDirectory { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpLanguageFeatureFiles, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpLanguageFeatureFiles, Mandatory = false)]
         public string Language { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpTestResultsFormat, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpTestResultsFormat, Mandatory = false)]
         public string TestResultsFormat { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpTestResultsFile, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpTestResultsFile, Mandatory = false)]
         public string TestResultsFile { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpSutName, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpSutName, Mandatory = false)]
         public string SystemUnderTestName { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpSutVersion, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpSutVersion, Mandatory = false)]
         public string SystemUnderTestVersion { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpDocumentationFormat, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpDocumentationFormat, Mandatory = false)]
         public string DocumentationFormat { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpIncludeExperimentalFeatures, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpIncludeExperimentalFeatures, Mandatory = false)]
         public SwitchParameter IncludeExperimentalFeatures { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpEnableComments, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpEnableComments, Mandatory = false)]
         public string EnableComments { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpExcludeTags, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpExcludeTags, Mandatory = false)]
         public string ExcludeTags { get; set; }
 
-        [Parameter(HelpMessage = CommandLinArgumentHelpTexts.HelpHideTags, Mandatory = false)]
+        [Parameter(HelpMessage = CommandLineArgumentHelpTexts.HelpHideTags, Mandatory = false)]
         public string HideTags { get; set; }
         
 

--- a/src/Pickles/Pickles/CommandLineArgumentHelpTexts.cs
+++ b/src/Pickles/Pickles/CommandLineArgumentHelpTexts.cs
@@ -1,5 +1,5 @@
 ﻿//  --------------------------------------------------------------------------------------------------------------------
-//  <copyright file="CommandLinArgumentHelpTexts.cs" company="PicklesDoc">
+//  <copyright file="CommandLineArgumentHelpTexts.cs" company="PicklesDoc">
 //  Copyright 2011 Jeffrey Cameron
 //  Copyright 2012-present PicklesDoc team and community contributors
 //
@@ -19,7 +19,7 @@
 //  --------------------------------------------------------------------------------------------------------------------
 namespace PicklesDoc.Pickles
 {
-    public static class CommandLinArgumentHelpTexts
+    public static class CommandLineArgumentHelpTexts
     {
         public const string HelpFeatureDir = "directory to start scanning recursively for features";
         public const string HelpOutputDir = "directory where output files will be placed";

--- a/src/Pickles/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles/Pickles.csproj
@@ -94,7 +94,7 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
-    <Compile Include="CommandLinArgumentHelpTexts.cs" />
+    <Compile Include="CommandLineArgumentHelpTexts.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="ConfigurationReporter.cs" />
     <Compile Include="CultureAwareDialectProvider.cs" />


### PR DESCRIPTION
`CommandLinArgumentHelpTexts` was already in place and used by `Pickles.PowerShell` project, so why not use it.
Fixed typo as well. 