### PR TITLE
M1 mac comp

### DIFF
--- a/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
+++ b/src/Pickles.CommandLine.UnitTests/WhenParsingCommandLineArguments.cs
@@ -351,9 +351,9 @@ namespace PicklesDoc.Pickles.CommandLine.UnitTests
         [Test]
         public void ThenNoExceptionIsThrownWhenResultsFileIsDir()
         {
-            FileSystem.AddFile(@"temp\results_foo1.xml", "<xml />");
-            FileSystem.AddFile(@"temp\results_foo2.xml", "<xml />");
-            var args = new[] { @"-link-results-file=temp\" };
+            FileSystem.AddFile(System.IO.Path.Combine("temp", "results_foo1.xml"), "<xml />");
+            FileSystem.AddFile(System.IO.Path.Combine("temp", "results_foo2.xml"), "<xml />");
+            var args = new[] { @"-link-results-file=temp" + System.IO.Path.DirectorySeparatorChar };
 
             var configuration = new Configuration();
             var commandLineArgumentParser = new CommandLineArgumentParser(FileSystem);

--- a/src/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
+++ b/src/Pickles.DocumentationBuilders.Html/Pickles.DocumentationBuilders.Html.csproj
@@ -72,6 +72,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
     <PackageReference Include="System.ServiceModel.Duplex" Version="4.9.0" />

--- a/src/Pickles.DocumentationBuilders.Html/ResourceWriter.cs
+++ b/src/Pickles.DocumentationBuilders.Html/ResourceWriter.cs
@@ -19,10 +19,10 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.IO.Abstractions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 
 namespace PicklesDoc.Pickles.DocumentationBuilders.Html
 {
@@ -104,11 +104,11 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Html
         {
             string path = this.fileSystem.Path.Combine(folder, filename);
 
-            using (Image image = Image.FromStream(this.GetResourceStream(this.namespaceOfResources + "img." + filename)))
+            using (Image image = Image.Load(this.GetResourceStream(this.namespaceOfResources + "img." + filename)))
             {
                 using (var stream = this.fileSystem.File.Create(path))
                 {
-                    image.Save(stream, ImageFormat.Png);
+                    image.Save(stream, new PngEncoder());
                 }
             }
         }

--- a/src/Pickles.DocumentationBuilders.Markdown.AcceptanceTests/Pickles.DocumentationBuilders.Markdown.AcceptanceTests.csproj
+++ b/src/Pickles.DocumentationBuilders.Markdown.AcceptanceTests/Pickles.DocumentationBuilders.Markdown.AcceptanceTests.csproj
@@ -64,6 +64,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="SpecFlow.NUnit" Version="3.7.38" />
   </ItemGroup>
 </Project>

--- a/src/Pickles.DocumentationBuilders.Markdown/MarkdownDocumentationBuilder.cs
+++ b/src/Pickles.DocumentationBuilders.Markdown/MarkdownDocumentationBuilder.cs
@@ -19,10 +19,10 @@
 //  --------------------------------------------------------------------------------------------------------------------
 
 using PicklesDoc.Pickles.DataStructures;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.IO.Abstractions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Png;
 
 namespace PicklesDoc.Pickles.DocumentationBuilders.Markdown
 {
@@ -80,11 +80,11 @@ namespace PicklesDoc.Pickles.DocumentationBuilders.Markdown
         {
             string path = this.fileSystem.Path.Combine(folder, targetfilename);
 
-            using (Image image = Image.FromStream(this.GetResourceStream(this.namespaceOfResources + sourcefilename)))
+            using (Image image = Image.Load(this.GetResourceStream(this.namespaceOfResources + sourcefilename)))
             {
                 using (var stream = this.fileSystem.File.Create(path))
                 {
-                    image.Save(stream, ImageFormat.Png);
+                    image.Save(stream, new PngEncoder());
                 }
             }
         }

--- a/src/Pickles.DocumentationBuilders.Markdown/Pickles.DocumentationBuilders.Markdown.csproj
+++ b/src/Pickles.DocumentationBuilders.Markdown/Pickles.DocumentationBuilders.Markdown.csproj
@@ -38,6 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="System.IO.Abstractions" Version="17.0.3" />
   </ItemGroup>

--- a/src/Pickles/Configuration.cs
+++ b/src/Pickles/Configuration.cs
@@ -108,9 +108,9 @@ namespace PicklesDoc.Pickles
             this.AddTestResultFileIfItExists(IFileInfo);
         }
 
-        public void AddTestResultFiles(IEnumerable<IFileInfo> IFileInfos)
+        public void AddTestResultFiles(IEnumerable<IFileInfo> fileInfos)
         {
-            foreach (var IFileInfo in IFileInfos ?? new IFileInfo[0])
+            foreach (var IFileInfo in fileInfos ?? new IFileInfo[0])
             {
                 this.AddTestResultFileIfItExists(IFileInfo);
             }


### PR DESCRIPTION
- replace System.Drawing with ImageSharp for cross-platform compatibility
- use Path functions for cross-platform compatibility