### PR TITLE
add missing HideTags parameter in Pickles.MSBuild.targets

### DIFF
--- a/src/Pickles/Pickles.MSBuild/build/Pickles.MSBuild.targets
+++ b/src/Pickles/Pickles.MSBuild/build/Pickles.MSBuild.targets
@@ -20,6 +20,7 @@
             Language="$(Pickles_Language)"
             IncludeExperimentalFeatures="$(Pickles_IncludeExperimentalFeatures)"
             EnableComments="$(Pickles_EnableComments)"
-            ExcludeTags="$(Pickles_ExcludeTags)" />
+            ExcludeTags="$(Pickles_ExcludeTags)"
+            HideTags="$(Pickles_HideTags)" />
     </Target>
 </Project>


### PR DESCRIPTION
Hello,

When I added the HideTag I forgot to update the MSBuild.targets.

In this pull request I would like to fix this mistake

Regards,