### PR TITLE
Consolidate nuget package versions

### DIFF
--- a/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
@@ -36,8 +36,8 @@
     <Reference Include="Autofac, Version=4.8.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>..\packages\Autofac.4.8.0\lib\net45\Autofac.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NFluent, Version=2.2.0.125, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
       <HintPath>..\packages\NFluent.2.2.0\lib\net45\NFluent.dll</HintPath>
@@ -54,8 +54,8 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/packages.config
+++ b/src/Pickles/Pickles.DocumentationBuilders.Json.UnitTests/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="4.8.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
   <package id="NFluent" version="2.2.0" targetFramework="net45" />
   <package id="NUnit" version="3.10.1" targetFramework="net45" />
   <package id="SpecFlow" version="2.3.2" targetFramework="net45" />
   <package id="System.IO.Abstractions" version="2.1.0.178" targetFramework="net45" />
   <package id="System.IO.Abstractions.TestingHelpers" version="2.1.0.178" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
 Non consistent versions were used from `Newtonsoft.Json` and `System.ValueTuple` in `Pickles.DocumentationBuilders.Json.UnitTests` project.