### PR TITLE
Delete hardcoded 'Index.html' in featureSearch.js

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/js/featureSearch.js
@@ -48,7 +48,7 @@
 
         // catching instances where pushState will not work (for instance file:// protocol)
         try {
-            var url = 'Index.html?feature=' + path;
+            var url = '?feature=' + path;
             window.history.pushState({ path: url }, '', url);
         }
         catch (ex) {


### PR DESCRIPTION
When the generated `Index.html` was renamed, feature search and/or any navigation using the URLs generated by the script resulted in a 404 error.

After this change the generated output file can be renamed to any filename without breaking the navigation.

As a side effect, the JavaScript warnings on the console at [line 55](https://github.com/picklesdoc/pickles/compare/develop...szaliszali:index-html?expand=1#diff-20a5d6517d056e883a21d09dc09ff6dfL55) are gone, too.