### PR TITLE
Improve readability of Background by making the .pre class in DHTM styled using a monospaced font

### DIFF
--- a/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
+++ b/src/Pickles/Pickles.BaseDhtmlFiles/css/styles.css
@@ -175,6 +175,7 @@ li.step {
     overflow: auto;
     white-space: pre-wrap;
     font-style: italic;
+    font-family: Monaco,Menlo,Consolas,"Courier New",monospace;
 }
 
 .selected {


### PR DESCRIPTION
Multiline text should be monospaced (as it is a .pre CSS-class).
This PR fixes this