### PR TITLE
Improve performance of VS Test results file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This document is formatted according to the principles of [Keep A CHANGELOG](htt
 
 ### Fixed
 
+- Improve performance of VS Test results file parsing ([586](https://github.com/picklesdoc/pickles/pull/586)) (by [@tlecomte](https://github.com/tlecomte))
+
 ### Security
 
 ## [2.20.1] - 2018-10-17

--- a/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingMultipleVsTestTestResultsFiles.cs
+++ b/src/Pickles/Pickles.TestFrameworks.UnitTests/VsTest/WhenParsingMultipleVsTestTestResultsFiles.cs
@@ -33,7 +33,7 @@ namespace PicklesDoc.Pickles.TestFrameworks.UnitTests.VsTest
     public class WhenParsingMultipleVsTestTestResultsFiles : WhenParsingTestResultFiles<VsTestResults>
     {
         public WhenParsingMultipleVsTestTestResultsFiles()
-            : base("VsTest." + "results-example-vstest - Run 1 (failing).trx;" + "MsTest." + "results-example-mstest - Run 2 (passing).trx")
+            : base("VsTest." + "results-example-vstest - Run 1 (failing).trx;" + "VsTest." + "results-example-vstest - Run 2 (passing).trx")
         {
         }
 

--- a/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
+++ b/src/Pickles/Pickles.TestFrameworks/VsTest/VsTestElementExtensions.cs
@@ -33,22 +33,26 @@ namespace PicklesDoc.Pickles.TestFrameworks.VsTest
 
         private static readonly XNamespace Ns = @"http://microsoft.com/schemas/VisualStudio/TeamTest/2010";
 
-        internal static bool BelongsToFeature(this XElement parentElement, string featureTitle)
+        internal static string Feature(this XElement parentElement)
         {
             //// <UnitTest>
             ////     <TestMethod className="  featureName  " />
             //// </UnitTest>
 
-            var propertiesElement = parentElement.Element(Ns + "TestMethod");
+            var className = parentElement
+                .Element(Ns + "TestMethod")
+                ?.Attributes("className")
+                ?.FirstOrDefault()
+                ?.Value;
 
-            if (propertiesElement == null)
+            if (className == null || !className.EndsWith("Feature", StringComparison.OrdinalIgnoreCase))
             {
-                return false;
+                return null;
             }
 
-            var attributes = propertiesElement.Attributes("className");
-            bool b = attributes.Any(a => a.Value.ToUpperInvariant().Contains(TransformName(featureTitle) + "FEATURE"));
-            return b;
+            var feature = className.Substring(0, className.LastIndexOf("Feature", StringComparison.OrdinalIgnoreCase)).Split('.').Last();
+
+            return feature;
         }
 
         internal static string Name(this XElement scenario)


### PR DESCRIPTION
On a VS test result file containing many tests, the current code is pretty slow. This was observed when migrating a codebase from NUnit3 result files to trx.

Here we improve the performance by caching the parsing of the results:
- a lookup of tests per feature
- a dictionary of test results per test id

On a sample file with about 1000 tests, the performance improves from 40.2 seconds to 2.5 seconds.

This was tested with:
```
.\Pickles.exe -f xxx -o xxx --trfmt=vstest --enableComments=false -df=json -lr=xxx.trx
```

The resulting `pickledFeatures.json` file is identical to the one before these changes (except the `GeneratedOn` field).