### PR TITLE
Flexible Word Generation

### DIFF
--- a/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -57,6 +57,9 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
             "  -h, -?, --help             " + "{0}" +
             "      --exp, --include-experimental-features" + "{0}" +
             "                             whether to include experimental features" + "{0}" +
+            "      --page, --features-on-same-page" + "{0}" +
+            "                             whether to allow printing multiple features on " + "{0}" +
+            "                               the same page" + "{0}" +
             "      --cmt, --enableComments=VALUE" + "{0}" +
             "                             whether to enable comments in the output" + "{0}" +
             "      --et, --excludeTags=VALUE" + "{0}" +

--- a/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -357,7 +357,8 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
             bool shouldContinue = commandLineArgumentParser.Parse(args, configuration, TextWriter.Null);
 
             Check.That(shouldContinue).IsTrue();
-            Check.That(configuration.HasTestResults).IsFalse();
+            Check.That(configuration.HasTestResults).IsTrue();
+            Check.That(configuration.TestResultsFiles.Count()).IsEqualTo(2);
         }
 
         [Test]

--- a/src/Pickles.CommandLine/CommandLineArgumentParser.cs
+++ b/src/Pickles.CommandLine/CommandLineArgumentParser.cs
@@ -43,6 +43,7 @@ namespace PicklesDoc.Pickles.CommandLine
         private string testResultsFormat;
         private bool versionRequested;
         private bool includeExperimentalFeatures;
+        private bool featuresOnSamePage;
         private string enableCommentsValue;
         private string excludeTags;
         private string hideTags;
@@ -64,6 +65,7 @@ namespace PicklesDoc.Pickles.CommandLine
                 { "v|version", v => this.versionRequested = v != null },
                 { "h|?|help", v => this.helpRequested = v != null },
                 { "exp|include-experimental-features", CommandLineArgumentHelpTexts.HelpIncludeExperimentalFeatures, v => this.includeExperimentalFeatures = v != null },
+                { "page|features-on-same-page", CommandLineArgumentHelpTexts.HelpFeaturesOnSamePage, v => this.featuresOnSamePage = v != null },
                 { "cmt|enableComments=", CommandLineArgumentHelpTexts.HelpEnableComments, v => this.enableCommentsValue = v },
                 { "et|excludeTags=", CommandLineArgumentHelpTexts.HelpExcludeTags, v => this.excludeTags = v },
                 { "ht|hideTags=", CommandLineArgumentHelpTexts.HelpHideTags, v => this.hideTags = v },
@@ -148,6 +150,11 @@ namespace PicklesDoc.Pickles.CommandLine
             if (!string.IsNullOrEmpty(this.hideTags))
             {
                 configuration.HideTags = this.hideTags;
+            }
+
+            if (featuresOnSamePage)
+            {
+                configuration.FeaturesOnSamePage = this.featuresOnSamePage;
             }
 
             bool enableComments;

--- a/src/Pickles.ObjectModel/IConfiguration.cs
+++ b/src/Pickles.ObjectModel/IConfiguration.cs
@@ -48,7 +48,10 @@ namespace PicklesDoc.Pickles
 
         bool ShouldIncludeExperimentalFeatures { get; }
 
+        /// <summary> Semicolon-separated List of Tags without the @ Character </summary>
         string ExcludeTags { get; set; }
+
+        /// <summary> Semicolon-separated List of Tags without the @ Character </summary>
         string HideTags { get; set; }
         Uri FeatureBaseUri { get; set; }
 
@@ -61,6 +64,9 @@ namespace PicklesDoc.Pickles
         void DisableExperimentalFeatures();
 
         bool ShouldEnableComments { get; }
+
+        /// <summary> Optional Flag to keep all Features on the same Page in the Word Output </summary>
+        bool FeaturesOnSamePage { get; set; }
 
         void EnableComments();
 

--- a/src/Pickles.Test/DirectoryCrawlers/FolderDirectoryTreeNodeTests.cs
+++ b/src/Pickles.Test/DirectoryCrawlers/FolderDirectoryTreeNodeTests.cs
@@ -154,7 +154,7 @@ namespace PicklesDoc.Pickles.Test.DirectoryCrawlers
 
             string relative = node.GetRelativeUriTo(uri);
 
-            Check.That(relative).IsEqualTo("DistributionOfRights"+Path.DirectorySeparatorChar);
+            Check.That(relative).IsEqualTo("DistributionOfRights/");
         }
     }
 }

--- a/src/Pickles.Test/Extensions/PathExtensionsTests.cs
+++ b/src/Pickles.Test/Extensions/PathExtensionsTests.cs
@@ -30,6 +30,7 @@ namespace PicklesDoc.Pickles.Test.Extensions
     [TestFixture]
     internal class PathExtensionsTests : BaseFixture
     {
+
         [Test]
         public void Get_A_Relative_Path_When_Location_Is_Deeper_Than_Root()
         {
@@ -38,7 +39,7 @@ namespace PicklesDoc.Pickles.Test.Extensions
 
             string actual = PathExtensions.MakeRelativePath("test",FileSystem.Path.Combine("test","deep","blah.feature"), fileSystem);
 
-            Check.That(actual).IsEqualTo(FileSystem.Path.Combine("deep","blah.feature"));
+            Check.That(actual).IsEqualTo("deep" + PathExtensions.Separator + "blah.feature");
         }
 
         [Test]
@@ -49,7 +50,7 @@ namespace PicklesDoc.Pickles.Test.Extensions
 
             string actual = PathExtensions.MakeRelativePath("test",FileSystem.Path.Combine("test","deep","blah.feature"), fileSystem);
 
-            Check.That(actual).IsEqualTo(FileSystem.Path.Combine("deep","blah.feature"));
+            Check.That(actual).IsEqualTo("deep" + PathExtensions.Separator + "blah.feature");
         }
     }
 }

--- a/src/Pickles.Test/WhenCrawlingFoldersForFeatures.cs
+++ b/src/Pickles.Test/WhenCrawlingFoldersForFeatures.cs
@@ -25,6 +25,7 @@ using NFluent;
 using NUnit.Framework;
 using PicklesDoc.Pickles.DataStructures;
 using PicklesDoc.Pickles.DirectoryCrawler;
+using PicklesDoc.Pickles.Extensions;
 
 namespace PicklesDoc.Pickles.Test
 {
@@ -68,7 +69,7 @@ namespace PicklesDoc.Pickles.Test
             INode subLevelOneDirectory = features.ChildNodes[4].Data;
             Check.That(subLevelOneDirectory).IsNotNull();
             Check.That(subLevelOneDirectory.Name).IsEqualTo("Sub Level One");
-            Check.That(subLevelOneDirectory.RelativePathFromRoot).IsEqualTo(@"SubLevelOne"+Path.DirectorySeparatorChar);
+            Check.That(subLevelOneDirectory.RelativePathFromRoot).IsEqualTo(@"SubLevelOne" + PathExtensions.Separator);
             Check.That(subLevelOneDirectory).IsInstanceOf<FolderNode>();
 
             Tree subLevelOneNode = features.ChildNodes[4];
@@ -77,13 +78,13 @@ namespace PicklesDoc.Pickles.Test
             INode levelOneSublevelOneFeature = subLevelOneNode.ChildNodes[0].Data;
             Check.That(levelOneSublevelOneFeature).IsNotNull();
             Check.That(levelOneSublevelOneFeature.Name).IsEqualTo("Addition");
-            Check.That(levelOneSublevelOneFeature.RelativePathFromRoot).IsEqualTo(FileSystem.Path.Combine("SubLevelOne","LevelOneSublevelOne.feature"));
+            Check.That(levelOneSublevelOneFeature.RelativePathFromRoot).IsEqualTo("SubLevelOne" + PathExtensions.Separator + "LevelOneSublevelOne.feature");
             Check.That(levelOneSublevelOneFeature).IsInstanceOf<FeatureNode>();
 
             INode levelOneSublevelTwoFeature = subLevelOneNode.ChildNodes[1].Data;
             Check.That(levelOneSublevelTwoFeature).IsNotNull();
             Check.That(levelOneSublevelTwoFeature.Name).IsEqualTo("Addition");
-            Check.That(levelOneSublevelTwoFeature.RelativePathFromRoot).IsEqualTo(FileSystem.Path.Combine("SubLevelOne","LevelOneSublevelTwo.feature"));
+            Check.That(levelOneSublevelTwoFeature.RelativePathFromRoot).IsEqualTo("SubLevelOne"+ PathExtensions.Separator + "LevelOneSublevelTwo.feature");
             Check.That(levelOneSublevelTwoFeature).IsInstanceOf<FeatureNode>();
 
             Tree subLevelTwoNode = subLevelOneNode.ChildNodes[2];
@@ -92,13 +93,13 @@ namespace PicklesDoc.Pickles.Test
             INode subLevelTwoDirectory = subLevelOneNode.ChildNodes[2].Data;
             Check.That(subLevelTwoDirectory).IsNotNull();
             Check.That(subLevelTwoDirectory.Name).IsEqualTo("Sub Level Two");
-            Check.That(subLevelTwoDirectory.RelativePathFromRoot).IsEqualTo(FileSystem.Path.Combine("SubLevelOne","SubLevelTwo")+Path.DirectorySeparatorChar);
+            Check.That(subLevelTwoDirectory.RelativePathFromRoot).IsEqualTo("SubLevelOne" + PathExtensions.Separator + "SubLevelTwo" + PathExtensions.Separator);
             Check.That(subLevelTwoDirectory).IsInstanceOf<FolderNode>();
 
             INode levelOneSublevelOneSubLevelTwoDirectory = subLevelOneNode.ChildNodes[2].ChildNodes[0].Data;
             Check.That(levelOneSublevelOneSubLevelTwoDirectory).IsNotNull();
             Check.That(levelOneSublevelOneSubLevelTwoDirectory.Name).IsEqualTo("Addition");
-            Check.That(levelOneSublevelOneSubLevelTwoDirectory.RelativePathFromRoot).IsEqualTo(FileSystem.Path.Combine("SubLevelOne","SubLevelTwo","LevelOneSublevelOneSubLevelTwo.feature"));
+            Check.That(levelOneSublevelOneSubLevelTwoDirectory.RelativePathFromRoot).IsEqualTo(("SubLevelOne" + PathExtensions.Separator + "SubLevelTwo" + PathExtensions.Separator + "LevelOneSublevelOneSubLevelTwo.feature"));
             Check.That(levelOneSublevelOneSubLevelTwoDirectory).IsInstanceOf<FeatureNode>();
         }
     }

--- a/src/Pickles/CommandLineArgumentHelpTexts.cs
+++ b/src/Pickles/CommandLineArgumentHelpTexts.cs
@@ -29,6 +29,7 @@ namespace PicklesDoc.Pickles
         public const string HelpDocumentationFormat = "the format of the output documentation";
         public const string HelpTestResultsFormat = "the format of the linked test results (nunit|nunit3|xunit|xunit2|mstest |cucumberjson|specrun|vstest)";
         public const string HelpIncludeExperimentalFeatures = "whether to include experimental features";
+        public const string HelpFeaturesOnSamePage = "whether to allow printing multiple Features on the same Page";
         public const string HelpEnableComments = "whether to enable comments in the output";
         public const string HelpExcludeTags = "exclude scenarios that match this tag";
         public const string HelpHideTags = "Technical tags that shouldn't be displayed (separated by ;)";

--- a/src/Pickles/Configuration.cs
+++ b/src/Pickles/Configuration.cs
@@ -29,6 +29,7 @@ using NLog;
 
 namespace PicklesDoc.Pickles
 {
+    /// <inheritdoc />
     public class Configuration : IConfiguration
     {
         private static readonly Logger Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType.Name);
@@ -114,6 +115,8 @@ namespace PicklesDoc.Pickles
                 this.AddTestResultFileIfItExists(IFileInfo);
             }
         }
+
+        public bool FeaturesOnSamePage { get; set; }
 
         public string ExcludeTags { get; set; }
 

--- a/src/Pickles/Extensions/PathExtensions.cs
+++ b/src/Pickles/Extensions/PathExtensions.cs
@@ -28,6 +28,9 @@ namespace PicklesDoc.Pickles.Extensions
 {
     public static class PathExtensions
     {
+        /// <summary> Since <see cref="Uri"/> is used, the Separator is NOT OS-dependent like <see cref="Path"/> assumes </summary>
+        public const char Separator = '/';
+
         public static string MakeRelativePath(string from, string to, IFileSystem fileSystem)
         {
             if (string.IsNullOrEmpty(from))


### PR DESCRIPTION
To generate a less cluttered Word Document we added the Feature of removing Tags and Scenarios with the existing 'HideTags' Switch. Also configurable separating Features by Page using a new Switch 'FeaturesOnSamePage'

Command Line Parameters:
* 'HideTags' filters Scenarios and Tags in Word Documents
* 'FeaturesOnSamePage' does not separate Features into Word-Pages