### PR TITLE
Pickles GUI: Generate equivalent PowerShell or Windows Console command line

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -119,6 +119,12 @@ Target "BuildTest.Runners.CommandLine" (fun _ ->
       |> Log "AppBuild-Output: "
 )
 
+Target "BuildTest.Runners.UI" (fun _ ->
+    !! "src/Pickles/Pickles.UserInterface.UnitTests/Pickles.UserInterface.UnitTests.csproj"
+      |> MSBuildRelease testDir "Build"
+      |> Log "AppBuild-Output: "
+)
+
 let createZip (packageType : string) =
     !! (buildDir + "/" + packageType + "/*.*") -- "*.zip"
         |> Zip (buildDir + packageType) (deployDir + "Pickles-" + packageType + "-" + version + ".zip")
@@ -151,6 +157,7 @@ Target "Default" (fun _ ->
   ==> "BuildTest.DocumentationBuilders.Json"
   ==> "BuildTest.DocumentationBuilders.Word"
   ==> "BuildTest.Runners.CommandLine"
+  ==> "BuildTest.Runners.UI"
   ==> "Zip"
   ==> "Default"
 

--- a/src/Pickles/.vs/config/applicationhost.config
+++ b/src/Pickles/.vs/config/applicationhost.config
@@ -163,7 +163,7 @@
             </site>
             <site name="Pickles.BaseDhtmlFiles" id="2">
                 <application path="/" applicationPool="Clr4IntegratedAppPool">
-                    <virtualDirectory path="/" physicalPath="C:\Dev\Code\GitHub\DirkRombauts\pickles\src\Pickles\Pickles.BaseDhtmlFiles" />                </application>
+                    <virtualDirectory path="/" physicalPath="C:\Projects\pickles\src\Pickles\Pickles.BaseDhtmlFiles" />                </application>
                 <bindings>
                     <binding protocol="http" bindingInformation="*:52000:localhost" />
                 </bindings>

--- a/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingCLICommands.cs
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingCLICommands.cs
@@ -18,19 +18,16 @@
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
-
+using System;
 using NFluent;
-
 using NUnit.Framework;
-
-using PicklesDoc.Pickles;
 using PicklesDoc.Pickles.UserInterface.CommandGeneration;
 using PicklesDoc.Pickles.UserInterface.Settings;
 
-namespace System.CommandGeneration
+namespace PicklesDoc.Pickles.UserInterface.UnitTests.CommandGeneration
 {
     [TestFixture]
-    public class WhenGeneratingCLICommands : PicklesDoc.Pickles.Test.BaseFixture
+    public class WhenGeneratingCLICommands : Test.BaseFixture
     {
         private const string MinimalCommandLine = @"pickles.exe --feature-directory=""C:\Specs"" ";
 

--- a/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingCLICommands.cs
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingCLICommands.cs
@@ -1,0 +1,215 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CLICommandGeneratorTests.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+
+using NFluent;
+
+using NUnit.Framework;
+
+using PicklesDoc.Pickles;
+using PicklesDoc.Pickles.UserInterface.CommandGeneration;
+using PicklesDoc.Pickles.UserInterface.Settings;
+
+namespace System.CommandGeneration
+{
+    [TestFixture]
+    public class WhenGeneratingCLICommands : PicklesDoc.Pickles.Test.BaseFixture
+    {
+        private const string MinimalCommandLine = @"pickles.exe --feature-directory=""C:\Specs"" ";
+
+        private MainModel CreateMinimalModel()
+        {
+            return
+                new MainModel
+                {
+                    FeatureDirectory = @"C:\Specs",
+                    DocumentationFormats = new[] { DocumentationFormat.Html },
+                    EnableComments = true,
+                    TestResultsFormat = TestResultsFormat.NUnit
+                };
+        }
+
+        private CommandGeneratorBase CreateGenerator()
+        {
+            return new CLICommandGenerator();
+        }
+
+        [Test]
+        public void ThenASingleCommandIsGeneratedForEverySelectedDocumentFormat()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"pickles.exe --feature-directory=""C:\Specs"" --documentation-format=cucumber"
+                     + Environment.NewLine
+                     + @"pickles.exe --feature-directory=""C:\Specs"" --documentation-format=json");
+        }
+
+        [Test]
+        public void ThenTheDocumentFormatIsAppendedToTheOutputDirectoryIfCreateDirectoryForEachOutputFormatIsTrue()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                OutputDirectory = @"C:\Out",
+                CreateDirectoryForEachOutputFormat = true,
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"pickles.exe --feature-directory=""C:\Specs"" --output-directory=""C:\Out\Cucumber"" --documentation-format=cucumber"
+                     + Environment.NewLine
+                     + @"pickles.exe --feature-directory=""C:\Specs"" --output-directory=""C:\Out\Json"" --documentation-format=json");
+        }
+
+        [Test]
+        public void ThenTheDocumentFormatIsAppendedToTheOutputDirectoryIfCreateDirectoryForEachOutputFormatIsTrueIfOutputDirectoryEndsWithDirectorySeparator()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                OutputDirectory = @"C:\Out\",
+                CreateDirectoryForEachOutputFormat = true,
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"pickles.exe --feature-directory=""C:\Specs"" --output-directory=""C:\Out\Cucumber"" --documentation-format=cucumber"
+                     + Environment.NewLine
+                     + @"pickles.exe --feature-directory=""C:\Specs"" --output-directory=""C:\Out\Json"" --documentation-format=json");
+        }
+
+        [Test]
+        public void ThenTheProjectNameAndVersionIsAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.ProjectName = "TestProject";
+            model.ProjectVersion = "v1.2.4beta1";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + "--system-under-test-name=TestProject --system-under-test-version=v1.2.4beta1");
+        }
+
+        [Test]
+        public void ThenTheTestResultsFormatAndTheLinkedResultsFileIsAppendedIfIncludeTestResultsIsTrue()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeTestResults = true;
+            model.TestResultsFile = "result.xml";
+            model.TestResultsFormat = TestResultsFormat.XUnit;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--link-results-file=""result.xml"" --test-results-format=xunit");
+        }
+
+        [Test]
+        public void ThenTheLinkedResultsFileIsAppendedOnlyIfIncludeTestResultsIsTrueAndTheTestResultsFormatIsNunit()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeTestResults = true;
+            model.TestResultsFile = "result.xml";
+            model.TestResultsFormat = TestResultsFormat.NUnit;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--link-results-file=""result.xml""");
+        }
+
+        [Test]
+        public void ThenLanguageIsAppendedIfItIsNotEnglish()
+        {
+            var model = this.CreateMinimalModel();
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "de"))
+                 .IsEqualTo(MinimalCommandLine + @"--language=de");
+        }
+
+        [Test]
+        public void ThenTheIncludeExperimentalFeaturesFlagIsAppendedIfIncludeExperimentalFeaturesIsTrue()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeExperimentalFeatures = true;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--include-experimental-features");
+        }
+
+        [Test]
+        public void ThenTheEnableCommentsFlagIsAppendedIfIncludeEnableCommentsIsFalse()
+        {
+            var model = this.CreateMinimalModel();
+            model.EnableComments = false;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--enableComments=false");
+        }
+
+        [Test]
+        public void ThenTheExcludeTagsAreAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.ExcludeTags = "ignore,foo";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--excludeTags=ignore,foo");
+        }
+
+        [Test]
+        public void ThenTheHideTagsAreAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.HideTags = "ignore,foo";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"--hideTags=ignore,foo");
+        }
+    }
+}

--- a/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingPowerShellCommands.cs
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingPowerShellCommands.cs
@@ -18,19 +18,16 @@
 //  </copyright>
 //  --------------------------------------------------------------------------------------------------------------------
 
-
+using System;
 using NFluent;
-
 using NUnit.Framework;
-
-using PicklesDoc.Pickles;
 using PicklesDoc.Pickles.UserInterface.CommandGeneration;
 using PicklesDoc.Pickles.UserInterface.Settings;
 
-namespace System.CommandGeneration
+namespace PicklesDoc.Pickles.UserInterface.UnitTests
 {
     [TestFixture]
-    public class WhenGeneratingPowerShellCommands : PicklesDoc.Pickles.Test.BaseFixture
+    public class WhenGeneratingPowerShellCommands : Test.BaseFixture
     {
         private const string MinimalCommandLine = @"Pickle-Features -FeatureDirectory ""C:\Specs"" ";
 

--- a/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingPowerShellCommands.cs
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/CommandGeneration/WhenGeneratingPowerShellCommands.cs
@@ -1,0 +1,215 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CLICommandGeneratorTests.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+
+using NFluent;
+
+using NUnit.Framework;
+
+using PicklesDoc.Pickles;
+using PicklesDoc.Pickles.UserInterface.CommandGeneration;
+using PicklesDoc.Pickles.UserInterface.Settings;
+
+namespace System.CommandGeneration
+{
+    [TestFixture]
+    public class WhenGeneratingPowerShellCommands : PicklesDoc.Pickles.Test.BaseFixture
+    {
+        private const string MinimalCommandLine = @"Pickle-Features -FeatureDirectory ""C:\Specs"" ";
+
+        private MainModel CreateMinimalModel()
+        {
+            return
+                new MainModel
+                {
+                    FeatureDirectory = @"C:\Specs",
+                    DocumentationFormats = new[] { DocumentationFormat.Html },
+                    EnableComments = true,
+                    TestResultsFormat = TestResultsFormat.NUnit
+                };
+        }
+
+        private CommandGeneratorBase CreateGenerator()
+        {
+            return new PowerShellCommandGenerator();
+        }
+
+        [Test]
+        public void ThenASingleCommandIsGeneratedForEverySelectedDocumentFormat()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"Pickle-Features -FeatureDirectory ""C:\Specs"" -DocumentationFormat Cucumber"
+                     + Environment.NewLine
+                     + @"Pickle-Features -FeatureDirectory ""C:\Specs"" -DocumentationFormat Json");
+        }
+
+        [Test]
+        public void ThenTheDocumentFormatIsAppendedToTheOutputDirectoryIfCreateDirectoryForEachOutputFormatIsTrue()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                OutputDirectory = @"C:\Out",
+                CreateDirectoryForEachOutputFormat = true,
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"Pickle-Features -FeatureDirectory ""C:\Specs"" -OutputDirectory ""C:\Out\Cucumber"" -DocumentationFormat Cucumber"
+                     + Environment.NewLine
+                     + @"Pickle-Features -FeatureDirectory ""C:\Specs"" -OutputDirectory ""C:\Out\Json"" -DocumentationFormat Json");
+        }
+
+        [Test]
+        public void ThenTheDocumentFormatIsAppendedToTheOutputDirectoryIfCreateDirectoryForEachOutputFormatIsTrueIfOutputDirectoryEndsWithDirectorySeparator()
+        {
+            var model = new MainModel
+            {
+                FeatureDirectory = @"C:\Specs",
+                OutputDirectory = @"C:\Out\",
+                CreateDirectoryForEachOutputFormat = true,
+                DocumentationFormats = new[] { DocumentationFormat.Cucumber, DocumentationFormat.Json },
+                EnableComments = true
+            };
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(
+                     @"Pickle-Features -FeatureDirectory ""C:\Specs"" -OutputDirectory ""C:\Out\Cucumber"" -DocumentationFormat Cucumber"
+                     + Environment.NewLine
+                     + @"Pickle-Features -FeatureDirectory ""C:\Specs"" -OutputDirectory ""C:\Out\Json"" -DocumentationFormat Json");
+        }
+
+        [Test]
+        public void ThenTheProjectNameAndVersionIsAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.ProjectName = "TestProject";
+            model.ProjectVersion = "v1.2.4beta1";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + "-SystemUnderTestName TestProject -SystemUnderTestVersion v1.2.4beta1");
+        }
+
+        [Test]
+        public void ThenTheTestResultsFormatAndTheLinkedResultsFileIsAppendedIfIncludeTestResultsIsTrue()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeTestResults = true;
+            model.TestResultsFile = "result.xml";
+            model.TestResultsFormat = TestResultsFormat.XUnit;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-TestResultsFile ""result.xml"" -TestResultsFormat xunit");
+        }
+
+        [Test]
+        public void ThenTheLinkedResultsFileIsAppendedOnlyIfIncludeTestResultsIsTrueAndTheTestResultsFormatIsNunit()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeTestResults = true;
+            model.TestResultsFile = "result.xml";
+            model.TestResultsFormat = TestResultsFormat.NUnit;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-TestResultsFile ""result.xml""");
+        }
+
+        [Test]
+        public void ThenLanguageIsAppendedIfItIsNotEnglish()
+        {
+            var model = this.CreateMinimalModel();
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "de"))
+                 .IsEqualTo(MinimalCommandLine + @"-Language de");
+        }
+
+        [Test]
+        public void ThenTheIncludeExperimentalFeaturesFlagIsAppendedIfIncludeExperimentalFeaturesIsTrue()
+        {
+            var model = this.CreateMinimalModel();
+            model.IncludeExperimentalFeatures = true;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-IncludeExperimentalFeatures");
+        }
+
+        [Test]
+        public void ThenTheEnableCommentsFlagIsAppendedIfIncludeEnableCommentsIsFalse()
+        {
+            var model = this.CreateMinimalModel();
+            model.EnableComments = false;
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-EnableComments false");
+        }
+
+        [Test]
+        public void ThenTheExcludeTagsAreAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.ExcludeTags = "ignore,foo";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-ExcludeTags ignore,foo");
+        }
+
+        [Test]
+        public void ThenTheHideTagsAreAppendedIfSet()
+        {
+            var model = this.CreateMinimalModel();
+            model.HideTags = "ignore,foo";
+
+            var sut = this.CreateGenerator();
+
+            Check.That(sut.Generate(model, "en"))
+                 .IsEqualTo(MinimalCommandLine + @"-HideTags ignore,foo");
+        }
+    }
+}

--- a/src/Pickles/Pickles.UserInterface.UnitTests/Pickles.UserInterface.UnitTests.csproj
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/Pickles.UserInterface.UnitTests.csproj
@@ -1,0 +1,127 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit.3.10.1\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>PicklesDoc.Pickles.UserInterface.UnitTests</RootNamespace>
+    <AssemblyName>PicklesDoc.Pickles.UserInterface.UnitTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="NFluent, Version=2.2.0.125, Culture=neutral, PublicKeyToken=18828b37b84b1437, processorArchitecture=MSIL">
+      <HintPath>..\packages\NFluent.2.2.0\lib\net45\NFluent.dll</HintPath>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.10.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.10.1\lib\net45\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.IO.Abstractions, Version=2.1.0.178, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.2.1.0.178\lib\net40\System.IO.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="TestingHelpers, Version=2.1.0.178, Culture=neutral, PublicKeyToken=96bf224d23c43e59, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Abstractions.TestingHelpers.2.1.0.178\lib\net40\TestingHelpers.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="..\VersionInfo.cs">
+      <Link>VersionInfo.cs</Link>
+    </Compile>
+    <Compile Include="CommandGeneration\WhenGeneratingPowerShellCommands.cs" />
+    <Compile Include="CommandGeneration\WhenGeneratingCLICommands.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Pickles.UserInterface\Pickles.UserInterface.csproj">
+      <Project>{F3768CCA-00C2-4280-9F8D-4585B5E214B1}</Project>
+      <Name>Pickles.UserInterface</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Pickles.ObjectModel\Pickles.ObjectModel.csproj">
+      <Project>{55382afc-e050-4df7-aa4f-0aba71e2e169}</Project>
+      <Name>Pickles.ObjectModel</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Pickles.Test\Pickles.Test.csproj">
+      <Project>{8BD9FCD2-7ED5-46B5-B6A4-7FA3775E159F}</Project>
+      <Name>Pickles.Test</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Pickles\Pickles.csproj">
+      <Project>{38BAD6E0-78AB-4AC3-91A8-BF72AF5EE394}</Project>
+      <Name>Pickles</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit.3.10.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.10.1\build\NUnit.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/src/Pickles/Pickles.UserInterface.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Reflection;
+
+[assembly: AssemblyTitle("Pickles.UserInterface.Test")]
+[assembly: AssemblyDescription("Unit and integration tests for the Pickles UI")]

--- a/src/Pickles/Pickles.UserInterface.UnitTests/app.config
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/src/Pickles/Pickles.UserInterface.UnitTests/packages.config
+++ b/src/Pickles/Pickles.UserInterface.UnitTests/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NFluent" version="2.2.0" targetFramework="net45" />
+  <package id="NUnit" version="3.10.1" targetFramework="net45" />
+  <package id="System.IO.Abstractions" version="2.1.0.178" targetFramework="net45" />
+  <package id="System.IO.Abstractions.TestingHelpers" version="2.1.0.178" targetFramework="net45" />
+</packages>

--- a/src/Pickles/Pickles.UserInterface/CommandGeneration/CLICommandGenerator.cs
+++ b/src/Pickles/Pickles.UserInterface/CommandGeneration/CLICommandGenerator.cs
@@ -1,0 +1,79 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CLICommandGenerator.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+
+using PicklesDoc.Pickles.UserInterface.Settings;
+
+namespace PicklesDoc.Pickles.UserInterface.CommandGeneration
+{
+    public class CLICommandGenerator : CommandGeneratorBase
+    {
+        protected override string GenerateSingleCommandLine(
+            MainModel model,
+            string outputDirectory,
+            DocumentationFormat documentationFormat,
+            string selectedLanguage)
+        {
+            var result = new StringBuilder("pickles.exe");
+            result.AppendFormat(" --feature-directory=\"{0}\"", model.FeatureDirectory);
+            result.AppendFormatIfNotEmpty(" --output-directory=\"{0}\"", outputDirectory);
+            result.AppendFormatIfNotEmpty(" --system-under-test-name={0}", model.ProjectName);
+            result.AppendFormatIfNotEmpty(" --system-under-test-version={0}", model.ProjectVersion);
+
+            if (model.IncludeTestResults)
+            {
+                result.AppendFormatIfNotEmpty(" --link-results-file=\"{0}\"", model.TestResultsFile);
+
+                if (model.TestResultsFormat != TestResultsFormat.NUnit)
+                {
+                    result.AppendFormat(" --test-results-format={0}", model.TestResultsFormat.ToString().ToLowerInvariant());
+                }
+            }
+
+            if (!string.Equals(selectedLanguage, "en", StringComparison.OrdinalIgnoreCase))
+            {
+                result.AppendFormatIfNotEmpty(" --language={0}", selectedLanguage);
+            }
+
+            if (documentationFormat != DocumentationFormat.Html)
+            {
+                result.AppendFormat(" --documentation-format={0}", documentationFormat.ToString().ToLowerInvariant());
+            }
+
+            if (model.IncludeExperimentalFeatures)
+            {
+                result.Append(" --include-experimental-features");
+            }
+
+            if (!model.EnableComments)
+            {
+                result.Append(" --enableComments=false");
+            }
+
+            result.AppendFormatIfNotEmpty(" --excludeTags={0}", model.ExcludeTags);
+            result.AppendFormatIfNotEmpty(" --hideTags={0}", model.HideTags);
+
+            return result.ToString();
+        }
+
+    }
+}

--- a/src/Pickles/Pickles.UserInterface/CommandGeneration/CommandGeneratorBase.cs
+++ b/src/Pickles/Pickles.UserInterface/CommandGeneration/CommandGeneratorBase.cs
@@ -1,0 +1,49 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="CommandGeneratorBase.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Linq;
+
+using PicklesDoc.Pickles.UserInterface.Settings;
+
+namespace PicklesDoc.Pickles.UserInterface.CommandGeneration
+{
+    public abstract class CommandGeneratorBase
+    {
+        public string Generate(MainModel model, string selectedLanguage)
+        {
+            return (from documentationFormat in model.DocumentationFormats
+                    let outputDirectory = model.CreateDirectoryForEachOutputFormat
+                                              ? model.OutputDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar + documentationFormat
+                                              : model.OutputDirectory
+                                           ?.ToLowerInvariant()
+                    select this.GenerateSingleCommandLine(model, outputDirectory, documentationFormat, selectedLanguage))
+                   .Aggregate(string.Empty, (c, n) => c + Environment.NewLine + n)
+                   .Trim();
+        }
+
+        protected abstract string GenerateSingleCommandLine(
+            MainModel model,
+            string outputDirectory,
+            DocumentationFormat documentationFormat,
+            string selectedLanguage);
+    }
+}

--- a/src/Pickles/Pickles.UserInterface/CommandGeneration/PowerShellCommandGenerator.cs
+++ b/src/Pickles/Pickles.UserInterface/CommandGeneration/PowerShellCommandGenerator.cs
@@ -1,0 +1,79 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="PowerShellCommandGenerator.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Text;
+
+using PicklesDoc.Pickles.UserInterface.Settings;
+
+namespace PicklesDoc.Pickles.UserInterface.CommandGeneration
+{
+    public class PowerShellCommandGenerator : CommandGeneratorBase
+    {
+        /// <inheritdoc />
+        protected override string GenerateSingleCommandLine(
+            MainModel model,
+            string outputDirectory,
+            DocumentationFormat documentationFormat,
+            string selectedLanguage)
+        {
+            var result = new StringBuilder("Pickle-Features")
+                         .AppendFormat(" -FeatureDirectory \"{0}\"", model.FeatureDirectory)
+                         .AppendFormatIfNotEmpty(" -OutputDirectory \"{0}\"", outputDirectory)
+                         .AppendFormatIfNotEmpty(" -SystemUnderTestName {0}", model.ProjectName)
+                         .AppendFormatIfNotEmpty(" -SystemUnderTestVersion {0}", model.ProjectVersion);
+
+            if (model.IncludeTestResults)
+            {
+                result.AppendFormatIfNotEmpty(" -TestResultsFile \"{0}\"", model.TestResultsFile);
+
+                if (model.TestResultsFormat != TestResultsFormat.NUnit)
+                {
+                    result.AppendFormat(" -TestResultsFormat {0}", model.TestResultsFormat.ToString().ToLowerInvariant());
+                }
+            }
+
+            if (!string.Equals(selectedLanguage, "en", StringComparison.OrdinalIgnoreCase))
+            {
+                result.AppendFormatIfNotEmpty(" -Language {0}", selectedLanguage);
+            }
+
+            if (documentationFormat != DocumentationFormat.Html)
+            {
+                result.AppendFormat(" -DocumentationFormat {0}", documentationFormat.ToString());
+            }
+
+            if (model.IncludeExperimentalFeatures)
+            {
+                result.Append(" -IncludeExperimentalFeatures");
+            }
+
+            if (!model.EnableComments)
+            {
+                result.Append(" -EnableComments false");
+            }
+
+            result.AppendFormatIfNotEmpty(" -ExcludeTags {0}", model.ExcludeTags);
+            result.AppendFormatIfNotEmpty(" -HideTags {0}", model.HideTags);
+
+            return result.ToString();
+        }
+    }
+}

--- a/src/Pickles/Pickles.UserInterface/CommandGeneration/StringBuilderExtensions.cs
+++ b/src/Pickles/Pickles.UserInterface/CommandGeneration/StringBuilderExtensions.cs
@@ -1,0 +1,34 @@
+﻿//  --------------------------------------------------------------------------------------------------------------------
+//  <copyright file="StringBuilderExtensions.cs" company="PicklesDoc">
+//  Copyright 2011 Jeffrey Cameron
+//  Copyright 2012-present PicklesDoc team and community contributors
+//  
+//  
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//  
+//      http://www.apache.org/licenses/LICENSE-2.0
+//  
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//  </copyright>
+//  --------------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace PicklesDoc.Pickles.UserInterface.CommandGeneration
+{
+    public static class StringBuilderExtensions
+    {
+        public static StringBuilder AppendFormatIfNotEmpty(this StringBuilder stringBuilder, string format, string value)
+        {
+            return string.IsNullOrWhiteSpace(value)
+                       ? stringBuilder
+                       : stringBuilder.AppendFormat(format, value);
+        }
+    }
+}

--- a/src/Pickles/Pickles.UserInterface/MainWindow.xaml
+++ b/src/Pickles/Pickles.UserInterface/MainWindow.xaml
@@ -48,6 +48,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
@@ -121,6 +122,17 @@
         <mahapps:ToggleSwitch Header="Include Experimental Features" Grid.RowSpan="2" Grid.Row="3" Grid.Column="5" Grid.ColumnSpan="1" IsChecked="{Binding Path=IncludeExperimentalFeatures, Mode=TwoWay}" Margin="5,0,0,5" />
 
         <Button Command="{Binding GeneratePickles}" Content="Generate" Grid.Row="11" Grid.Column="4" HorizontalAlignment="Right" VerticalAlignment="Center" FontSize="24" Padding="15" Grid.ColumnSpan="2" Margin="0,0,20,20" />
+
+        <Grid Grid.Row="12" Grid.Column="4" Grid.ColumnSpan="2">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" />
+          </Grid.ColumnDefinitions>
+
+          <Button Command="{Binding GeneratePowerShellCommand}" Content="PowerShell Command" Grid.Column="1" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10 0 10 10"/>
+          <Button Command="{Binding GenerateCLICommand}" Content="CLI Command" Grid.Column="2" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="10 0 20 10"/>
+        </Grid>
         <nlogViewer:NlogViewer x:Name="logCtrl" Grid.Column="0" Grid.ColumnSpan="6" Grid.Row="13
                                " LevelWidth="auto" ExceptionWidth="auto" MessageWidth="auto" />
 

--- a/src/Pickles/Pickles.UserInterface/Pickles.UserInterface.csproj
+++ b/src/Pickles/Pickles.UserInterface/Pickles.UserInterface.csproj
@@ -113,6 +113,10 @@
     <Compile Include="..\VersionInfo.cs">
       <Link>VersionInfo.cs</Link>
     </Compile>
+    <Compile Include="CommandGeneration\CLICommandGenerator.cs" />
+    <Compile Include="CommandGeneration\CommandGeneratorBase.cs" />
+    <Compile Include="CommandGeneration\PowerShellCommandGenerator.cs" />
+    <Compile Include="CommandGeneration\StringBuilderExtensions.cs" />
     <Compile Include="Mvvm\NotifySelectionChangedCollection.cs" />
     <Compile Include="Settings\DataDirectoryDeriver.cs" />
     <Compile Include="Settings\IMainModelSerializer.cs" />

--- a/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
+++ b/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Windows;
 using System.Windows.Input;
 
 using Autofac;
@@ -32,6 +33,7 @@ using Autofac;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
 using PicklesDoc.Pickles.ObjectModel;
+using PicklesDoc.Pickles.UserInterface.CommandGeneration;
 using PicklesDoc.Pickles.UserInterface.Mvvm;
 using PicklesDoc.Pickles.UserInterface.Settings;
 
@@ -62,6 +64,10 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
         private readonly RelayCommand browseForTestResultsFileCommand;
 
         private readonly RelayCommand generateCommand;
+
+        private readonly RelayCommand generatePowerShellCommandCommand;
+
+        private readonly RelayCommand generateCLICommandCommand;
 
         private readonly RelayCommand openOutputDirectory;
 
@@ -132,6 +138,8 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
             this.browseForOutputFolderCommand = new RelayCommand(this.DoBrowseForOutputFolder);
             this.browseForTestResultsFileCommand = new RelayCommand(this.DoBrowseForTestResultsFile);
             this.generateCommand = new RelayCommand(this.DoGenerate, this.CanGenerate);
+            this.generatePowerShellCommandCommand = new RelayCommand(this.DoGeneratePowerShellCommand, this.CanGenerate);
+            this.generateCLICommandCommand = new RelayCommand(this.DoGenerateCLICommand, this.CanGenerate);
             this.openOutputDirectory = new RelayCommand(this.DoOpenOutputDirectory, this.CanOpenOutputDirectory);
 
             this.PropertyChanged += this.MainWindowViewModelPropertyChanged;
@@ -229,6 +237,16 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
         public ICommand GeneratePickles
         {
             get { return this.generateCommand; }
+        }
+
+        public ICommand GeneratePowerShellCommand
+        {
+            get { return this.generatePowerShellCommandCommand; }
+        }
+
+        public ICommand GenerateCLICommand
+        {
+            get { return this.generateCLICommandCommand; }
         }
 
         public ICommand BrowseForFeatureFolder
@@ -393,67 +411,67 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
             switch (e.PropertyName)
             {
                 case "FeatureFolder":
-                {
-                    if (this.fileSystem.Directory.Exists(this.featureFolder))
                     {
-                        this.IsFeatureDirectoryValid = true;
-                    }
-                    else
-                    {
-                        this.IsFeatureDirectoryValid = false;
-                    }
+                        if (this.fileSystem.Directory.Exists(this.featureFolder))
+                        {
+                            this.IsFeatureDirectoryValid = true;
+                        }
+                        else
+                        {
+                            this.IsFeatureDirectoryValid = false;
+                        }
 
-                    break;
-                }
+                        break;
+                    }
 
                 case "OutputFolder":
-                {
-                    if (this.fileSystem.Directory.Exists(this.outputFolder))
                     {
-                        this.IsOutputDirectoryValid = true;
-                    }
-                    else
-                    {
-                        this.IsOutputDirectoryValid = false;
-                    }
+                        if (this.fileSystem.Directory.Exists(this.outputFolder))
+                        {
+                            this.IsOutputDirectoryValid = true;
+                        }
+                        else
+                        {
+                            this.IsOutputDirectoryValid = false;
+                        }
 
-                    this.openOutputDirectory.RaiseCanExecuteChanged();
+                        this.openOutputDirectory.RaiseCanExecuteChanged();
 
-                    break;
-                }
+                        break;
+                    }
 
                 case "TestResultsFile":
-                {
-                    if (this.testResultsFile == null ||
-                        this.testResultsFile.Split(';').All(trf => this.fileSystem.File.Exists(trf)))
                     {
-                        this.IsTestResultsFileValid = true;
-                    }
-                    else
-                    {
-                        this.IsTestResultsFileValid = false;
-                    }
+                        if (this.testResultsFile == null ||
+                            this.testResultsFile.Split(';').All(trf => this.fileSystem.File.Exists(trf)))
+                        {
+                            this.IsTestResultsFileValid = true;
+                        }
+                        else
+                        {
+                            this.IsTestResultsFileValid = false;
+                        }
 
-                    break;
-                }
+                        break;
+                    }
 
                 case "ProjectName":
-                {
-                    this.IsProjectNameValid = !string.IsNullOrWhiteSpace(this.projectName);
-                    break;
-                }
+                    {
+                        this.IsProjectNameValid = !string.IsNullOrWhiteSpace(this.projectName);
+                        break;
+                    }
 
                 case "ProjectVersion":
-                {
-                    this.IsProjectVersionValid = !string.IsNullOrWhiteSpace(this.projectVersion);
-                    break;
-                }
+                    {
+                        this.IsProjectVersionValid = !string.IsNullOrWhiteSpace(this.projectVersion);
+                        break;
+                    }
 
                 case "SelectedTestResultsFormat":
-                {
-                    this.IsTestResultsFormatValid = Enum.IsDefined(typeof(TestResultsFormat), this.selectedTestResultsFormat);
-                    break;
-                }
+                    {
+                        this.IsTestResultsFormatValid = Enum.IsDefined(typeof(TestResultsFormat), this.selectedTestResultsFormat);
+                        break;
+                    }
 
                 case "IsRunning":
                 case "IsFeatureDirectoryValid":
@@ -465,10 +483,12 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
                 case "IsLanguageValid":
                 case "IncludeTests":
                 case "IsDocumentationFormatValid":
-                {
-                    this.generateCommand.RaiseCanExecuteChanged();
-                    break;
-                }
+                    {
+                        this.generateCommand.RaiseCanExecuteChanged();
+                        this.generatePowerShellCommandCommand.RaiseCanExecuteChanged();
+                        this.generateCLICommandCommand.RaiseCanExecuteChanged();
+                        break;
+                    }
             }
         }
 
@@ -484,6 +504,44 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
                    && this.isDocumentationFormatValid
                    && this.isLanguageValid;
         }
+
+        private void DoGenerateCommandLine(CommandGeneratorBase generator)
+        {
+            var model = this.CreateMainModel();
+            var language = this.selectedLanguage.TwoLetterISOLanguageName;
+            var commands = generator.Generate(model, language);
+            Clipboard.SetText(commands);
+            MessageBox.Show("Copied the following commands into the clipboard:\n\n" + commands, "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+        }
+
+        private void DoGeneratePowerShellCommand()
+        {
+            DoGenerateCommandLine(new PowerShellCommandGenerator());
+        }
+
+        private void DoGenerateCLICommand()
+        {
+            DoGenerateCommandLine(new CLICommandGenerator());
+        }
+
+        private MainModel CreateMainModel() =>
+            new MainModel
+            {
+                FeatureDirectory = this.featureFolder,
+                OutputDirectory = this.outputFolder,
+                ExcludeTags = this.excludeTags,
+                HideTags = this.HideTags,
+                CreateDirectoryForEachOutputFormat = this.createDirectoryForEachOutputFormat,
+                DocumentationFormats = this.documentationFormats.Selected.ToArray(),
+                ProjectName = this.projectName,
+                ProjectVersion = this.projectVersion,
+                IncludeTestResults = this.includeTests,
+                TestResultsFile = this.testResultsFile,
+                TestResultsFormat = this.selectedTestResultsFormat,
+                SelectedLanguageLcid = this.selectedLanguage.LCID,
+                EnableComments = this.enableComments,
+                IncludeExperimentalFeatures = this.includeExperimentalFeatures
+            };
 
         private void DoGenerate()
         {

--- a/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
+++ b/src/Pickles/Pickles.UserInterface/ViewModel/MainViewModel.cs
@@ -25,6 +25,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Input;
 
@@ -32,6 +33,9 @@ using Autofac;
 
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Command;
+
+using NLog;
+
 using PicklesDoc.Pickles.ObjectModel;
 using PicklesDoc.Pickles.UserInterface.CommandGeneration;
 using PicklesDoc.Pickles.UserInterface.Mvvm;
@@ -53,6 +57,8 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
     /// </summary>
     public class MainViewModel : ViewModelBase
     {
+        private static readonly Logger Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType.Name);
+
         private readonly MultiSelectableCollection<DocumentationFormat> documentationFormats;
 
         private readonly TestResultsFormat[] testResultsFormats;
@@ -511,7 +517,7 @@ namespace PicklesDoc.Pickles.UserInterface.ViewModel
             var language = this.selectedLanguage.TwoLetterISOLanguageName;
             var commands = generator.Generate(model, language);
             Clipboard.SetText(commands);
-            MessageBox.Show("Copied the following commands into the clipboard:\n\n" + commands, "Info", MessageBoxButton.OK, MessageBoxImage.Information);
+            Log.Info(CultureInfo.InvariantCulture, "Copied the following commands into the clipboard:\n\n" + commands);
         }
 
         private void DoGeneratePowerShellCommand()

--- a/src/Pickles/Pickles.sln
+++ b/src/Pickles/Pickles.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2041
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pickles", "Pickles\Pickles.csproj", "{38BAD6E0-78AB-4AC3-91A8-BF72AF5EE394}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -105,6 +105,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build Scripts", "Build Scri
 		..\..\test.fsx = ..\..\test.fsx
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Pickles.UserInterface.UnitTests", "Pickles.UserInterface.UnitTests\Pickles.UserInterface.UnitTests.csproj", "{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -203,6 +205,10 @@ Global
 		{C708FB0D-E2E0-4BE4-BB64-4373E4A0C8AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C708FB0D-E2E0-4BE4-BB64-4373E4A0C8AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C708FB0D-E2E0-4BE4-BB64-4373E4A0C8AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -215,6 +221,10 @@ Global
 		{52414CCC-E080-4FBF-AA3B-7E0117AE3673} = {E1DDC21E-D21E-4B2C-8561-17F630EC8F36}
 		{632BD477-03C9-4CC6-8840-6723DE75652E} = {E1DDC21E-D21E-4B2C-8561-17F630EC8F36}
 		{C708FB0D-E2E0-4BE4-BB64-4373E4A0C8AA} = {4E977674-6919-4F15-A6E3-37BFAC18C7E5}
+		{BF20B6BD-8712-4102-A05D-1CCB37BD6CF0} = {4E977674-6919-4F15-A6E3-37BFAC18C7E5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {611A2C36-6DED-4ACB-AEA4-D2DDE16A4841}
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = Pickles.CommandLine\Pickles.CommandLine.csproj

--- a/test.fsx
+++ b/test.fsx
@@ -89,6 +89,15 @@ Target "Test.Runners.CommandLine" (fun _ ->
              ToolPath = "packages/NUnit.ConsoleRunner/tools/nunit3-console.exe" })
 )
 
+Target "Test.Runners.UI" (fun _ ->
+    !! (testDir + "PicklesDoc.Pickles.UserInterface.UnitTests.dll")
+      |> NUnit3 (fun p ->
+          {p with
+             ShadowCopy = false;
+             OutputDir = testDir + "PicklesDoc.Pickles.UserInterface.UnitTests.TestResults.xml";
+             ToolPath = "packages/NUnit.ConsoleRunner/tools/nunit3-console.exe" })
+)
+
 "Test"
     ==> "Test.DocumentationBuilders.Cucumber"
     ==> "Test.DocumentationBuilders.Dhtml"
@@ -97,6 +106,7 @@ Target "Test.Runners.CommandLine" (fun _ ->
     ==> "Test.DocumentationBuilders.Json"
     ==> "Test.DocumentationBuilders.Word"
     ==> "Test.Runners.CommandLine"
+    ==> "Test.Runners.UI"
     ==> "Test.TestFrameworks"
 
 // start build


### PR DESCRIPTION
This PR will fix #90

It adds two buttons, which generate the respective commands, put them into the clipboard and show a message box with the generated commands.
For each document output type, a single command line will be generated