### PR TITLE
Removing duplication from "--test-results-format" and "-trfmt" argument parsing tests

### DIFF
--- a/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -361,110 +361,6 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
         }
 
         [Test]
-        public void ThenCanParseResultsFormatMstestWithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=mstest" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.MsTest);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatMstestWithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=mstest" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.MsTest);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatNunitWithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=nunit" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.NUnit);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatNunitWithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=nunit" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.NUnit);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatXunitWithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=xunit" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.XUnit);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatXunitWithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=xunit" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.XUnit);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatXunit1WithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=xunit1" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.XUnit1);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatXunit1WithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=xunit1" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.XUnit1);
-        }
-
-        [Test]
         public void ThenCanParseShortFormArgumentsSuccessfully()
         {
             var args = new[] { @"-f=c:\features", @"-o=c:\features-output" };
@@ -525,58 +421,6 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
         }
 
         [Test]
-        public void ThenCanParseResultsFormatCucumberJsonWithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=cucumberjson" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.CucumberJson);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatCucumberJsonWithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=cucumberjson" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.CucumberJson);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatSpecrunWithLongFormSuccessfully()
-        {
-            var args = new[] { @"-test-results-format=specrun" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.SpecRun);
-        }
-
-        [Test]
-        public void ThenCanParseResultsFormatSpecrunWithShortFormSuccessfully()
-        {
-            var args = new[] { @"-trfmt=specrun" };
-
-            var configuration = new Configuration();
-            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
-            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
-
-            Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.TestResultsFormat).IsEqualTo(TestResultsFormat.SpecRun);
-        }
-
-        [Test]
         public void ThenCanFilterOutNonExistingTestResultFiles()
         {
             FileSystem.AddDirectory(@"c:\");
@@ -608,12 +452,46 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
         {
             var args = new[] { @"-excludeTags=exclude-tag" };
 
-            var configuration = new Configuration();
+            IConfiguration configuration = new Configuration();
             var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
             bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
 
             Check.That(shouldContinue).IsTrue();
             Check.That(configuration.ExcludeTags).IsEqualTo("exclude-tag");
+        }
+
+        private static readonly object[] TestResultsFormatCases =
+        {
+            new object[] { @"mstest", TestResultsFormat.MsTest },
+            new object[] { @"nunit", TestResultsFormat.NUnit },
+            new object[] { @"xunit", TestResultsFormat.XUnit },
+            new object[] { @"xunit1", TestResultsFormat.XUnit1 },
+            new object[] { @"cucumberjson", TestResultsFormat.CucumberJson },
+            new object[] { @"specrun", TestResultsFormat.SpecRun },
+        };
+
+        [Test, TestCaseSource(nameof(TestResultsFormatCases))]
+        public void ThenCanParseResultsFormatWithLongFormSuccessfully(string argument, TestResultsFormat expectedResultsFormat)
+        {
+            this.ThenCanParseResultsFormatSuccessfully(@"-test-results-format=", argument, expectedResultsFormat);
+        }
+
+        [Test, TestCaseSource(nameof(TestResultsFormatCases))]
+        public void ThenCanParseResultsFormatWithShortFormSuccessfully(string argument, TestResultsFormat expectedResultsFormat)
+        {
+            this.ThenCanParseResultsFormatSuccessfully(@"-trfmt=", argument, expectedResultsFormat);
+        }
+
+        private void ThenCanParseResultsFormatSuccessfully(string argumentName, string argument, TestResultsFormat expectedResultsFormat)
+        {
+            var args = new[] { argumentName + argument };
+
+            var configuration = new Configuration();
+            var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);
+            bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
+
+            Check.That(shouldContinue).IsTrue();
+            Check.That(configuration.TestResultsFormat).IsEqualTo(expectedResultsFormat);
         }
 
         [Test]

--- a/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -464,10 +464,13 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
         {
             new object[] { @"mstest", TestResultsFormat.MsTest },
             new object[] { @"nunit", TestResultsFormat.NUnit },
+            new object[] { @"nunit3", TestResultsFormat.NUnit3 },
             new object[] { @"xunit", TestResultsFormat.XUnit },
             new object[] { @"xunit1", TestResultsFormat.XUnit1 },
+            new object[] { @"xunit2", TestResultsFormat.xUnit2 },
             new object[] { @"cucumberjson", TestResultsFormat.CucumberJson },
             new object[] { @"specrun", TestResultsFormat.SpecRun },
+            new object[] { @"vstest", TestResultsFormat.VsTest },
         };
 
         [Test, TestCaseSource(nameof(TestResultsFormatCases))]

--- a/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -493,11 +493,5 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
             Check.That(shouldContinue).IsTrue();
             Check.That(configuration.TestResultsFormat).IsEqualTo(expectedResultsFormat);
         }
-
-        [Test]
-        public void Two_Plus_Two_Equals_Five()
-        {
-            //Check.That(2 + 2).Equals(5);
-        }
     }
 }


### PR DESCRIPTION
Hi,
Again some small refactoring to make space for another work I try to do on `Configuration` class and on it's usage.

Also added missing test cases for parsing `test-results-format` arguments.
