### PR TITLE
Support .net 6 in addition to existing frameworks

### DIFF
--- a/src/Pickles.CommandLine.UnitTests/Pickles.CommandLine.UnitTests.csproj
+++ b/src/Pickles.CommandLine.UnitTests/Pickles.CommandLine.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.CommandLine.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.CommandLine.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>

--- a/src/Pickles.CommandLine/Pickles.CommandLine.csproj
+++ b/src/Pickles.CommandLine/Pickles.CommandLine.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>PicklesDoc.Pickles.CommandLine</RootNamespace>
     <AssemblyName>Pickles</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RuntimeIdentifiers>win10-x64;osx.10.11-x64;linux-x64</RuntimeIdentifiers>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Pickles\</SolutionDir>
     <AssemblyTitle>Pickles.CommandLine</AssemblyTitle>
@@ -48,6 +48,7 @@
     <RepositoryUrl>https://github.com/picklesdoc/pickles</RepositoryUrl>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pickles</ToolCommandName>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugType>full</DebugType>

--- a/src/Pickles.DocumentationBuilders.Cucumber.UnitTests/Pickles.DocumentationBuilders.Cucumber.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Cucumber.UnitTests/Pickles.DocumentationBuilders.Cucumber.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Cucumber.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Cucumber.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>

--- a/src/Pickles.DocumentationBuilders.Cucumber/Pickles.DocumentationBuilders.Cucumber.csproj
+++ b/src/Pickles.DocumentationBuilders.Cucumber/Pickles.DocumentationBuilders.Cucumber.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Cucumber</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Cucumber</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Cucumber</AssemblyTitle>
     <Description>A Pickles output formatter that outputs Cucmber JSON documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Dhtml.UnitTests/Pickles.DocumentationBuilders.Dhtml.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Dhtml.UnitTests/Pickles.DocumentationBuilders.Dhtml.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Dhtml.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Dhtml.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Dhtml.UnitTests</AssemblyTitle>
     <Description>Unit tests for the Pickles output formatter that outputs DHTML documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
+++ b/src/Pickles.DocumentationBuilders.Dhtml/Pickles.DocumentationBuilders.Dhtml.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Dhtml</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Dhtml</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Dhtml</AssemblyTitle>
     <Description>A Pickles output formatter that outputs DHTML documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Excel.UnitTests/Pickles.DocumentationBuilders.Excel.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Excel.UnitTests/Pickles.DocumentationBuilders.Excel.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Excel.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Excel.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Excel.UnitTests</AssemblyTitle>
     <Description>Unit Tests for the Pickles output formatter that outputs MS Excel documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Excel/Pickles.DocumentationBuilders.Excel.csproj
+++ b/src/Pickles.DocumentationBuilders.Excel/Pickles.DocumentationBuilders.Excel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Excel</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Excel</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Excel</AssemblyTitle>
     <Description>A Pickles output formatter that outputs MS Excel documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Pickles.ObjectModel\Pickles.ObjectModel.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.13.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />

--- a/src/Pickles.DocumentationBuilders.Html.UnitTests/Pickles.DocumentationBuilders.Html.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Html.UnitTests/Pickles.DocumentationBuilders.Html.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Html.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Html.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Html</AssemblyTitle>
     <Description>A Pickles output formatter that outputs HTML documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
+++ b/src/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Html</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Html</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Html</AssemblyTitle>
     <Description>A Pickles output formatter that outputs HTML documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -66,7 +66,7 @@
     <EmbeddedResource Include="Resources\js\scripts.js" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />

--- a/src/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Json.UnitTests/Pickles.DocumentationBuilders.Json.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Json.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Json.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Json.UnitTests</AssemblyTitle>
     <Description>Unit tests for the Pickles output formatter that outputs Json documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Json/Pickles.DocumentationBuilders.Json.csproj
+++ b/src/Pickles.DocumentationBuilders.Json/Pickles.DocumentationBuilders.Json.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Json</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Json</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Json</AssemblyTitle>
     <Description>A Pickles output formatter that outputs Json documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Pickles.ObjectModel\Pickles.ObjectModel.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Pickles.DocumentationBuilders.Markdown.AcceptanceTests/Pickles.DocumentationBuilders.Markdown.AcceptanceTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Markdown.AcceptanceTests/Pickles.DocumentationBuilders.Markdown.AcceptanceTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Markdown.AcceptanceTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Markdown.AcceptanceTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Markdown.AcceptanceTests</AssemblyTitle>
     <Description>Acceptance tests for the Pickles output formatter that outputs Markdown documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Markdown.UnitTests/Pickles.DocumentationBuilders.Markdown.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Markdown.UnitTests/Pickles.DocumentationBuilders.Markdown.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Markdown.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Markdown.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Markdown.UnitTests</AssemblyTitle>
     <Description>Unit tests for the Pickles output formatter that outputs Markdown documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Markdown/Pickles.DocumentationBuilders.Markdown.csproj
+++ b/src/Pickles.DocumentationBuilders.Markdown/Pickles.DocumentationBuilders.Markdown.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Markdown</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Markdown</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Markdown</AssemblyTitle>
     <Description>A Pickles output formatter that outputs Markdown documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Word.UnitTests/Pickles.DocumentationBuilders.Word.UnitTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Word.UnitTests/Pickles.DocumentationBuilders.Word.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Word.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Word.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Word.UnitTests</AssemblyTitle>
     <Description>Unit Tests for the Pickles output formatter that outputs MS Word documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.DocumentationBuilders.Word/Pickles.DocumentationBuilders.Word.csproj
+++ b/src/Pickles.DocumentationBuilders.Word/Pickles.DocumentationBuilders.Word.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.DocumentationBuilders.Word</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.DocumentationBuilders.Word</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>Pickles.DocumentationBuilders.Word</AssemblyTitle>
     <Description>A Pickles output formatter that outputs MS Word documents</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\Pickles.ObjectModel\Pickles.ObjectModel.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.13.1" />
     <PackageReference Include="NLog" Version="4.5.3" />
     <PackageReference Include="System.IO.Packaging" Version="5.0.0" />

--- a/src/Pickles.MSBuild/Pickles.MSBuild.csproj
+++ b/src/Pickles.MSBuild/Pickles.MSBuild.csproj
@@ -3,7 +3,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <RootNamespace>PicklesDoc.Pickles.MSBuild</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.MSBuild.Tasks</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Pickles\</SolutionDir>
     <AssemblyTitle>Pickles.MSBuild</AssemblyTitle>
     <Description>

--- a/src/Pickles.ObjectModel/Pickles.ObjectModel.csproj
+++ b/src/Pickles.ObjectModel/Pickles.ObjectModel.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.ObjectModel</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>PicklesDoc.Pickles.ObjectModel</AssemblyTitle>
     <Description>The object model for Pickles</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.PowerShell/Pickles.PowerShell.csproj
+++ b/src/Pickles.PowerShell/Pickles.PowerShell.csproj
@@ -3,7 +3,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <RootNamespace>PicklesDoc.Pickles.PowerShell</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.PowerShell</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\Pickles\</SolutionDir>
     <AssemblyTitle>Pickles.PowerShell</AssemblyTitle>
     <Description>

--- a/src/Pickles.Test/Pickles.Test.csproj
+++ b/src/Pickles.Test/Pickles.Test.csproj
@@ -3,7 +3,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <RootNamespace>PicklesDoc.Pickles.Test</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.Test</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AssemblyTitle>Pickles.Test</AssemblyTitle>
     <Description>Unit and integration tests for Pickles</Description>

--- a/src/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
+++ b/src/Pickles.TestFrameworks.UnitTests/Pickles.TestFrameworks.UnitTests.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.TestFrameworks.UnitTests</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.TestFrameworks.UnitTests</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+   <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <AssemblyTitle>PicklesDoc.Pickles.TestFrameworks.UnitTests</AssemblyTitle>
     <Description>Unit tests for the supported test frameworks for inputting test results to Pickles</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
+++ b/src/Pickles.TestFrameworks/Pickles.TestFrameworks.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>PicklesDoc.Pickles.TestFrameworks</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.TestFrameworks</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>PicklesDoc.Pickles.TestFrameworks</AssemblyTitle>
     <Description>Supported test frameworks for inputting test results to Pickles</Description>
     <OutputPath>bin\$(Configuration)\</OutputPath>

--- a/src/Pickles/Pickles.csproj
+++ b/src/Pickles/Pickles.csproj
@@ -3,7 +3,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <RootNamespace>PicklesDoc.Pickles</RootNamespace>
     <AssemblyName>PicklesDoc.Pickles.Library</AssemblyName>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <AssemblyTitle>Pickles</AssemblyTitle>
     <Description>A documentation generator for features written in the Gherkin language</Description>
@@ -49,7 +49,7 @@
     <ProjectReference Include="..\Pickles.TestFrameworks\Pickles.TestFrameworks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.8.0" />
+    <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="DocumentFormat.OpenXml" Version="2.13.1" />
     <PackageReference Include="gherkin" Version="6.0.0" />
     <PackageReference Include="NLog" Version="4.5.3" />

--- a/src/markdowndeep/markdowndeep.csproj
+++ b/src/markdowndeep/markdowndeep.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyTitle>markdowndeep</AssemblyTitle>
     <Product>markdowndeep</Product>
     <Copyright>Copyright ©  2021</Copyright>


### PR DESCRIPTION
Merry Christmas! 
Thanks again for the great project, here at CoverGo we use pickles to generate cucumber JSON to use within Behave.Pro Jira plugin

We are using pickles on macOS ARM in a project using .net 6.
It is convenient to build projects, run tests and run pickles within the same DockerFile using the same base image for .net6
This PR is adding .Net 6 support to the existing frameworks. There are a couple of red tests due to missing native libraries, but we use this version successfully already, and I'm not sure how to fix these tests. 

There is Autofac version bump from 4.0.0 to 6.3.0 as it has issues with .net 6 during the build

There is a small behavior change in .net 6 when multiple files get copied to the output with the same name.In .net 5 it was ok, just a file overwrite. In .net6 it will lead to an error. 
Because of this change, after migration to .net 6 pickles have a compile-time error with complaints about NLog.config in the pickles command line project. We are configuring the project to use the old behavior from .net 5 via "ErrorOnDuplicatePublishOutputFiles" attribute
